### PR TITLE
Try to find Fsi.exe in typical install dir if not on path

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -8,7 +8,7 @@ git https://github.com/ionide/ionide-vscode-helpers.git master build:"build.sh",
 git https://github.com/ionide/FsAutoComplete.git projectSymbols build:"build.sh LocalRelease", OS: mono
 git https://github.com/fsprojects/Forge.git master build:"build.sh", OS: mono
 
-git git@github.com:ionide/ionide-fsgrammar.git
+git https://github.com/ionide/ionide-fsgrammar.git
 
 nuget FAKE
 nuget Npm.js

--- a/paket.lock
+++ b/paket.lock
@@ -1,6 +1,6 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.29.2)
+    FAKE (4.30.1)
     Microsoft.Bcl (1.1.10) - framework: net10, net11, net20, net30, net35, net40, net40-full
       Microsoft.Bcl.Build (>= 1.0.14)
     Microsoft.Bcl.Build (1.0.21) - import_targets: false, framework: net10, net11, net20, net30, net35, net40, net40-full
@@ -28,17 +28,17 @@ GIT
       build: build.sh LocalRelease
       os: mono
   remote: https://github.com/fsprojects/Forge.git
-     (5a71633e50eec713046fdc2d5b2ba607f6debc12)
+     (22d2225486c5a50924442379e8a8b55145e2624d)
       build: build.cmd
       os: windows
-     (5a71633e50eec713046fdc2d5b2ba607f6debc12)
+     (22d2225486c5a50924442379e8a8b55145e2624d)
       build: build.sh
       os: mono
-  remote: git@github.com:ionide/ionide-fsgrammar.git
+  remote: https://github.com/ionide/ionide-fsgrammar.git
      (c8fea8dc0a224a2ceb2371bc5e941157aca3de9e)
 GITHUB
   remote: fsharp/FAKE
-    modules/Octokit/Octokit.fsx (c56456abac6b744c3bb95b217687db19fd19b367)
+    modules/Octokit/Octokit.fsx (60671fd319f4fa769a80036b25e9c60ac50c3a37)
       Octokit (>= 0.20)
   remote: Ionide/ionide-vscode-helpers
     Fable.Import.Axios.fs (777815f9c3f9b3925e42c6394c7f1f5fac124d6a)

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -21,8 +21,9 @@ module Fsi =
     let private start () =
         try
             fsiProcess |> Option.iter(fun fp -> fp.kill ())
+            let fsiExePath = if Process.isWin () then VSCode.getFsiFullPathWin "Fsi.exe" else "fsharpi"
             fsiProcess <-
-                (if Process.isWin () then Process.spawn "Fsi.exe" "" "--fsi-server-input-codepage:65001" else Process.spawn "fsharpi" "" "--fsi-server-input-codepage:65001")
+                (Process.spawn fsiExePath "" "--fsi-server-input-codepage:65001")
                 |> Process.onExit (fun _ -> fsiOutput |> Option.iter (fun outChannel -> outChannel.clear () ))
                 |> Process.onOutput handle
                 |> Process.onError handle

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -83,5 +83,5 @@
     <Compile Include="Components/Forge.fs" />
     <Compile Include="fsharp.fs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets" />
 </Project>


### PR DESCRIPTION
Use VSCode.getFsiFullPathWin (submitted in another PR to ionide-vscode-helpers) so that users who do not have Fsi.exe on their path should still get a working interpreter out of the box.

(Also some changes I need to make to ge the build working on Windows)