### PR TITLE
Better logging, output channel option

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -13,10 +13,10 @@ NUGET
     Octokit (0.21.1)
 GIT
   remote: https://github.com/ionide/FsAutoComplete.git
-     (b4d61070e2de61e10418a21db2da2f10a9598e2e)
+     (caf889845342a2264254c5e0269c38e4622dcd74)
       build: build.cmd LocalRelease
       os: windows
-     (b4d61070e2de61e10418a21db2da2f10a9598e2e)
+     (caf889845342a2264254c5e0269c38e4622dcd74)
       build: build.sh LocalRelease
       os: mono
   remote: https://github.com/fsprojects/Forge.git
@@ -27,10 +27,10 @@ GIT
       build: build.sh Build
       os: mono
   remote: https://github.com/ionide/ionide-fsgrammar.git
-     (58ab704e354566063876c81e118453960afd5442)
+     (aedc50eb4dbd258ce91d7b5668ece930bbe69471)
 GITHUB
   remote: fsharp/FAKE
-    modules/Octokit/Octokit.fsx (cd7849e12cf4a6619863671828ed1b0418e90d7f)
+    modules/Octokit/Octokit.fsx (934dc8313e2c54793813058fe2540511ad3b8468)
       Octokit (>= 0.20)
   remote: Ionide/ionide-vscode-helpers
     Fable.Import.Axios.fs (318127fa718355e06b4b1c34d15d1bcaf61279bf)

