### PR TITLE
Add CopyFSAC for Default target

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -229,6 +229,7 @@ Target "Test" DoNothing
 
 "Clean"
 ==> "RunScript"
+==> "CopyFSAC"
 ==> "Default"
 
 "CopyFSACToTests"


### PR DESCRIPTION
Hi,

On the clean ionide clone if run F5 in vscode - it fails with the "Failed to start language services. Please check if Microsoft Build Tools 2013 are installed". This is because FSAC is not copied to the release folder on default target in build.fsx. 
This PR fixes this. 
