### PR TITLE
[WIP] More pretty output

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -180,9 +180,9 @@
         },
         "FSharp.logLanguageServiceRequestsOutputWindowLevel": {
             "type": "string",
-            "default": "INF",
+            "default": "INFO",
             "enum": [
-                "DBG", "INF", "WRN", "ERR"
+                "DEBUG", "INFO", "WARN", "ERROR"
             ]
         },
         "FSharp.automaticProjectModification": {

--- a/release/package.json
+++ b/release/package.json
@@ -178,6 +178,13 @@
                 "none", "output", "devconsole", "both"
             ]
         },
+        "FSharp.logLanguageServiceRequestsOutputWindowLevel": {
+            "type": "string",
+            "default": "INF",
+            "enum": [
+                "DBG", "INF", "WRN", "ERR"
+            ]
+        },
         "FSharp.automaticProjectModification": {
           "type": "boolean",
           "default": false,

--- a/release/package.json
+++ b/release/package.json
@@ -181,6 +181,7 @@
         "FSharp.logLanguageServiceRequestsOutputWindowLevel": {
             "type": "string",
             "default": "INFO",
+            "description": "Determines how verbose the output window logging is.",
             "enum": [
                 "DEBUG", "INFO", "WARN", "ERROR"
             ]

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -44,95 +44,132 @@ module LanguageService =
         r'.ToString().Substring(0,4)
 
     let port = genPort ()
-    let private url s = sprintf @"http://localhost:%s/%s" port s
-
+    let private url fsacAction = (sprintf "http://localhost:%s/%s" port fsacAction)
     let mutable private service : child_process_types.ChildProcess option =  None
+    let private platformPathSeparator = if Process.isMono () then "/" else "\\"
+    let private makeRequestId =
+        let mutable requestId = 0
+        fun () -> (requestId <- requestId + 1); requestId
+    let private makePathWorkspaceRelative (path: string) = path.Replace(vscode.workspace.rootPath, "~" + platformPathSeparator)
+    let private makeOutgoingLogPrefix =
+        let outgoingLogFormat = "REQ ({0:000}) ->"
+        fun (id:int) -> String.Format(outgoingLogFormat, id)
+    let private makeIncomingLogPrefix =
+        let incomingLogFormat = "RES ({0:000}) <-"
+        fun (id:int) -> String.Format(incomingLogFormat, id)
 
-    let request<'a, 'b> (ep: string) id  (obj : 'a) =
-        log.Debug ("REQUEST  : %s, Request=%j", ep, obj)
-
+    let private logOutgoingRequest id (fsacAction:string) obj =
+        // log.Debug (makeOutgoingLogPrefix(id) + " %s: Request=%j", fsacAction, obj)
         // At the INFO level, it's nice to see only the key data to get an overview of
         // what's happening, without being bombarded with too much detail
-        if JS.isDefined (obj?FileName) then
-            log.Info ("REQUEST  : %s, FileName=%j", ep, obj?FileName)
-        else if JS.isDefined (obj?Symbol) then
-            log.Info ("REQUEST  : %s, Symbol=%j", ep, obj?Symbol)
-        else
-            log.Info ("REQUEST  : %s", ep)
+        let extraPropInfo =
+            if (JS.isDefined (obj?FileName)) then Some ", File=%j", Some (makePathWorkspaceRelative (obj?FileName |> unbox))
+            elif (JS.isDefined (obj?Symbol)) then Some ", Symbol=%j", Some (obj?Symbol |> unbox)
+            elif (JS.isDefined (obj?Project)) then Some ", Project=%j", Some (obj?Project |> unbox)
+            else None, None
 
-        ax.post (ep, obj)
+        match extraPropInfo with
+        | None, None ->
+            log.Info (makeOutgoingLogPrefix(id) + " %s", fsacAction)
+        | Some extraTmpl, extraArg ->
+            log.Info (makeOutgoingLogPrefix(id) + " %s" + extraTmpl, fsacAction, extraArg)
+        | _, _ -> failwithf "cannot happen %A" extraPropInfo
+
+    let private logIncomingResponse id fsacAction (started: DateTime) (r: Axios.AxiosXHR<_>) (res: _ option) (ex: exn option) =
+        let elapsed = DateTime.Now - started
+        log.Debug (makeIncomingLogPrefix(id) + " HTTP %s response %s in %s ms: %j", r.config.method, r.statusText, elapsed.TotalMilliseconds, r.data)
+        match res, ex with
+        | Some res, None ->
+            log.Info (makeIncomingLogPrefix(id) + " %s in %s ms: Kind=%s ", fsacAction, elapsed.TotalMilliseconds, res?Kind)
+            log.Debug (makeIncomingLogPrefix(id) + " %s in %s ms: Kind=%s, Data=%j", fsacAction, elapsed.TotalMilliseconds, res?Kind, res?Data)
+        | None, Some ex ->
+            log.Error (makeIncomingLogPrefix(id) + " %s ERROR in %s ms: %j, Data=%j", fsacAction, elapsed.TotalMilliseconds, ex.ToString(), obj)
+        | _, _ -> log.Error(makeIncomingLogPrefix(id) + " %s ERROR in %s ms: %j, %j, %j", fsacAction, elapsed.TotalMilliseconds, res, ex.ToString(), obj)
+
+    let private logIncomingResponseError id fsacAction (started: DateTime) (r: obj) =
+        let elapsed = DateTime.Now - started
+        log.Error (makeIncomingLogPrefix(id) + " %s ERROR in %s ms: %s Data=%j",
+                    fsacAction, elapsed.TotalMilliseconds, r.ToString(), obj)
+
+    let private request<'a, 'b> (fsacAction: string) id (obj : 'a) =
+        let started = DateTime.Now
+        let fullRequestUrl = url fsacAction
+        logOutgoingRequest id fsacAction obj
+
+        ax.post (fullRequestUrl, obj)
         |> Promise.onFail (fun r ->
-            log.Error ("FAILED   : %s, Failure=%j Data=%j", ep, r.ToString(), obj)
+            // The outgoing request was not made
+            logIncomingResponseError id fsacAction started r
             null |> unbox
         )
         |> Promise.map(fun r ->
+            // the outgoing request was made
             try
-                let res = (r.data |> unbox<string[]>).[id] |> JS.JSON.parse |> unbox<'b>
-                log.Info ("RESPONSE : %s, Kind=%s", ep, res?Kind)
-                log.Debug ("RESPONSE : %s, Kind=%s, Data=%j", ep, res?Kind, res?Data)
+                let res = (r.data |> unbox<string[]>).[0] |> JS.JSON.parse |> unbox<'b>
+                logIncomingResponse id fsacAction started r (Some res) None
                 if res?Kind |> unbox = "error" || res?Kind |> unbox = "info" then null |> unbox
                 else res
             with
             | ex ->
-                log.Error ("RESPONSE : %s, Failure=%j, Data=%j", ep, ex.ToString(), obj)
+                logIncomingResponse id fsacAction started r None (Some ex)
                 null |> unbox
         )
 
     let project s =
         {ProjectRequest.FileName = s}
-        |> request (url "project") 0
+        |> request ("project") (makeRequestId())
 
     let parseProject () =
         ""
-        |> request (url "parseProjects") 0
+        |> request ("parseProjects") (makeRequestId())
 
     let parse path (text : string) =
         let lines = text.Replace("\uFEFF", "").Split('\n')
         {ParseRequest.FileName = path; ParseRequest.Lines = lines; ParseRequest.IsAsync = true }
-        |> request (url "parse") 0
+        |> request ("parse") (makeRequestId())
 
     let helptext s =
         {HelptextRequest.Symbol = s}
-        |> request (url "helptext") 0
+        |> request ("helptext") (makeRequestId())
 
     let completion fn sl line col =
         {CompletionRequest.Line = line; FileName = fn; Column = col; Filter = "Contains"; SourceLine = sl}
-        |> request (url "completion")1
+        |> request ("completion") (makeRequestId())
 
     let symbolUse fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request (url "symboluse") 0
+        |> request ("symboluse") (makeRequestId())
 
     let symbolUseProject fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request (url "symboluseproject") 0
+        |> request ("symboluseproject") (makeRequestId())
 
     let methods fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request (url "methods") 0
+        |> request ("methods") (makeRequestId())
 
     let tooltip fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request (url "tooltip") 0
+        |> request ("tooltip") (makeRequestId())
 
     let toolbar fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request (url "tooltip") 0
+        |> request ("tooltip") (makeRequestId())
 
     let findDeclaration fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request (url "finddeclaration") 0
+        |> request ("finddeclaration") (makeRequestId())
 
     let declarations fn =
         {DeclarationsRequest.FileName = fn}
-        |> request (url "declarations") 0
+        |> request ("declarations") (makeRequestId())
 
 
     let declarationsProjects () =
-        "" |> request (url "declarationsProjects")  0
+        "" |> request ("declarationsProjects") (makeRequestId())
 
     let compilerLocation () =
-        "" |> request (url "compilerlocation")  0
+        "" |> request ("compilerlocation") (makeRequestId())
 
     let lint s =
         {ProjectRequest.FileName = s}
@@ -147,25 +184,33 @@ module LanguageService =
                 else
                     child_process.spawn(path, [| string port|] |> ResizeArray)
 
+            let mutable isResolvedAsStarted = false
             child
             |> Process.onOutput (fun n ->
+                // The `n` object is { "type":"Buffer", "data":[...bytes] }
+                // and by calling .ToString() we are decoding the buffer into a string.
+                let outputString = n.ToString()
                 // Wait until FsAC sends the 'listener started' magic string until
                 // we inform the caller that it's ready to accept requests.
-                let isStartedMessage = (n.ToString().Contains(": listener started in"))
+                let isStartedMessage = outputString.Contains(": listener started in")
                 if isStartedMessage then
                     log.Debug ("got FSAC line, is it the started message? %s", isStartedMessage)
                     service <- Some child
                     resolve child
-                else
-                   log.Debug ("got FSAC line: %j", n)
-            )
-            |> Process.onErrorOutput (fun n ->
-                log.Error ("got FSAC error output: %j", n)
-                reject ()
+                    isResolvedAsStarted <- true
+
+                // always log the output
+                log.Debug ("FSAC stdout: %s", n.ToString())
             )
             |> Process.onError (fun e ->
-                log.Error ("got FSAC error: %j", e)
-                reject ()
+                log.Error ("FSAC process error: %s", e.ToString())
+                if not isResolvedAsStarted then
+                    reject ()
+            )
+            |> Process.onErrorOutput (fun n ->
+                log.Error ("FSAC stderr: %s", n.ToString())
+                if not isResolvedAsStarted then
+                    reject ()
             )
             |> ignore
         )

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -190,7 +190,7 @@ module LanguageService =
 
     let lint s =
         {ProjectRequest.FileName = s}
-        |> request (url "lint") 0
+        |> request ("lint") 0 (makeRequestId())
 
     let start' path =
         Promise.create (fun resolve reject ->

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -129,63 +129,63 @@ module LanguageService =
 
     let project s =
         {ProjectRequest.FileName = s}
-        |> request ("project") 0 (makeRequestId())
+        |> request "project" 0 (makeRequestId())
 
     let parseProject () =
         ""
-        |> request ("parseProjects") 0 (makeRequestId())
+        |> request "parseProjects" 0 (makeRequestId())
 
     let parse path (text : string) =
         let lines = text.Replace("\uFEFF", "").Split('\n')
         {ParseRequest.FileName = path; ParseRequest.Lines = lines; ParseRequest.IsAsync = true }
-        |> request ("parse") 0 (makeRequestId())
+        |> request "parse" 0 (makeRequestId())
 
     let helptext s =
         {HelptextRequest.Symbol = s}
-        |> request ("helptext") 0 (makeRequestId())
+        |> request "helptext" 0 (makeRequestId())
 
     let completion fn sl line col =
         {CompletionRequest.Line = line; FileName = fn; Column = col; Filter = "Contains"; SourceLine = sl}
-        |> request ("completion") 0 (makeRequestId())
+        |> request "completion" 0 (makeRequestId())
 
     let symbolUse fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request ("symboluse") 0 (makeRequestId())
+        |> request "symboluse" 0 (makeRequestId())
 
     let symbolUseProject fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request ("symboluseproject") 0 (makeRequestId())
+        |> request "symboluseproject" 0 (makeRequestId())
 
     let methods fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request ("methods") 0 (makeRequestId())
+        |> request "methods" 0 (makeRequestId())
 
     let tooltip fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request ("tooltip") 0 (makeRequestId())
+        |> request "tooltip" 0 (makeRequestId())
 
     let toolbar fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request ("tooltip") 0 (makeRequestId())
+        |> request "tooltip" 0 (makeRequestId())
 
     let findDeclaration fn line col =
         {PositionRequest.Line = line; FileName = fn; Column = col; Filter = ""}
-        |> request ("finddeclaration") 0 (makeRequestId())
+        |> request "finddeclaration" 0 (makeRequestId())
 
     let declarations fn =
         {DeclarationsRequest.FileName = fn}
-        |> request ("declarations") 0 (makeRequestId())
+        |> request "declarations" 0 (makeRequestId())
 
 
     let declarationsProjects () =
-        "" |> request ("declarationsProjects") 0 (makeRequestId())
+        "" |> request "declarationsProjects" 0 (makeRequestId())
 
     let compilerLocation () =
-        "" |> request ("compilerlocation") 0 (makeRequestId())
+        "" |> request "compilerlocation" 0 (makeRequestId())
 
     let lint s =
         {ProjectRequest.FileName = s}
-        |> request ("lint") 0 (makeRequestId())
+        |> request "lint" 0 (makeRequestId())
 
     let start' path =
         Promise.create (fun resolve reject ->
@@ -204,7 +204,7 @@ module LanguageService =
                 let outputString = n.ToString()
                 // Wait until FsAC sends the 'listener started' magic string until
                 // we inform the caller that it's ready to accept requests.
-                let isStartedMessage = outputString.Contains(": listener started in")
+                let isStartedMessage = outputString.Contains ": listener started in"
                 if isStartedMessage then
                     log.Debug ("got FSAC line, is it the started message? %s", isStartedMessage)
                     service <- Some child

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -29,7 +29,12 @@ module LanguageService =
 
     let logLanguageServiceRequestsOutputWindowLevel =
         try
-            workspace.getConfiguration().get("FSharp.logLanguageServiceRequestsOutputWindowLevel", Level.INF)
+            match workspace.getConfiguration().get("FSharp.logLanguageServiceRequestsOutputWindowLevel", "INF") with
+            | "DBG" -> Level.DBG
+            | "INF" -> Level.INF
+            | "WRN" -> Level.WRN
+            | "ERR" -> Level.ERR
+            | _ -> Level.INF
         with
         | _ -> Level.INF
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -76,7 +76,6 @@ module LanguageService =
         fun (id:int) -> String.Format(incomingLogFormat, id)
 
     let private logOutgoingRequest id (fsacAction:string) obj =
-        // log.Debug (makeOutgoingLogPrefix(id) + " %s: Request=%j", fsacAction, obj)
         // At the INFO level, it's nice to see only the key data to get an overview of
         // what's happening, without being bombarded with too much detail
         let extraPropInfo =

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -57,7 +57,7 @@ module LanguageService =
     let private makeRequestId =
         let mutable requestId = 0
         fun () -> (requestId <- requestId + 1); requestId
-    let private makePathWorkspaceRelative (path: string) =
+    let private relativePathForDisplay (path: string) =
         path.Replace(vscode.workspace.rootPath + platformPathSeparator, "~" + platformPathSeparator)
     let private makeOutgoingLogPrefix =
         let outgoingLogFormat = "REQ ({0:000}) ->"
@@ -71,14 +71,14 @@ module LanguageService =
         // At the INFO level, it's nice to see only the key data to get an overview of
         // what's happening, without being bombarded with too much detail
         let extraPropInfo =
-            if (JS.isDefined (obj?FileName)) then Some ", File = \"%s\"", Some (makePathWorkspaceRelative (obj?FileName |> unbox))
-            elif (JS.isDefined (obj?Project)) then Some ", Project = \"%s\"", Some (makePathWorkspaceRelative (obj?Project |> unbox))
+            if (JS.isDefined (obj?FileName)) then Some ", File = \"%s\"", Some (relativePathForDisplay (obj?FileName |> unbox))
+            elif (JS.isDefined (obj?Project)) then Some ", Project = \"%s\"", Some (relativePathForDisplay (obj?Project |> unbox))
             elif (JS.isDefined (obj?Symbol)) then Some ", Symbol = \"%s\"", Some (obj?Symbol |> unbox)
             else None, None
 
         match extraPropInfo with
         | None, None -> log.Info (makeOutgoingLogPrefix(id) + " {%s}", fsacAction)
-        | Some extraTmpl, extraArg -> log.Info (makeOutgoingLogPrefix(id) + " {%s}" + extraTmpl, fsacAction, extraArg)
+        | Some extraTmpl, Some extraArg -> log.Info (makeOutgoingLogPrefix(id) + " {%s}" + extraTmpl, fsacAction, extraArg)
         | _, _ -> failwithf "cannot happen %A" extraPropInfo
 
     let private logIncomingResponse id fsacAction (started: DateTime) (r: Axios.AxiosXHR<_>) (res: _ option) (ex: exn option) =

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -68,12 +68,8 @@ module LanguageService =
         fun () -> (requestId <- requestId + 1); requestId
     let private relativePathForDisplay (path: string) =
         path.Replace(vscode.workspace.rootPath + platformPathSeparator, "~" + platformPathSeparator)
-    let private makeOutgoingLogPrefix =
-        let outgoingLogFormat = "REQ ({0:000}) ->"
-        fun (id:int) -> String.Format(outgoingLogFormat, id)
-    let private makeIncomingLogPrefix =
-        let incomingLogFormat = "RES ({0:000}) <-"
-        fun (id:int) -> String.Format(incomingLogFormat, id)
+    let private makeOutgoingLogPrefix (id:int) = String.Format("REQ ({0:000}) ->", id)
+    let private makeIncomingLogPrefix (id:int) = String.Format("RES ({0:000}) <-", id)
 
     let private logOutgoingRequest id (fsacAction:string) obj =
         // At the INFO level, it's nice to see only the key data to get an overview of

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -30,13 +30,13 @@ module LanguageService =
     let logLanguageServiceRequestsOutputWindowLevel =
         try
             match workspace.getConfiguration().get("FSharp.logLanguageServiceRequestsOutputWindowLevel", "INFO") with
-            | "DEBUG" -> Level.DBG
-            | "INFO" -> Level.INF
-            | "WARN" -> Level.WRN
-            | "ERROR" -> Level.ERR
-            | _ -> Level.INF
+            | "DEBUG" -> Level.DEBUG
+            | "INFO" -> Level.INFO
+            | "WARN" -> Level.WARN
+            | "ERROR" -> Level.ERROR
+            | _ -> Level.INFO
         with
-        | _ -> Level.INF
+        | _ -> Level.INFO
 
     // Always log to the logger, and let it decide where/if to write the message
     let log =
@@ -47,11 +47,11 @@ module LanguageService =
             | LogConfigSetting.DevConsole -> None, true
             | LogConfigSetting.Output -> Some (window.createOutputChannel "F# Language Service"), false
 
-        let consoleMinLevel = if logRequestsToConsole then DBG else WRN
+        let consoleMinLevel = if logRequestsToConsole then DEBUG else WARN
         let inst = ConsoleAndOutputChannelLogger(Some "IONIDE-FSAC", logLanguageServiceRequestsOutputWindowLevel, channel, Some consoleMinLevel)
-        if logLanguageServiceRequestsOutputWindowLevel <> Level.DBG then
-            let levelString = logLanguageServiceRequestsOutputWindowLevel.ToString().Trim()
-            inst.Info ("Logging to output at level %s. If you want detailed messages, try level DBG.", levelString)
+        if logLanguageServiceRequestsOutputWindowLevel <> Level.DEBUG then
+            let levelString = logLanguageServiceRequestsOutputWindowLevel.ToString()
+            inst.Info ("Logging to output at level %s. If you want detailed messages, try level DEBUG.", levelString)
         inst
 
     let genPort () =

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -29,11 +29,11 @@ module LanguageService =
 
     let logLanguageServiceRequestsOutputWindowLevel =
         try
-            match workspace.getConfiguration().get("FSharp.logLanguageServiceRequestsOutputWindowLevel", "INF") with
-            | "DBG" -> Level.DBG
-            | "INF" -> Level.INF
-            | "WRN" -> Level.WRN
-            | "ERR" -> Level.ERR
+            match workspace.getConfiguration().get("FSharp.logLanguageServiceRequestsOutputWindowLevel", "INFO") with
+            | "DEBUG" -> Level.DBG
+            | "INFO" -> Level.INF
+            | "WARN" -> Level.WRN
+            | "ERROR" -> Level.ERR
             | _ -> Level.INF
         with
         | _ -> Level.INF

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -75,9 +75,9 @@ module LanguageService =
         // At the INFO level, it's nice to see only the key data to get an overview of
         // what's happening, without being bombarded with too much detail
         let extraPropInfo =
-            if (JS.isDefined (obj?FileName)) then Some ", File = \"%s\"", Some (relativePathForDisplay (obj?FileName |> unbox))
-            elif (JS.isDefined (obj?Project)) then Some ", Project = \"%s\"", Some (relativePathForDisplay (obj?Project |> unbox))
-            elif (JS.isDefined (obj?Symbol)) then Some ", Symbol = \"%s\"", Some (obj?Symbol |> unbox)
+            if JS.isDefined (obj?FileName) then Some ", File = \"%s\"", Some (relativePathForDisplay (obj?FileName |> unbox))
+            elif JS.isDefined (obj?Project) then Some ", Project = \"%s\"", Some (relativePathForDisplay (obj?Project |> unbox))
+            elif JS.isDefined (obj?Symbol) then Some ", Symbol = \"%s\"", Some (obj?Symbol |> unbox)
             else None, None
 
         match extraPropInfo with

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -48,7 +48,11 @@ module LanguageService =
             | LogConfigSetting.Output -> Some (window.createOutputChannel "F# Language Service"), false
 
         let consoleMinLevel = if logRequestsToConsole then DBG else WRN
-        ConsoleAndOutputChannelLogger(Some "IONIDE-FSAC", logLanguageServiceRequestsOutputWindowLevel, channel, Some consoleMinLevel)
+        let inst = ConsoleAndOutputChannelLogger(Some "IONIDE-FSAC", logLanguageServiceRequestsOutputWindowLevel, channel, Some consoleMinLevel)
+        if logLanguageServiceRequestsOutputWindowLevel <> Level.DBG then
+            let levelString = logLanguageServiceRequestsOutputWindowLevel.ToString().Trim()
+            inst.Info ("Logging to output at level %s. If you want detailed messages, try level DBG.", levelString)
+        inst
 
     let genPort () =
         let r = JS.Math.random ()

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -11,6 +11,7 @@ module Logging =
             static member GetLevelNum level = match level with DBG->10|INF->20|WRN->30|ERR->40
             override this.ToString() = match this with ERR->"ERROR"|INF->"INFO " |WRN->"WARN "|DBG->"DEBUG"
             member this.isGreaterOrEqualTo level = Level.GetLevelNum(this) >= Level.GetLevelNum(level)
+            member this.isLessOrEqualTo level = Level.GetLevelNum(this) <= Level.GetLevelNum(level)
 
     let private writeDevToolsConsole (level: Level) (source: string option) (template: string) (args: obj[]) =
         // just replace %j (Util.format->JSON specifier --> console->OBJECT %O specifier)
@@ -54,9 +55,9 @@ module Logging =
                         (infoTemplateAndArgs: string * obj[]) =
             // OutputChannel: when at DBG level, use the DBG template and args, otherwise INF
             if out.IsSome then
-                if chanMinLevel.isGreaterOrEqualTo(Level.DBG) then
+                if chanMinLevel.isLessOrEqualTo(Level.DBG) then
                     writeOutputChannel out.Value DBG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
-                elif chanMinLevel.isGreaterOrEqualTo(Level.INF) then
+                elif chanMinLevel.isLessOrEqualTo(Level.INF) then
                     writeOutputChannel out.Value INF source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
 
             // Console: when at DBG level, use the DBG template and args, otherwise INF

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -47,20 +47,20 @@ module Logging =
     /// https://nodejs.org/api/util.html#util_util_format_format
     type ConsoleAndOutputChannelLogger(source: string option, chanMinLevel: Level, out:OutputChannel option, consoleMinLevel: Level option) =
 
-        /// Logs a different message in either DBG (if enabled) or INF (otherwise).
+        /// Logs a different message in either DEBUG (if enabled) or INFO (otherwise).
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.DebugOrInfo
                         (debugTemplateAndArgs: string * obj[])
                         (infoTemplateAndArgs: string * obj[]) =
-            // OutputChannel: when at DBG level, use the DBG template and args, otherwise INF
+            // OutputChannel: when at DEBUG level, use the DEBUG template and args, otherwise INFO
             if out.IsSome then
                 if chanMinLevel.isLessOrEqualTo(Level.DEBUG) then
                     writeOutputChannel out.Value DEBUG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
                 elif chanMinLevel.isLessOrEqualTo(Level.INFO) then
                     writeOutputChannel out.Value INFO source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
 
-            // Console: when at DBG level, use the DBG template and args, otherwise INF
+            // Console: when at DEBUG level, use the DEBUG template and args, otherwise INFO
             if consoleMinLevel.IsSome then
                 if Level.DEBUG.isGreaterOrEqualTo(consoleMinLevel.Value) then
                     writeDevToolsConsole DEBUG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -12,7 +12,24 @@ module Logging =
             override this.ToString() = match this with ERR->"ERROR"|INF->"INFO " |WRN->"WARN "|DBG->"DEBUG"
             member this.isGreaterOrEqualTo level = Level.GetLevelNum(this) >= Level.GetLevelNum(level)
 
-    let internal write (out: OutputChannel option)
+    let private writeDevToolsConsole (level: Level) (source: string option) (template: string) (args: obj[]) =
+        // just replace %j (Util.format->JSON specifier --> console->OBJECT %O specifier)
+        // the other % specifiers are basically the same
+        let browserLogTemplate = String.Format("[{0,5}] {1}", source.ToString().PadRight(5), template.Replace("%j", "%O"))
+        match args.Length with
+        | 0 -> Fable.Import.Browser.console.log (browserLogTemplate)
+        | 1 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0])
+        | 2 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1])
+        | 3 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1], args.[2])
+        | 4 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1], args.[2], args.[3])
+        | _ -> Fable.Import.Browser.console.log (browserLogTemplate, args)
+
+    let private writeOutputChannel (out: OutputChannel) level source template args =
+        let formattedMessage = util.format(template, args)
+        let formattedLogLine = String.Format("[{0:HH:mm:ss} {1}] {2}", DateTime.Now, string level, formattedMessage)
+        out.appendLine (formattedLogLine)
+
+    let private writeBothIfConfigured (out: OutputChannel option)
               (chanMinLevel: Level)
               (consoleMinLevel: Level option)
               (level: Level)
