### PR TITLE
Pass parameters to the FSI terminal creation routine

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -33,6 +33,6 @@ GITHUB
     modules/Octokit/Octokit.fsx (a7c04ed4fe1c6b8d840b964447e24c7159f97d36)
       Octokit (>= 0.20)
   remote: Ionide/ionide-vscode-helpers
-    Fable.Import.Axios.fs (97d5a1895341cf43fa6a1a8ce32cf186614582df)
-    Fable.Import.VSCode.fs (97d5a1895341cf43fa6a1a8ce32cf186614582df)
-    Helpers.fs (97d5a1895341cf43fa6a1a8ce32cf186614582df)
+    Fable.Import.Axios.fs (4d9e58acd9c8756f6dffafcc7a20abf99e328c08)
+    Fable.Import.VSCode.fs (4d9e58acd9c8756f6dffafcc7a20abf99e328c08)
+    Helpers.fs (4d9e58acd9c8756f6dffafcc7a20abf99e328c08)

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -48,11 +48,12 @@ module Fsi =
                     workspace.getConfiguration().get("FSharp.fsiExtraParameters", Array.empty<string>) |> List.ofArray
 
                 if Environment.isWin then
-                    [ "--fsi-server-input-codepage:65001" ] @ fsiParams |> String.concat " "
+                    [ "--fsi-server-input-codepage:65001" ] @ fsiParams
                 else
-                    fsiParams |> String.concat " "
+                    fsiParams
+                |> Array.ofList
 
-            let terminal = window.createTerminal("F# Interactive", Environment.fsi)
+            let terminal = window.createTerminal("F# Interactive", Environment.fsi, parms)
             fsiOutput <- Some terminal
             sendCd ()
             terminal.show(true)


### PR DESCRIPTION
Hi,

In latest version there is a regression - not passing extra parameters to FSI terminal process.
This PR fixes it, but only once https://github.com/ionide/ionide-vscode-helpers/pull/5 is accepted, since signature of the createTerminal is wrong in current release.

PS: The build might be broken here, I didn't want to reference different version of Fable.Import.VSCode.fs from my forked repo, but I checked it locally - all works fine.