### PR TITLE
Update to use FsiAnyCpu.exe by default

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -170,6 +170,11 @@
           "type": "string",
           "default": "",
           "description": "The directory containing the F# tools"
+        },
+        "FSharp.fsiFileName": {
+          "type": "string",
+          "default": "",
+          "description": "The directory containing the F# tools"
         }
       }
     }

--- a/release/package.json
+++ b/release/package.json
@@ -171,10 +171,10 @@
           "default": "",
           "description": "The directory containing the F# tools"
         },
-        "FSharp.fsiFileName": {
+        "FSharp.fsiFilePath": {
           "type": "string",
           "default": "",
-          "description": "The directory containing the F# tools"
+          "description": "The path to the F# Interactive tool used by Ionide-FSharp"
         }
       }
     }

--- a/src/Components/Environment.fs
+++ b/src/Components/Environment.fs
@@ -59,8 +59,15 @@ module Environment =
         |> List.map (fun v -> v </> exeName)
         |> List.tryFind fileExists    
 
+    let private getFsiFileName () =
+        if isWin then
+            let cfg = workspace.getConfiguration ()
+            let fsiName = cfg.get("FSharp.fsiFileName", "")
+            if fsiName = ""  then "FsiAnyCpu.exe" else fsiName  
+        else "fsharpi"
+
     let fsi =
-        let fileName = if isWin then "fsi.exe" else "fsharpi"
+        let fileName = getFsiFileName () 
         let dirs = getListDirectoriesToSearchForTools ()
         match findFirstValidFilePath fileName dirs with
         | None -> fileName

--- a/src/Components/Environment.fs
+++ b/src/Components/Environment.fs
@@ -59,15 +59,15 @@ module Environment =
         |> List.map (fun v -> v </> exeName)
         |> List.tryFind fileExists    
 
-    let private getFsiFileName () =
+    let private getFsiFilePath () =
         if isWin then
             let cfg = workspace.getConfiguration ()
-            let fsiName = cfg.get("FSharp.fsiFileName", "")
-            if fsiName = ""  then "FsiAnyCpu.exe" else fsiName  
+            let fsiPath = cfg.get("FSharp.fsiFilePath", "")
+            if fsiPath = ""  then "FsiAnyCpu.exe" else fsiPath  
         else "fsharpi"
 
     let fsi =
-        let fileName = getFsiFileName () 
+        let fileName = getFsiFilePath () 
         let dirs = getListDirectoriesToSearchForTools ()
         match findFirstValidFilePath fileName dirs with
         | None -> fileName


### PR DESCRIPTION
Update to use FsiAnyCpu.exe on Windows platform to provide better support of 64 bit OS. FSharp.fsiFileName configuration parameter let user specify any other name, ex: fsi.exe.