### PR TITLE
perform an npm update to make sure we've got the latest fable 

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -272,17 +272,18 @@
     "vscode.fsharp"
   ],
   "scripts": {
+    "prebuild":"npm update",
     "build": "fable ../src/Ionide.FSharp.fsproj -s -o ../release -m commonjs --verbose"
   },
   "dependencies": {
     "axios": "*",
-    "fable-core": "*",
+    "fable-core": "0.6.x",
     "toml": "*",
     "ws": "*",
     "xhr2": "*"
   },
   "devDependencies": {
-    "fable-compiler": "*",
+    "fable-compiler": "0.6.x",
     "mocha": "*",
     "vscode": "*"
   }

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -202,7 +202,7 @@ module LanguageService =
                 ) |> unbox) |> ignore
             ())
 
-    let startSocker () =
+    let startSocket () =
         let address = sprintf "ws://localhost:%s/notify" port
         try
             let sck = WebSocket address
@@ -253,7 +253,7 @@ module LanguageService =
             |> ignore
         )
         |> Promise.onSuccess (fun _ ->
-            startSocker ()
+            startSocket ()
         )
         |> Promise.onFail (fun _ ->
             if Process.isMono () then


### PR DESCRIPTION
This PR makes use of npm's script conventions to make sure that we've got the right dependencies in place before build. This should make newcomers' experience more smooth, as well as help to get people who haven't updated in a while running!

To make this work I locked down Fable's dependencies to the 0.6 version line, which we will now need to explicitly update from now on.

In addition, later we may want to move to yarn to get the benefits of a lockfile and a reproducible build.