@@ -20,46 +37,52 @@ module Logging =
               (template: string)
               (args: obj[]) =
         if consoleMinLevel.IsSome && level.isGreaterOrEqualTo(consoleMinLevel.Value) then
-            // just replace %j (Util.format->JSON specifier --> console->OBJECT %O specifier)
-            // the other % specifiers are basically the same
-            let browserLogTemplate = String.Format("[{0,5}] {1}", source.ToString().PadRight(5), template.Replace("%j", "%O"))
-            match args.Length with
-            | 0 -> Fable.Import.Browser.console.log (browserLogTemplate)
-            | 1 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0])
-            | 2 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1])
-            | 3 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1], args.[2])
-            | 4 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1], args.[2], args.[3])
-            | _ -> Fable.Import.Browser.console.log (browserLogTemplate, args)
+            writeDevToolsConsole level source template args
 
-        if level.isGreaterOrEqualTo(chanMinLevel) then
-            match out with
-            | Some chan ->
-                let formattedMessage = util.format(template, args).Replace("\n", " ")
-                let formattedLogLine = String.Format("[{0:HH:mm:ss} {1}] {2}", DateTime.Now, string level, formattedMessage)
-                chan.appendLine (formattedLogLine)
-            | _ -> ()
+        if out.IsSome && level.isGreaterOrEqualTo(chanMinLevel) then
+            writeOutputChannel out.Value level source template args
 
     /// The templates may use node util.format placeholders: %s, %d, %j, %%
     /// https://nodejs.org/api/util.html#util_util_format_format
