### PR TITLE
Remove <para></para> in Markdown.replaceXml

### DIFF
--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -99,7 +99,7 @@ module Markdown =
         [ r"<c>(((?!<c>)(?!<\/c>).)*)<\/c>", sprintf "`%s`" ]
 
     let private removePatterns =
-        [ "<summary>"; "</summary>" ]
+        [ "<summary>"; "</summary>"; "<para>"; "</para>" ]
 
     /// Replaces XML tags with Markdown equivalents.
     let replaceXml (str: string) : string =


### PR DESCRIPTION
Hi,
This is tiny PR to remove `<para>` from comments, so this

![image](https://cloud.githubusercontent.com/assets/3036330/19578700/320b2b82-971d-11e6-8cd0-87bbdd560874.png)

looks like this

![image](https://cloud.githubusercontent.com/assets/3036330/19578751/69318ec6-971d-11e6-9245-cdd4051c2cf8.png)
