### PR TITLE
Look for fsi in common install paths on Windows

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -8,7 +8,7 @@ git https://github.com/ionide/ionide-vscode-helpers.git master build:"build.sh",
 git https://github.com/ionide/FsAutoComplete.git keywords build:"build.sh LocalRelease", OS: mono
 git https://github.com/fsprojects/Forge.git master build:"build.sh", OS: mono
 
-git git@github.com:ionide/ionide-fsgrammar.git
+git https://github.com/ionide/ionide-fsgrammar.git
 
 nuget FAKE
 nuget Npm.js

--- a/paket.lock
+++ b/paket.lock
@@ -21,10 +21,10 @@ GIT
       build: build.sh
       os: mono
   remote: https://github.com/ionide/FsAutoComplete.git
-     (2903174dc9ac12a9420022254ea518f55c1e54bc)
+     (caf889845342a2264254c5e0269c38e4622dcd74)
       build: build.cmd LocalRelease
       os: windows
-     (2903174dc9ac12a9420022254ea518f55c1e54bc)
+     (caf889845342a2264254c5e0269c38e4622dcd74)
       build: build.sh LocalRelease
       os: mono
   remote: https://github.com/fsprojects/Forge.git
@@ -34,7 +34,7 @@ GIT
      (22d2225486c5a50924442379e8a8b55145e2624d)
       build: build.sh
       os: mono
-  remote: git@github.com:ionide/ionide-fsgrammar.git
+  remote: https://github.com/ionide/ionide-fsgrammar.git
      (c8fea8dc0a224a2ceb2371bc5e941157aca3de9e)
 GITHUB
   remote: fsharp/FAKE

--- a/src/Components/Environment.fs
+++ b/src/Components/Environment.fs
@@ -1,0 +1,42 @@
+namespace Ionide.VSCode.FSharp
+
+//---------------------------------------------------
+//Find path of F# install and FSI path
+//---------------------------------------------------
+// Below code adapted from similar in FSSutoComplete project
+module Environment = 
+    open Fable.Core
+    open Fable.Import.Node
+    open Fable.Import.Node.fs_types
+    
+    let isWin = ``process``.platform = "win32"
+    
+    let (</>) a b = 
+        if isWin then a + @"\" + b
+        else a + "/" + b
+    
+    let dirExists dir = fs.statSync(dir).isDirectory()
+    
+    let getOrElse defaultValue option = 
+        match option with
+        | None -> defaultValue
+        | Some x -> x
+    
+    let private programFilesX86 = 
+        let wow64 = ``process``.env?``PROCESSOR_ARCHITEW6432`` |> unbox<string>
+        let globalArch = ``process``.env?``PROCESSOR_ARCHITECTURE`` |> unbox<string>
+        match wow64, globalArch with
+        | "AMD64", "AMD64" | null, "AMD64" | "x86", "AMD64" -> ``process``.env?``ProgramFiles(x86)`` |> unbox<string>
+        | _ -> ``process``.env?``ProgramFiles`` |> unbox<string>
+        |> fun detected -> 
+            if detected = null then @"C:\Program Files (x86)\"
+            else detected
+    
+    let private fsharpInstallationPath = 
+        [ "4.0"; "3.1"; "3.0" ]
+        |> List.map (fun v -> programFilesX86 </> @"\Microsoft SDKs\F#\" </> v </> @"\Framework\v4.0")
+        |> List.tryFind dirExists
+    
+    let fsi = 
+        if true then "fsharpi"
+        else getOrElse "" fsharpInstallationPath </> "fsi.exe"

--- a/src/Components/Environment.fs
+++ b/src/Components/Environment.fs
@@ -38,5 +38,5 @@ module Environment =
         |> List.tryFind dirExists
     
     let fsi = 
-        if true then "fsharpi"
+        if not isWin then "fsharpi"
         else getOrElse "" fsharpInstallationPath </> "fsi.exe"

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -20,9 +20,10 @@ module Fsi =
 
     let private start () =
         try
+            //window.showInformationMessage ("FSI path: " + Environment.fsi) |> ignore
             fsiProcess |> Option.iter(fun fp -> fp.kill ())
             fsiProcess <-
-                (if Process.isWin () then Process.spawn "Fsi.exe" "" "--fsi-server-input-codepage:65001" else Process.spawn "fsharpi" "" "--fsi-server-input-codepage:65001")
+                (Process.spawn Environment.fsi "" "--fsi-server-input-codepage:65001")
                 |> Process.onExit (fun _ -> fsiOutput |> Option.iter (fun outChannel -> outChannel.clear () ))
                 |> Process.onOutput handle
                 |> Process.onError handle

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyName>Ionide.FSharp</AssemblyName>
@@ -27,6 +27,18 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\paket-files\Ionide\ionide-vscode-helpers\Fable.Import.VSCode.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/Fable.Import.VSCode.fs</Link>
+    </Compile>
+    <Compile Include="..\paket-files\Ionide\ionide-vscode-helpers\Helpers.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/Helpers.fs</Link>
+    </Compile>
+    <Compile Include="..\paket-files\Ionide\ionide-vscode-helpers\Fable.Import.Axios.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/Fable.Import.Axios.fs</Link>
+    </Compile>
     <Reference Include="Fable.Core">
       <HintPath>../release/node_modules/fable-core/Fable.Core.dll</HintPath>
     </Reference>
@@ -37,18 +49,6 @@
     <Reference Include="System.Numerics" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="../paket-files/Ionide/ionide-vscode-helpers/Fable.Import.VSCode.fs">
-      <Link>paket-files/Fable.Import.VSCode.fs</Link>
-      <Paket>true</Paket>
-    </Compile>
-    <Compile Include="../paket-files/Ionide/ionide-vscode-helpers/Helpers.fs">
-      <Link>paket-files/Helpers.fs</Link>
-      <Paket>true</Paket>
-    </Compile>
-    <Compile Include="../paket-files/Ionide/ionide-vscode-helpers/Fable.Import.Axios.fs">
-      <Link>paket-files/Fable.Import.Axios.fs</Link>
-      <Paket>true</Paket>
-    </Compile>
     <None Include="paket.references" />
     <Compile Include="Core/DTO.fs" />
     <Compile Include="Core/LanguageService.fs" />
@@ -63,11 +63,12 @@
     <Compile Include="Components/Highlights.fs" />
     <Compile Include="Components/Rename.fs" />
     <Compile Include="Components/WorkspaceSymbols.fs" />
+    <Compile Include="Components/Environment.fs" />
     <Compile Include="Components/Fsi.fs" />
     <Compile Include="Components/QuickInfo.fs" />
     <Compile Include="Components/WebPreview.fs" />
     <Compile Include="Components/Forge.fs" />
     <Compile Include="fsharp.fs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets" />
 </Project>


### PR DESCRIPTION
Attempt to get interactive working out of the box even if the Fsharp install dir is not on path on windows.

Added Environment.fs which contains code to look for the fsi.exe in the standard install paths on Windows (note for Linux/Mac I just assume it is on path).  This path is then used on spawning fsi in Fsi.fs.  I have not been able to test this on non-windows but as lot of the code is adapted fromthe FSAutocomplete project it should be robust.
(Also this commit adds a change to paket.dependencies to use standard https for fsgrammar.)