--- a/release/README.md
+++ b/release/README.md
@@ -2,7 +2,9 @@
 **Enhanced F# Language Features for Visual Studio Code**  
 _Part of the [Ionide](http://ionide.io) plugin suite._
 
-[Need Help? You can find us on Gitter](https://gitter.im/ionide/ionide-project) - [![Join the chat at https://gitter.im/ionide/ionide-project](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg?style=flat-square)](https://gitter.im/ionide/ionide-project?utm_source=share-link&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[Need Help? You can find us on Gitter](https://gitter.im/ionide/ionide-project):
+
+[![Join the chat at https://gitter.im/ionide/ionide-project](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg?style=flat-square)](https://gitter.im/ionide/ionide-project?utm_source=share-link&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 # Getting Started
 
@@ -54,8 +56,6 @@ choco install visualstudiocode -y
 - Highlighting usages
 
 
-
-
 ## WebPreview
 `WebView` allows the user to override the default conventions used to run and preview web applications. To do so You need to create an `.ionide` file in the root folder of Your project opened by VSCode. The configuration file uses the [TOML](https://github.com/toml-lang/toml) language.
 
@@ -93,13 +93,21 @@ startingPage = ""
 * startingPage - webpage displayed in WebPreview - usually ` ` or `index.html`
 
 ## How to contribute
+
 [![](https://ci.appveyor.com/api/projects/status/5wqf80vub6hqywj8?svg=true)](https://ci.appveyor.com/project/Ionide/ionide-vscode-fsharp)
+
 1. Clone repo
 2. Run `build.cmd Build` (or `build.sh Build`)
 3. Open folder in VSCode `code .`
 4. Make changes
 5. Press `F5` to build plugin and start experimental instance of VSCode
 6. Make PR ;)
+
+## How to get logs for debugging / issue reporting
+
+1. Set `"FSharp.logLanguageServiceRequestsToConsole": true` in settings
+2. Toggle Developer Tools (`Help |> Toggle Developer Tools`)
+3. Go to console tab
 
 
 ## Contributing and copyright

--- a/release/package.json
+++ b/release/package.json
@@ -141,6 +141,7 @@
       }
     ],
     "outputChannels": [
+      "F# Language Service",
       "F# Interactive",
       "Forge"
     ],
@@ -173,6 +174,11 @@
           "type": "boolean",
           "default": false,
           "description": "Log language service (FSAC) requests to the developer tools console"
+        },
+        "FSharp.logLanguageServiceRequestsToOutputWindow": {
+          "type": "boolean",
+          "default": false,
+          "description": "Log language service (FSAC) requests to the 'F# Language Service' output window channel"
         },
         "FSharp.automaticProjectModification": {
           "type": "boolean",

--- a/release/package.json
+++ b/release/package.json
@@ -170,20 +170,13 @@
       "type": "object",
       "title": "FSharp configuration",
       "properties": {
-        "FSharp.logLanguageServiceRequestsToConsole": {
-          "type": "boolean",
-          "default": false,
-          "description": "Log language service (FSAC) requests to the developer tools console"
-        },
-        "FSharp.logLanguageServiceRequestsToOutputWindow": {
-          "type": "boolean",
-          "default": false,
-          "description": "Log language service (FSAC) requests to the 'F# Language Service' output window channel"
-        },
-        "FSharp.automaticProjectModification": {
-          "type": "boolean",
-          "default": false,
-          "description": "Automatically modifies fsproj on file add/remove"
+        "FSharp.logLanguageServiceRequests": {
+            "type": "string",
+            "default": "none",
+            "description": "Enable logging language service requests (FSAC)  to an output channel, the developer tools console, or both",
+            "enum": [
+                "none", "output", "devconsole", "both"
+            ]
         },
         "FSharp.toolsDirPath": {
           "type": "string",

--- a/release/package.json
+++ b/release/package.json
@@ -178,6 +178,11 @@
                 "none", "output", "devconsole", "both"
             ]
         },
+        "FSharp.automaticProjectModification": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically modifies fsproj on file add/remove"
+        },
         "FSharp.toolsDirPath": {
           "type": "string",
           "default": "",

--- a/src/Components/QuickInfo.fs
+++ b/src/Components/QuickInfo.fs
@@ -25,17 +25,19 @@ module QuickInfo =
             if JS.isDefined event.textEditor?document then
                 let doc = event.textEditor.document
                 let pos = event.selections.[0].active
-                let! o = LanguageService.tooltip (doc.fileName) (int pos.line + 1) (int pos.character + 1)
-                if o |> unbox <> null then
-                    let res = (o.Data |> Array.fold (fun acc n -> (n |> Array.toList) @ acc ) []).Head.Signature
-                    if JS.isDefined res then
-                        let t = res.Split('\n').[0]
-                        item |> Option.iter (fun n -> n.hide ())
-                        let i = window.createStatusBarItem (1 |> unbox, -1.)
-                        i.text <- t
-                        i.tooltip <- res
-                        i.show ()
-                        item <- Some i
+                
+                if doc.languageId = "fsharp" then
+                    let! o = LanguageService.tooltip (doc.fileName) (int pos.line + 1) (int pos.character + 1)
+                    if o |> unbox <> null then
+                        let res = (o.Data |> Array.fold (fun acc n -> (n |> Array.toList) @ acc ) []).Head.Signature
+                        if JS.isDefined res then
+                            let t = res.Split('\n').[0]
+                            item |> Option.iter (fun n -> n.hide ())
+                            let i = window.createStatusBarItem (1 |> unbox, -1.)
+                            i.text <- t
+                            i.tooltip <- res
+                            i.show ()
+                            item <- Some i
         }
 
     let mutable private timer = None

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -14,11 +14,22 @@ open Ionide.VSCode.Helpers
 module LanguageService =
     let ax =  Node.require.Invoke "axios" |>  unbox<Axios.AxiosStatic>
 
-    let logRequests =
+    let logRequestsToConsole =
         try
             workspace.getConfiguration().get("FSharp.logLanguageServiceRequestsToConsole", false)
         with
         | _ -> false
+
+    let logRequestsToOutputWindow =
+        try
+            workspace.getConfiguration().get("FSharp.logLanguageServiceRequestsToOutputWindow", false)
+        with
+        | _ -> false
+
+    // Always log to the logger, and let it decide where/if to write the message
+    let log =
+        let channel = if logRequestsToOutputWindow then Some (window.createOutputChannel "F# Language Service") else None
+        ConsoleAndOutputChannelLogger(Some "IONIDE-FSAC", INF, channel, logRequestsToConsole)
 
     let genPort () =
         let r = JS.Math.random ()
@@ -30,25 +41,33 @@ module LanguageService =
 
     let mutable private service : child_process_types.ChildProcess option =  None
 
-    let request<'a, 'b> ep id  (obj : 'a) =
-        if logRequests then Browser.console.log ("[IONIDE-FSAC-REQ]", id, ep, obj)
+    let request<'a, 'b> (ep: string) id  (obj : 'a) =       
+        log.Debug ("REQUEST  : %s, Request=%j", ep, obj)
+
+        // At the INFO level, it's nice to see only the key data to get an overview of
+        // what's happening, without being bombarded with too much detail
+        if JS.isDefined (obj?FileName) then
+            log.Info ("REQUEST  : %s, FileName=%j", ep, obj?FileName)
+        else if JS.isDefined (obj?Symbol) then
+            log.Info ("REQUEST  : %s, Symbol=%j", ep, obj?Symbol)
+        else
+            log.Info ("REQUEST  : %s", ep)
+
         ax.post (ep, obj)
         |> Promise.onFail (fun r ->
-            Browser.console.error ("[IONIDE-FSAC-ERR]", id, ep, r)
+            log.Error ("FAILED   : %s, Failure=%j Data=%j", ep, r.ToString(), obj)
             null |> unbox
         )
         |> Promise.map(fun r ->
             try
                 let res = (r.data |> unbox<string[]>).[id] |> JS.JSON.parse |> unbox<'b>
-                if logRequests then
-                    match res?Kind |> unbox with
-                    | "error" -> Browser.console.error ("[IONIDE-FSAC-RES]", id, ep, res?Kind, res?Data)
-                    | _ -> Browser.console.info ("[IONIDE-FSAC-RES]", id, ep, res?Kind, res?Data)
+                log.Info ("RESPONSE : %s, Kind=%s", ep, res?Kind)
+                log.Debug ("RESPONSE : %s, Kind=%s, Data=%j", ep, res?Kind, res?Data)
                 if res?Kind |> unbox = "error" || res?Kind |> unbox = "info" then null |> unbox
                 else res
             with
             | ex ->
-                Browser.console.error ("[IONIDE-FSAC-ERR]", id, ep, r, ex)
+                log.Error ("RESPONSE : %s, Failure=%j, Data=%j", ep, ex.ToString(), obj)
                 null |> unbox
         )
 
@@ -122,19 +141,30 @@ module LanguageService =
                 // Wait until FsAC sends the 'listener started' magic string until
                 // we inform the caller that it's ready to accept requests.
                 let isStartedMessage = (n.ToString().Contains(": listener started in"))
+<<<<<<< 1898be6147b8ca75c1b5fbc4515c1937f7b3325b
                 if isStartedMessage then
                     Browser.console.log ("[IONIDE-FSAC-SIG] started message?", isStartedMessage)
                     service <- Some child
+=======
+                if isStartedMessage then 
+                    log.Debug ("got FSAC line, is it the started message? %s", isStartedMessage)
+                    service <- Some child 
+>>>>>>> Use logging API in LanguageService
                     resolve child
                 else
-                   Browser.console.log (n.ToString())
+                   log.Debug ("got FSAC line: %j", n)
             )
+<<<<<<< 1898be6147b8ca75c1b5fbc4515c1937f7b3325b
             |> Process.onErrorOutput (fun n ->
                 Browser.console.error (n.ToString())
+=======
+            |> Process.onErrorOutput (fun n -> 
+                log.Error ("got FSAC error output: %j", n)
+>>>>>>> Use logging API in LanguageService
                 reject ()
             )
             |> Process.onError (fun e ->
-                Browser.console.error (e.ToString())
+                log.Error ("got FSAC error: %j", e)
                 reject ()
             )
             |> ignore

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -141,26 +141,15 @@ module LanguageService =
                 // Wait until FsAC sends the 'listener started' magic string until
                 // we inform the caller that it's ready to accept requests.
                 let isStartedMessage = (n.ToString().Contains(": listener started in"))
-<<<<<<< 1898be6147b8ca75c1b5fbc4515c1937f7b3325b
-                if isStartedMessage then
-                    Browser.console.log ("[IONIDE-FSAC-SIG] started message?", isStartedMessage)
-                    service <- Some child
-=======
                 if isStartedMessage then 
                     log.Debug ("got FSAC line, is it the started message? %s", isStartedMessage)
                     service <- Some child 
->>>>>>> Use logging API in LanguageService
                     resolve child
                 else
                    log.Debug ("got FSAC line: %j", n)
             )
-<<<<<<< 1898be6147b8ca75c1b5fbc4515c1937f7b3325b
-            |> Process.onErrorOutput (fun n ->
-                Browser.console.error (n.ToString())
-=======
             |> Process.onErrorOutput (fun n -> 
                 log.Error ("got FSAC error output: %j", n)
->>>>>>> Use logging API in LanguageService
                 reject ()
             )
             |> Process.onError (fun e ->

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -1,0 +1,65 @@
+namespace Ionide.VSCode.FSharp
+
+[<AutoOpen>]
+module Logging =
+    open Fable.Import.Node
+    open Fable.Import.vscode
+    open System
+
+    type Level = DBG|INF|WRN|ERR
+        with
+            static member GetLevelNum level = match level with DBG->10|INF->20|WRN->30|ERR->40        
+            override this.ToString() = match this with ERR->"ERR"|INF->"INF"|WRN->"WRN"|DBG->"DBG" 
+            member this.isGreaterOrEqualTo level = Level.GetLevelNum(this) >= Level.GetLevelNum(level)
+
+    let internal write (out: OutputChannel option)
+              (chanMinLevel: Level)
+              (consoleMinLevel: Level option)
+              (level: Level)
+              (source: string option)
+              (template: string)
+              (args: obj[]) =
+        if consoleMinLevel.IsSome && level.isGreaterOrEqualTo(consoleMinLevel.Value) then
+            // just replace %j (Util.format->JSON specifier --> console->OBJECT %O specifier)
+            // the other % specifiers are basically the same
+            let browserLogTemplate = "[" + source.ToString() + "] " + template.Replace("%j", "%O")
+            match args.Length with
+            | 0 -> Fable.Import.Browser.console.log (browserLogTemplate)
+            | 1 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0])
+            | 2 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1])
+            | 3 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1], args.[2])
+            | 4 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1], args.[2], args.[3])
+            | _ -> Fable.Import.Browser.console.log (browserLogTemplate, args)
+
+        if level.isGreaterOrEqualTo(chanMinLevel) then
+            match out with
+            | Some chan -> 
+                let formattedMessage = util.format(template, args).Replace("\n", " ")
+                let formattedLogLine = String.Format("[{0:HH:mm:ss} {1}] {2}", DateTime.Now, string level, formattedMessage)
+                chan.appendLine (formattedLogLine)
+            | _ -> ()
+
+    /// The templates may use node util.format placeholders: %s, %d, %j, %%
+    /// https://nodejs.org/api/util.html#util_util_format_format
+    type ConsoleAndOutputChannelLogger(source: string option, chanMinLevel: Level, out:OutputChannel option, logToConsole: bool) =
+        let consoleMinLevel = if logToConsole then Some DBG else Some WRN // always dump warnings and errors to console
+        /// Logs a message that should/could be seen by developers when diagnosing problems.
+        /// The templates may use node util.format placeholders: %s, %d, %j, %%
+        /// https://nodejs.org/api/util.html#util_util_format_format
+        member this.Debug (template, [<ParamArray>]args:obj[]) =
+            write out chanMinLevel consoleMinLevel DBG source template args
+        /// Logs a message that should/could be seen by the user in the output channel.
+        /// The templates may use node util.format placeholders: %s, %d, %j, %%
+        /// https://nodejs.org/api/util.html#util_util_format_format
+        member this.Info (template, [<ParamArray>]args:obj[]) =
+            write out chanMinLevel consoleMinLevel INF source template args
+        /// Logs a message that should/could be seen by the user in the output channel when a problem happens.
+        /// The templates may use node util.format placeholders: %s, %d, %j, %%
+        /// https://nodejs.org/api/util.html#util_util_format_format
+        member this.Error (template, [<ParamArray>]args:obj[]) =
+            write out chanMinLevel consoleMinLevel ERR source template args
+        /// Logs a message that should/could be seen by the user in the output channel when a problem happens.
+        /// The templates may use node util.format placeholders: %s, %d, %j, %%
+        /// https://nodejs.org/api/util.html#util_util_format_format
+        member this.Warn (template, [<ParamArray>]args:obj[]) =
+            write out chanMinLevel consoleMinLevel WRN source template args

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -44,6 +44,7 @@
       <Paket>True</Paket>
       <Link>paket-files/Fable.Import.Axios.fs</Link>
     </Compile>
