### PR TITLE
Bump FSharp.Core dependency to 4.4.0.0

### DIFF
--- a/release/bin/FsAutoComplete.Suave.exe.config
+++ b/release/bin/FsAutoComplete.Suave.exe.config
@@ -9,7 +9,7 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.3.1.0" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.4.0.0" />
   </dependentAssembly>
   <dependentAssembly>
     <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />


### PR DESCRIPTION
Bump the version to 4.4.0.0 so that autocomplete can work for F# 4.0,
e.g. machines with only VS2015 installed.