### PR TITLE
Mono path setting, promises refactor

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -170,6 +170,11 @@
           "type": "string",
           "default": "",
           "description": "The directory containing the F# tools"
+        },
+        "FSharp.monoPath" : {
+          "type": "string",
+          "default": "mono",
+          "description": "The path to Mono executable"
         }
       }
     }

--- a/src/Components/Forge.fs
+++ b/src/Components/Forge.fs
@@ -19,6 +19,7 @@ module Forge =
 
     let private location = (VSCode.getPluginPath "Ionide.Ionide-fsharp") </> "bin_forge" </> "Forge.exe"
     let outputChannel = window.createOutputChannel "Forge"
+    let monoPath = workspace.getConfiguration().get("FSharp.monoPath", "mono")
 
     let private spawnForge (cmd : string) =
         let cmd = cmd.Replace("\r", "").Replace("\n", "")
@@ -26,11 +27,11 @@ module Forge =
         outputChannel.clear ()
         outputChannel.append ("forge " + cmd + "\n")
 
-        Process.spawnWithNotification location "mono" cmd outputChannel
+        Process.spawnWithNotification location monoPath cmd outputChannel
 
 
     let private execForge cmd =
-        Process.exec location "mono" (cmd + " --no-prompt")
+        Process.exec location monoPath (cmd + " --no-prompt")
 
     let private handleForgeList (error : Node.Error, stdout : Buffer, stderr : Buffer) =
         if(stdout.toString() = "") then

--- a/src/Components/Forge.fs
+++ b/src/Components/Forge.fs
@@ -19,7 +19,6 @@ module Forge =
 
     let private location = (VSCode.getPluginPath "Ionide.Ionide-fsharp") </> "bin_forge" </> "Forge.exe"
     let outputChannel = window.createOutputChannel "Forge"
-    let monoPath = workspace.getConfiguration().get("FSharp.monoPath", "mono")
 
     let private spawnForge (cmd : string) =
         let cmd = cmd.Replace("\r", "").Replace("\n", "")
@@ -27,11 +26,11 @@ module Forge =
         outputChannel.clear ()
         outputChannel.append ("forge " + cmd + "\n")
 
-        Process.spawnWithNotification location monoPath cmd outputChannel
+        Process.spawnWithNotification location "mono" cmd outputChannel
 
 
     let private execForge cmd =
-        Process.exec location monoPath (cmd + " --no-prompt")
+        Process.exec location "mono" (cmd + " --no-prompt")
 
     let private handleForgeList (error : Node.Error, stdout : Buffer, stderr : Buffer) =
         if(stdout.toString() = "") then

--- a/src/Components/Forge.fs
+++ b/src/Components/Forge.fs
@@ -95,7 +95,7 @@ module Forge =
                 let! n =
                     sprintf "list references -p %s" edit
                     |> execForge
-                    |> Promise.success handleForgeList
+                    |> Promise.map handleForgeList
 
                 if n.Count <> 0 then
                     let opts = createEmpty<QuickPickOptions>
@@ -131,7 +131,7 @@ module Forge =
                 let! n =
                     sprintf "list projectReferences -p %s" edit
                     |> execForge
-                    |> Promise.success handleForgeList
+                    |> Promise.map handleForgeList
 
                 if n.Count <> 0 then
                     let opts = createEmpty<QuickPickOptions>

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -29,7 +29,7 @@ module Fsi =
                 (Process.spawn Environment.fsi "" "--fsi-server-input-codepage:65001")
                 |> Process.onExit (fun _ -> fsiOutput |> Option.iter (fun outChannel -> outChannel.clear () ))
                 |> Process.onOutput handle
-                |> Process.onError handle
+                |> Process.onErrorOutput handle
                 |> Some
             fsiOutput |> Option.iter (fun outChannel -> outChannel.show (2 |> unbox) )
         with

--- a/src/Components/Linter.fs
+++ b/src/Components/Linter.fs
@@ -36,7 +36,7 @@ module Linter =
 
     let private parse path text =
         LanguageService.parse path text
