### PR TITLE
Fsi extra params

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -215,6 +215,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enables integration with FSharpLinter (additional warnigns)"
+        },
+        "FSharp.fsiExtraParameters": {
+          "type": "array",
+          "default": [],
+          "description": "Allows to pass extra parameters to FSI process"
         }
       }
     }

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -46,14 +46,19 @@ module Fsi =
             let terminal = window.createTerminal("F# Interactive")
             fsiOutput <- Some terminal
             let fsi, clear =
+                let fsiParams = 
+                    workspace.getConfiguration().get("FSharp.fsiExtraParameters", Array.empty<string>) |> List.ofArray
+                            
                 if Environment.isWin then
+                    let winParams = [ "--fsi-server-input-codepage:65001" ] @ fsiParams |> String.concat " "
+ 
                     if isPowershell () then
-                        sprintf "cmd /c \"%s\" --fsi-server-input-codepage:65001" Environment.fsi, "clear"
+                        sprintf "cmd /c \"%s\" %s" Environment.fsi winParams, "clear"
                     else
-                        sprintf "\"%s\" --fsi-server-input-codepage:65001" Environment.fsi, "cls"
+                        sprintf "\"%s\" %s" Environment.fsi winParams, "cls"
                 else
-                    Environment.fsi, "clear"
-
+                    let nonWinParams = fsiParams |> String.concat " "
+                    sprintf "%s %s" Environment.fsi nonWinParams, "clear"
 
             terminal.sendText(clear, true)
             terminal.sendText(fsi, true)


### PR DESCRIPTION
Hi,

While I was working on some scripts I referenced FSharp.Core directly, but FSI doesn't start if you do so, it wants you to have "--noframework" parameter passed during the start in this situation. 
So this PR adds ability to provide extra parameters to FSI startup from separate setting. 

I hope it will be useful not only to me.