### PR TITLE
Correct spelling of warnings

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -214,7 +214,7 @@
         "FSharp.linter": {
           "type": "boolean",
           "default": true,
-          "description": "Enables integration with FSharpLinter (additional warnigns)"
+          "description": "Enables integration with FSharpLinter (additional warnings)"
         },
         "FSharp.fsiExtraParameters": {
           "type": "array",


### PR DESCRIPTION
Figured this would be irritating to get an issue for when it was so easy to fix. This just corrects the spelling of warnings in the config description for FSharp.Linter.