### PR TITLE
Add configuration option to specify tools dir

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -155,15 +155,20 @@
       }
     ],
     "configuration": {
-        "type": "object",
-        "title": "FSharp configuration",
-        "properties": {
-            "FSharp.automaticProjectModification": {
-                "type": "boolean",
-                "default": false,
-                "description": "Automatically modifies fsproj on file add/remove"
-            }
+      "type": "object",
+      "title": "FSharp configuration",
+      "properties": {
+        "FSharp.automaticProjectModification": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically modifies fsproj on file add/remove"
+        },
+        "FSharp.toolsDirPath": {
+          "type": "string",
+          "default": "",
+          "description": "The directory containing the F# tools"
         }
+      }
     }
   },
   "activationEvents": [

--- a/src/Components/Environment.fs
+++ b/src/Components/Environment.fs
@@ -6,18 +6,21 @@ namespace Ionide.VSCode.FSharp
 // Below code adapted from similar in FSSutoComplete project
 module Environment =
     open Fable.Core
+    open Fable.Import.vscode
     open Fable.Import.Node
     open Fable.Import.Node.fs_types
 
-    let isWin = ``process``.platform = "win32"
+    let private isWin = ``process``.platform = "win32"
 
-    let (</>) a b =
+    let private (</>) a b =
         if isWin then a + @"\" + b
         else a + "/" + b
 
-    let dirExists dir = fs.statSync(dir).isDirectory()
+    let private dirExists dir = fs.statSync(dir).isDirectory()
 
-    let getOrElse defaultValue option =
+    let private fileExists file = fs.statSync(file).isFile()
+
+    let private getOrElse defaultValue option =
         match option with
         | None -> defaultValue
         | Some x -> x
@@ -32,11 +35,32 @@ module Environment =
             if detected = null then @"C:\Program Files (x86)\"
             else detected
 
-    let private fsharpInstallationPath () =
+    let private getToolsPathWindows () =
         [ "4.0"; "3.1"; "3.0" ]
         |> List.map (fun v -> programFilesX86 </> @"\Microsoft SDKs\F#\" </> v </> @"\Framework\v4.0")
         |> List.tryFind dirExists
 
+    let private getToolsPathFromConfiguration () =
+        let cfg = workspace.getConfiguration ()
+        let path = cfg.get("FSharp.toolsDirPath", "")
+        if not (path = "") && dirExists path then Some path
+        else None
+
+    let private getListDirectoriesToSearchForTools () =
+        if isWin then
+            [ getToolsPathFromConfiguration (); getToolsPathWindows () ] 
+        else
+            [ getToolsPathFromConfiguration () ]
+        |> List.choose id
+       
+    let private findFirstValidFilePath exeName directoryList =
+        directoryList
+        |> List.map (fun v -> v </> exeName)
+        |> List.tryFind fileExists    
+
     let fsi =
-        if not isWin then "fsharpi"
-        else getOrElse "" (fsharpInstallationPath ()) </> "fsi.exe"
+        let fileName = if isWin then "fsi.exe" else "fsharpi"
+        let dirs = getListDirectoriesToSearchForTools ()
+        match findFirstValidFilePath fileName dirs with
+        | None -> fileName
+        | Some x -> x

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -20,7 +20,7 @@ module Fsi =
 
     let private start () =
         try
-            //window.showInformationMessage ("FSI path: " + Environment.fsi) |> ignore
+            // window.showInformationMessage ("FSI path: " + Environment.fsi) |> ignore
             fsiProcess |> Option.iter(fun fp -> fp.kill ())
             fsiProcess <-
                 (Process.spawn Environment.fsi "" "--fsi-server-input-codepage:65001")


### PR DESCRIPTION
**Search for `fsi ` first in the path specified in the user settings file, then if not found (and on windows) try the standard install dirs, then if not found just use the exe name and presume it will be found on path.**


Just revisting my previous commit in light of #99 I thought it would be good to have a configuration option for the tools path.  This should help those people who can't/don't want to add the tools dir to their path.  I saw it was also suggested to include fsi.exe with the extension ( #4 ), or offer to download it for the user, but until then this should work ok.