-    type ConsoleAndOutputChannelLogger(source: string option, chanMinLevel: Level, out:OutputChannel option, logToConsole: bool) =
-        let consoleMinLevel = if logToConsole then Some DBG else Some WRN // always dump warnings and errors to console
+    type ConsoleAndOutputChannelLogger(source: string option, chanMinLevel: Level, out:OutputChannel option, consoleMinLevel: Level option) =
+
+        /// Logs a different message in either DBG (if enabled) or INF (otherwise).
+        /// The templates may use node util.format placeholders: %s, %d, %j, %%
+        /// https://nodejs.org/api/util.html#util_util_format_format
+        member this.DebugOrInfo
+                        (debugTemplateAndArgs: string * obj[])
+                        (infoTemplateAndArgs: string * obj[]) =
+            // OutputChannel: when at DBG level, use the DBG template and args, otherwise INF
+            if out.IsSome then
+                if Level.DBG.isGreaterOrEqualTo(chanMinLevel) then
+                    writeOutputChannel out.Value DBG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
+                elif Level.INF.isGreaterOrEqualTo(chanMinLevel) then
+                    writeOutputChannel out.Value INF source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
+
+            // Console: when at DBG level, use the DBG template and args, otherwise INF
+            if consoleMinLevel.IsSome then
+                if Level.DBG.isGreaterOrEqualTo(consoleMinLevel.Value) then
+                    writeDevToolsConsole DBG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
+                elif Level.INF.isGreaterOrEqualTo(consoleMinLevel.Value) then
+                    writeDevToolsConsole INF source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
+
         /// Logs a message that should/could be seen by developers when diagnosing problems.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Debug (template, [<ParamArray>]args:obj[]) =
