### PR TITLE
Wait for LanguageService to start correctly

### DIFF
--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -13,26 +13,28 @@ let activate(disposables: Disposable[]) =
     df.language <- Some "fsharp"
     let df' : DocumentSelector = df |> U3.Case2
 
-
     LanguageService.start ()
-    Linter.activate disposables
-    |> Promise.bind(fun _ -> Project.activate ())
+    |> Promise.success (fun t ->
+        Linter.activate disposables
+        |> Promise.bind(fun _ -> Project.activate ())
+        |> ignore
+
+        Tooltip.activate df' disposables
+        Autocomplete.activate df' disposables
+        ParameterHints.activate df' disposables
+        Definition.activate df' disposables
+        Reference.activate df' disposables
+        Symbols.activate df' disposables
+        Highlights.activate df' disposables
+        Rename.activate df' disposables
+        WorkspaceSymbols.activate df' disposables
+
+        Fsi.activate disposables
+        QuickInfo.activate disposables
+        WebPreview.activate disposables
+        Forge.activate disposables
+    )
     |> ignore
-
-    Tooltip.activate df' disposables
-    Autocomplete.activate df' disposables
-    ParameterHints.activate df' disposables
-    Definition.activate df' disposables
-    Reference.activate df' disposables
-    Symbols.activate df' disposables
-    Highlights.activate df' disposables
-    Rename.activate df' disposables
-    WorkspaceSymbols.activate df' disposables
-
-    Fsi.activate disposables
-    QuickInfo.activate disposables
-    WebPreview.activate disposables
-    Forge.activate disposables
 
     ()
 


### PR DESCRIPTION
Before contining to start other dependant services. This should fix the case where FSAC hasn't completed starting, and the `project` discovery fails, leaving completion and tooltips disabled.
