### PR TITLE
make paket.dependencies cross platform

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,8 +1,13 @@
 source https://nuget.org/api/v2
 
-git https://github.com/ionide/ionide-vscode-helpers.git master build:"build.cmd"
-git https://github.com/ionide/FsAutoComplete.git projectSymbols build:"build.cmd LocalRelease"
-git https://github.com/fsprojects/Forge.git master build:"build.cmd"
+git https://github.com/ionide/ionide-vscode-helpers.git master build:"build.cmd", OS: windows
+git https://github.com/ionide/FsAutoComplete.git projectSymbols build:"build.cmd LocalRelease", OS: windows
+git https://github.com/fsprojects/Forge.git master build:"build.cmd", OS: windows
+
+git https://github.com/ionide/ionide-vscode-helpers.git master build:"build.sh", OS: mono
+git https://github.com/ionide/FsAutoComplete.git projectSymbols build:"build.sh LocalRelease", OS: mono
+git https://github.com/fsprojects/Forge.git master build:"build.sh", OS: mono
+
 git git@github.com:ionide/ionide-fsgrammar.git
 
 nuget FAKE


### PR DESCRIPTION
Added `OS: windows` and `OS: mono` to `paket.dependencies` file in order to be able to bild the project out of the box on other than windows OSs .