+    <Compile Include="Core/Logging.fs" />
     <Compile Include="Core/DTO.fs" />
     <Compile Include="Core/LanguageService.fs" />
     <Compile Include="Core/Project.fs" />


### PR DESCRIPTION
There is now a new logging option, which is `none` (no logging) by default:
```json
"FSharp.logLanguageServiceRequests": {
    "type": "string", 
    "default": "none",
    "description": "Enable logging language service requests (FSAC)  to an output channel, the developer tools console, or both",
     "enum": [
         "none", "output", "devconsole", "both"
     ]
}
```

The OutputChannel log is designed to give an overview/summary of activity in the F# language service.
![image](https://cloud.githubusercontent.com/assets/570470/17826584/982dacc0-66b5-11e6-8d76-4df409e8a322.png)
Colourized:
![image](https://cloud.githubusercontent.com/assets/570470/17828449/7bd888b8-66d5-11e6-863c-78df019119c9.png)

The Developer Tools\Console log is designed to:
 1. Always capture errors (regardless of above config settings)
 1. Contain debug detail level logs, including request/response objects

![image](https://cloud.githubusercontent.com/assets/570470/17826617/ed31b176-66b5-11e6-8283-528d8e638e96.png)

![image](https://cloud.githubusercontent.com/assets/570470/17826641/2c6271dc-66b6-11e6-9c41-155aac605332.png)
