### PR TITLE
Log FSAC http request failures to console,

### DIFF
--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -30,6 +30,10 @@ module LanguageService =
     let request<'a, 'b> ep id  (obj : 'a) =
         if logRequests then Browser.console.log ("[IONIDE-FSAC-REQ]", id, ep, obj)
         ax.post (ep, obj)
+        |> Promise.fail (fun r ->
+            Browser.console.error ("[IONIDE-FSAC-ERR]", id, ep, r)
+            null |> unbox
+        )
         |> Promise.success(fun r ->
             try
                 let res = (r.data |> unbox<string[]>).[id] |> JS.JSON.parse |> unbox<'b>
@@ -41,6 +45,7 @@ module LanguageService =
                 else res
             with
             | ex ->
+                Browser.console.error ("[IONIDE-FSAC-ERR]", id, ep, r, ex)
                 null |> unbox
         )
 


### PR DESCRIPTION
regardless of the value of `FSharp.logLanguageServiceRequestsToConsole`, because errors should be seen, and shouldn't happen often (if all goes well).

<img width="858" alt="screen shot 2016-08-10 at 12 44 14" src="https://cloud.githubusercontent.com/assets/570470/17540279/2d867c18-5ef8-11e6-9e71-9d5fe809f0f0.png">
