### PR TITLE
enable coreclr debugger for f# files

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -379,6 +379,11 @@
         "fileMatch": "fableconfig.json",
         "url": "./schemas/fableconfig.json"
       }
+    ],
+    "breakpoints": [
+      {
+        "language": "fsharp"
+      }
     ]
   },
   "activationEvents": [


### PR DESCRIPTION
enable coreclr debugger for f# files

the debugger itself is packaged with omnisharp

ref #366 