-            write out chanMinLevel consoleMinLevel DBG source template args
+            writeBothIfConfigured out chanMinLevel consoleMinLevel DBG source template args
         /// Logs a message that should/could be seen by the user in the output channel.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Info (template, [<ParamArray>]args:obj[]) =
-            write out chanMinLevel consoleMinLevel INF source template args
+            writeBothIfConfigured out chanMinLevel consoleMinLevel INF source template args
         /// Logs a message that should/could be seen by the user in the output channel when a problem happens.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Error (template, [<ParamArray>]args:obj[]) =
-            write out chanMinLevel consoleMinLevel ERR source template args
+            writeBothIfConfigured out chanMinLevel consoleMinLevel ERR source template args
         /// Logs a message that should/could be seen by the user in the output channel when a problem happens.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Warn (template, [<ParamArray>]args:obj[]) =
-            write out chanMinLevel consoleMinLevel WRN source template args
+            writeBothIfConfigured out chanMinLevel consoleMinLevel WRN source template args

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -8,7 +8,7 @@ module Logging =
 
     type Level = DBG|INF|WRN|ERR
         with
-            static member GetLevelNum level = match level with DBG->10|INF->20|WRN->30|ERR->40
+            static member GetLevelNum = function DBG->10|INF->20|WRN->30|ERR->40
             override this.ToString() = match this with ERR->"ERROR"|INF->"INFO"|WRN->"WARN"|DBG->"DEBUG"
             member this.isGreaterOrEqualTo level = Level.GetLevelNum(this) >= Level.GetLevelNum(level)
             member this.isLessOrEqualTo level = Level.GetLevelNum(this) <= Level.GetLevelNum(level)

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -54,9 +54,9 @@ module Logging =
                         (infoTemplateAndArgs: string * obj[]) =
             // OutputChannel: when at DBG level, use the DBG template and args, otherwise INF
             if out.IsSome then