-        |> Promise.success (fun (ev : ParseResult) ->  (Uri.file path, mapResult ev |> Seq.map fst |> ResizeArray) |> currentDiagnostic.set  )
+        |> Promise.map (fun (ev : ParseResult) ->  (Uri.file path, mapResult ev |> Seq.map fst |> ResizeArray) |> currentDiagnostic.set  )
 
 
     let parseFile (file : TextDocument) =

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -15,7 +15,7 @@ let activate(disposables: Disposable[]) =
     let df' : DocumentSelector = df |> U3.Case2
 
     LanguageService.start ()
-    |> Promise.success (fun _ -> 
+    |> Promise.onSuccess (fun _ -> 
         Linter.activate disposables
         |> Promise.bind(fun _ -> Project.activate ())
         |> ignore

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -31,6 +31,7 @@ let activate(disposables: Disposable[]) =
         WorkspaceSymbols.activate df' disposables
         QuickInfo.activate disposables
     )
+    |> Promise.catch (fun error -> promise { () }) // prevent unhandled rejected promises
     |> ignore
 
     Forge.activate disposables

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -9,33 +9,33 @@ open Fable.Import.vscode
 open Ionide.VSCode.Helpers
 open Ionide.VSCode.FSharp
 
-let internal languageServiceListeningCallback disposables df' =
-    Linter.activate disposables
-    |> Promise.bind(fun _ -> Project.activate ())
-    |> ignore
-
-    Tooltip.activate df' disposables
-    Autocomplete.activate df' disposables
-    ParameterHints.activate df' disposables
-    Definition.activate df' disposables
-    Reference.activate df' disposables
-    Symbols.activate df' disposables
-    Highlights.activate df' disposables
-    Rename.activate df' disposables
-    WorkspaceSymbols.activate df' disposables
-    QuickInfo.activate disposables
-
 let activate(disposables: Disposable[]) =
     let df = createEmpty<DocumentFilter>
     df.language <- Some "fsharp"
     let df' : DocumentSelector = df |> U3.Case2
 
-    LanguageService.start (fun () -> languageServiceListeningCallback disposables df')
+    LanguageService.start ()
+    |> Promise.success (fun _ -> 
+        Linter.activate disposables
+        |> Promise.bind(fun _ -> Project.activate ())
+        |> ignore
+
+        Tooltip.activate df' disposables
+        Autocomplete.activate df' disposables
+        ParameterHints.activate df' disposables
+        Definition.activate df' disposables
+        Reference.activate df' disposables
+        Symbols.activate df' disposables
+        Highlights.activate df' disposables
+        Rename.activate df' disposables
+        WorkspaceSymbols.activate df' disposables
+        QuickInfo.activate disposables
+    )
     |> ignore
+
     Forge.activate disposables
     Fsi.activate disposables
     WebPreview.activate disposables
-
 
     ()
 


### PR DESCRIPTION
Hi,

I've added FSharp.monoPath setting usage to the LanguageService.start. 
During the testing I had some issues with error propagation using current promises implementation so it lead to this [PR-Fix promises #4](https://github.com/ionide/ionide-vscode-helpers/pull/4) in ionide-vscode-helpers project. If it is accepted - than this PR will fix ionide Promises usage accroding to the changes in Promises API. 

Most noticeable change is in LanguageService.start - I've removed usage of continuation lambda passed in start() method in favor of using Promise.create, which has `resolve` and `reject` methods, allowing to shift promise to needed state. Now the promise is resolved when stdout of FsAutoComplete notifies it is started, and rejected, when any error occurs in the started process, even if user specifies wrong mono path in settings and child_process.spawn throws ENOENT error. 

Please let me know what you think on this. 

PS: the automatic build should be failing now, since it depends on Helpers.fs from helpers project, and only will work if [PR-Fix promises #4](https://github.com/ionide/ionide-vscode-helpers/pull/4) is accepted. 

Thanks.