### PR TITLE
Add syntax for `inline` so that inlined methods and non-inlined

### DIFF
--- a/release/syntaxes/fsharp.json
+++ b/release/syntaxes/fsharp.json
@@ -140,7 +140,7 @@
             "patterns": [
                 {
                     "name": "binding.fsharp",
-                    "begin": "(val mutable|val|let mutable|let|member|static member|override|let!)(\\s+rec|mutable)?(\\s+private|internal|public)?\\s+(\\([^\\s-]*\\)|[_a-zA-Z]([_a-zA-Z0-9,\\.]|(?<=,)\\s)*)",
+                    "begin": "(val mutable|val|let mutable|let inline|let|member inline|member|static member inline|static member|override|let!)(\\s+rec|mutable)?(\\s+private|internal|public)?\\s+(\\([^\\s-]*\\)|[_a-zA-Z]([_a-zA-Z0-9,\\.]|(?<=,)\\s)*)",
                     "end": "((``.*``)|(with)|=|$)",
                     "beginCaptures": {
                         "1": {


### PR DESCRIPTION
methods highlight in the same way