-                if Level.DBG.isGreaterOrEqualTo(chanMinLevel) then
+                if chanMinLevel.isGreaterOrEqualTo(Level.DBG) then
                     writeOutputChannel out.Value DBG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
-                elif Level.INF.isGreaterOrEqualTo(chanMinLevel) then
+                elif chanMinLevel.isGreaterOrEqualTo(Level.INF) then
                     writeOutputChannel out.Value INF source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
 
             // Console: when at DBG level, use the DBG template and args, otherwise INF

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -8,8 +8,8 @@ module Logging =
 
     type Level = DBG|INF|WRN|ERR
         with
-            static member GetLevelNum level = match level with DBG->10|INF->20|WRN->30|ERR->40        
-            override this.ToString() = match this with ERR->"ERR"|INF->"INF"|WRN->"WRN"|DBG->"DBG" 
+            static member GetLevelNum level = match level with DBG->10|INF->20|WRN->30|ERR->40
+            override this.ToString() = match this with ERR->"ERROR"|INF->"INFO " |WRN->"WARN "|DBG->"DEBUG"
             member this.isGreaterOrEqualTo level = Level.GetLevelNum(this) >= Level.GetLevelNum(level)
 
     let internal write (out: OutputChannel option)
@@ -22,7 +22,7 @@ module Logging =
         if consoleMinLevel.IsSome && level.isGreaterOrEqualTo(consoleMinLevel.Value) then
             // just replace %j (Util.format->JSON specifier --> console->OBJECT %O specifier)
             // the other % specifiers are basically the same
