### PR TITLE
add initial msbuild tasks and configuration

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -192,6 +192,22 @@
       {
         "command": "MSBuild.buildSelected",
         "title": "MSBuild: Build project"
+      },
+      {
+        "command": "MSBuild.rebuildCurrent",
+        "title": "MSBuild: Rebuild current project"
+      },
+      {
+        "command": "MSBuild.rebuildSelected",
+        "title": "MSBuild: Rebuild project"
+      },
+      {
+        "command": "MSBuild.cleanCurrent",
+        "title": "MSBuild: Clean current project"
+      },
+      {
+        "command": "MSBuild.cleanSelected",
+        "title": "MSBuild: Clean project"
       }
     ],
     "outputChannels": [

--- a/release/package.json
+++ b/release/package.json
@@ -184,13 +184,22 @@
       {
         "command": "Expecto.stopWatchMode",
         "title": "Expecto: Stop Watch Mode"
+      },
+      {
+        "command": "MSBuild.buildCurrent",
+        "title": "MSBuild: Build current project"
+      },
+      {
+        "command": "MSBuild.buildSelected",
+        "title": "MSBuild: Build project"
       }
     ],
     "outputChannels": [
       "F# Language Service",
       "F# Interactive",
       "Forge",
-      "Expecto"
+      "Expecto",
+      "MSBuild"
     ],
     "keybindings": [
       {
@@ -336,6 +345,11 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically shows Expecto output panle"
+        },
+        "FSharp.msbuildLocation": {
+          "type":"string",
+          "default":"",
+          "description": "Use a specific version of msbuild to build this project."
         }
       }
     },

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -1,0 +1,63 @@
+namespace Ionide.VSCode.FSharp
+
+open System
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Import
+open Fable.Import.vscode
+open Fable.Import.Node
+
+open DTO
+open Ionide.VSCode.Helpers
+
+module MSBuild = 
+    let private outputChannel = window.createOutputChannel "msbuild"
+    let private logger = ConsoleAndOutputChannelLogger(Some "msbuild", Level.DEBUG, Some outputChannel, Some Level.DEBUG)
+
+    let msbuildLocation = 
+        match Environment.msbuild with
+        | Some location -> location
+        | None -> Configuration.get "msbuild.exe" "FSharp.msbuildLocation"
+
+    let invokeMSBuild project =
+        let safeproject = sprintf "\"%s\"" project
+        logger.Debug("invoking msbuild from %s on %s", msbuildLocation, safeproject)
+        Process.spawnWithNotification msbuildLocation "mono" safeproject outputChannel |> ignore
+
+    /// discovers the project that the active document belongs to and builds that
+    let buildCurrentProject () = 
+        logger.Debug("discovering project")
+        match window.activeTextEditor.document with
+        | Document.FSharp | Document.CSharp | Document.VB ->
+            let currentProject = Project.getLoaded () |> Seq.where (fun p -> p.Files |> List.exists (String.endWith window.activeTextEditor.document.fileName)) |> Seq.tryHead
+            match currentProject with
+            | Some p -> 
+                logger.Debug("found project %s", p.Project)
+                invokeMSBuild p.Project
+            | None -> 
+                logger.Debug("could not find a project that contained the file %s", window.activeTextEditor.document.fileName)
+                ()
+        | Document.Other -> logger.Debug("I don't know how to handle a project of type %s", window.activeTextEditor.document.languageId)
+        
+    /// prompts the user to choose a project and builds that project
+    let buildProject () =
+        promise {
+            logger.Debug "building current project"
+            let projects = Project.getAll () |> ResizeArray
+            if projects.Count <> 0 then
+                let opts = createEmpty<QuickPickOptions>
+                opts.placeHolder <- Some "Project to build"
+                let! chosen = window.showQuickPick(projects |> Case1, opts)
+                logger.Debug("user chose project %s", chosen)
+                if JS.isDefined chosen 
+                then 
+                    invokeMSBuild chosen
+        }
+        
+    let activate disposables = 
+        let registerCommand com (action : unit -> _) = vscode.commands.registerCommand(com, unbox<Func<obj, obj>> action) |> ignore
+        logger.Debug("MSBuild found at %s", msbuildLocation)
+        registerCommand "MSBuild.buildCurrent" buildCurrentProject
+        registerCommand "MSBuild.buildSelected" buildProject
+        logger.Debug("MSBuild activated")
+        ()

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -56,8 +56,11 @@ module Option =
 
 [<RequireQualifiedAccess>]
 module Document =
-    let (|FSharp|Other|) (document : TextDocument) =
-        if document.languageId = "fsharp" then FSharp else Other
+    let (|FSharp|CSharp|VB|Other|) (document : TextDocument) =
+        if document.languageId = "fsharp" then FSharp 
+        else if document.languageId = "csharp" then CSharp
+        else if document.languageId = "vb" then VB 
+        else Other
 
 [<RequireQualifiedAccess>]
 module Configuration =

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -88,6 +88,7 @@
     <Compile Include="Components/QuickFix.fs" />
     <Compile Include="Components/ResolveNamespaces.fs" />
     <Compile Include="Components/Expecto.fs" />
+    <Compile Include="Components/MSBuild.fs" />
     <Compile Include="Components/Help.fs" />
     <Compile Include="fsharp.fs" />
   </ItemGroup>

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -38,6 +38,7 @@ let activate(disposables: Disposable[]) =
         ResolveNamespaces.activate df' disposables
         Help.activate disposables
         Expecto.activate disposables
+        MSBuild.activate disposables
     )
     |> Promise.catch (fun error -> promise { () }) // prevent unhandled rejected promises
     |> ignore


### PR DESCRIPTION
Very basic initial implementation of #142. This doesn't do anything complex like specifying targets or configurations, but it does work on my local projects just fine.