-            let browserLogTemplate = "[" + source.ToString() + "] " + template.Replace("%j", "%O")
+            let browserLogTemplate = String.Format("[{0,5}] {1}", source.ToString().PadRight(5), template.Replace("%j", "%O"))
             match args.Length with
             | 0 -> Fable.Import.Browser.console.log (browserLogTemplate)
             | 1 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0])
@@ -33,7 +33,7 @@ module Logging =
 
         if level.isGreaterOrEqualTo(chanMinLevel) then
             match out with
-            | Some chan -> 
+            | Some chan ->
                 let formattedMessage = util.format(template, args).Replace("\n", " ")
                 let formattedLogLine = String.Format("[{0:HH:mm:ss} {1}] {2}", DateTime.Now, string level, formattedMessage)
                 chan.appendLine (formattedLogLine)

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -9,14 +9,14 @@ module Logging =
     type Level = DBG|INF|WRN|ERR
         with
             static member GetLevelNum level = match level with DBG->10|INF->20|WRN->30|ERR->40
-            override this.ToString() = match this with ERR->"ERROR"|INF->"INFO " |WRN->"WARN "|DBG->"DEBUG"
+            override this.ToString() = match this with ERR->"ERROR"|INF->"INFO"|WRN->"WARN"|DBG->"DEBUG"
             member this.isGreaterOrEqualTo level = Level.GetLevelNum(this) >= Level.GetLevelNum(level)
             member this.isLessOrEqualTo level = Level.GetLevelNum(this) <= Level.GetLevelNum(level)
 
     let private writeDevToolsConsole (level: Level) (source: string option) (template: string) (args: obj[]) =
         // just replace %j (Util.format->JSON specifier --> console->OBJECT %O specifier)
         // the other % specifiers are basically the same
-        let browserLogTemplate = String.Format("[{0,5}] {1}", source.ToString().PadRight(5), template.Replace("%j", "%O"))
+        let browserLogTemplate = String.Format("[{0}] {1}", source.ToString(), template.Replace("%j", "%O"))
         match args.Length with
         | 0 -> Fable.Import.Browser.console.log (browserLogTemplate)
         | 1 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0])
@@ -27,7 +27,7 @@ module Logging =
 
     let private writeOutputChannel (out: OutputChannel) level source template args =
         let formattedMessage = util.format(template, args)
-        let formattedLogLine = String.Format("[{0:HH:mm:ss} {1}] {2}", DateTime.Now, string level, formattedMessage)
+        let formattedLogLine = String.Format("[{0:HH:mm:ss} {1,-5}] {2}", DateTime.Now, string level, formattedMessage)
         out.appendLine (formattedLogLine)
 
     let private writeBothIfConfigured (out: OutputChannel option)

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -6,10 +6,10 @@ module Logging =
     open Fable.Import.vscode
     open System
 
-    type Level = DBG|INF|WRN|ERR
+    type Level = DEBUG|INFO|WARN|ERROR
         with
-            static member GetLevelNum = function DBG->10|INF->20|WRN->30|ERR->40
-            override this.ToString() = match this with ERR->"ERROR"|INF->"INFO"|WRN->"WARN"|DBG->"DEBUG"
+            static member GetLevelNum = function DEBUG->10|INFO->20|WARN->30|ERROR->40
+            override this.ToString() = match this with ERROR->"ERROR"|INFO->"INFO"|WARN->"WARN"|DEBUG->"DEBUG"
             member this.isGreaterOrEqualTo level = Level.GetLevelNum(this) >= Level.GetLevelNum(level)
             member this.isLessOrEqualTo level = Level.GetLevelNum(this) <= Level.GetLevelNum(level)
 
@@ -55,35 +55,35 @@ module Logging =
                         (infoTemplateAndArgs: string * obj[]) =
             // OutputChannel: when at DBG level, use the DBG template and args, otherwise INF
             if out.IsSome then
-                if chanMinLevel.isLessOrEqualTo(Level.DBG) then
-                    writeOutputChannel out.Value DBG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
-                elif chanMinLevel.isLessOrEqualTo(Level.INF) then
-                    writeOutputChannel out.Value INF source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
+                if chanMinLevel.isLessOrEqualTo(Level.DEBUG) then
+                    writeOutputChannel out.Value DEBUG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
+                elif chanMinLevel.isLessOrEqualTo(Level.INFO) then
+                    writeOutputChannel out.Value INFO source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
 
             // Console: when at DBG level, use the DBG template and args, otherwise INF
             if consoleMinLevel.IsSome then
-                if Level.DBG.isGreaterOrEqualTo(consoleMinLevel.Value) then
-                    writeDevToolsConsole DBG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
-                elif Level.INF.isGreaterOrEqualTo(consoleMinLevel.Value) then
-                    writeDevToolsConsole INF source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
+                if Level.DEBUG.isGreaterOrEqualTo(consoleMinLevel.Value) then
+                    writeDevToolsConsole DEBUG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
+                elif Level.INFO.isGreaterOrEqualTo(consoleMinLevel.Value) then
+                    writeDevToolsConsole INFO source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
 
         /// Logs a message that should/could be seen by developers when diagnosing problems.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Debug (template, [<ParamArray>]args:obj[]) =
-            writeBothIfConfigured out chanMinLevel consoleMinLevel DBG source template args
+            writeBothIfConfigured out chanMinLevel consoleMinLevel DEBUG source template args
         /// Logs a message that should/could be seen by the user in the output channel.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Info (template, [<ParamArray>]args:obj[]) =
-            writeBothIfConfigured out chanMinLevel consoleMinLevel INF source template args
+            writeBothIfConfigured out chanMinLevel consoleMinLevel INFO source template args
         /// Logs a message that should/could be seen by the user in the output channel when a problem happens.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Error (template, [<ParamArray>]args:obj[]) =
-            writeBothIfConfigured out chanMinLevel consoleMinLevel ERR source template args
+            writeBothIfConfigured out chanMinLevel consoleMinLevel ERROR source template args
         /// Logs a message that should/could be seen by the user in the output channel when a problem happens.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Warn (template, [<ParamArray>]args:obj[]) =
-            writeBothIfConfigured out chanMinLevel consoleMinLevel WRN source template args
+            writeBothIfConfigured out chanMinLevel consoleMinLevel WARN source template args


### PR DESCRIPTION
There are a few things going on here, but it's all about making the output more pretty.

I changed the level messages from (e.g. `INF` to `INFO` so that [vscode-log-output-colorizer](https://github.com/IBM-Bluemix/vscode-log-output-colorizer) can highlight them.

A `requestId` was introduced, which simply assigns a number to the request so that multiple log messages be correlated with each other.

A bug was fixed with FSAC stderr output, where instead of printing the text, it printed a `Buffer`. Now we don't try to `reject` the language service promise after we already called `resolve` earlier.

I introduced a setting to control console output verbosity:
```json
 "FSharp.logLanguageServiceRequestsOutputWindowLevel": {
            "type": "string",
            "default": "INFO",
            "enum": [
                "DEBUG", "INFO", "WARN", "ERROR"
            ]
        },
```

At `INF` level:
![screen shot 2016-08-22 at 16 18 46](https://cloud.githubusercontent.com/assets/570470/17845473/70eeb772-6885-11e6-845c-0f82dccb063c.png)

At `DBG` level:
![screen shot 2016-08-22 at 16 27 13](https://cloud.githubusercontent.com/assets/570470/17845463/59c5f1c8-6885-11e6-920d-b2f586f9053c.png)
