### PR TITLE
on non-windows systems, probe for msbuild/xbuild wrappers

### DIFF
--- a/src/Components/Expecto.fs
+++ b/src/Components/Expecto.fs
@@ -218,8 +218,7 @@ module Expecto =
         |> List.map(fun proj ->
             let path = proj.Project
             promise {
-                let! envmsbuild = Environment.msbuild
-                let msbuild = defaultArg envmsbuild "xbuild"
+                let! msbuild = Environment.msbuild
                 logger.Debug ("%s %s", msbuild, path)
                 return! Process.spawnWithNotification msbuild "" path outputChannel
                 |> Process.toPromise

--- a/src/Components/Expecto.fs
+++ b/src/Components/Expecto.fs
@@ -217,11 +217,14 @@ module Expecto =
         getExpectoProjects ()
         |> List.map(fun proj ->
             let path = proj.Project
-            let msbuild = defaultArg Environment.msbuild "xbuild"
-            logger.Debug ("%s %s", msbuild, path)
-
-            Process.spawnWithNotification msbuild "" path outputChannel
-            |> Process.toPromise)
+            promise {
+                let! envmsbuild = Environment.msbuild
+                let msbuild = defaultArg envmsbuild "xbuild"
+                logger.Debug ("%s %s", msbuild, path)
+                return! Process.spawnWithNotification msbuild "" path outputChannel
+                |> Process.toPromise
+            }
+        )
         |> Promise.all
         |> Promise.bind (fun codes ->
             if codes |> Seq.exists ((<>) "0") then

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -10,36 +10,43 @@ open Fable.Import.Node
 open DTO
 open Ionide.VSCode.Helpers
 
-module MSBuild = 
+module MSBuild =
     let private outputChannel = window.createOutputChannel "msbuild"
     let private logger = ConsoleAndOutputChannelLogger(Some "msbuild", Level.DEBUG, Some outputChannel, Some Level.DEBUG)
 
-    let msbuildLocation = 
-        match Environment.msbuild with
-        | Some location -> location
-        | None -> Configuration.get "msbuild.exe" "FSharp.msbuildLocation"
+    let msbuildLocation =
+        let defaultLocation = "msbuild.exe"
+        let configured = Configuration.get defaultLocation "FSharp.msbuildLocation"
+        if configured <> defaultLocation && configured <> ""
+        then configured |> Promise.lift
+        else
+            Environment.msbuild |> Promise.map (fun envOption -> defaultArg envOption defaultLocation)
 
     let invokeMSBuild project target =
         let safeproject = sprintf "\"%s\"" project
-        logger.Debug("invoking msbuild from %s on %s for target %s", msbuildLocation, safeproject, target)
         let command = sprintf "%s /t:%s" safeproject target
-        Process.spawnWithNotification msbuildLocation "mono" command outputChannel |> ignore
+        promise {
+            let! msbuildPath = msbuildLocation
+            logger.Debug("invoking msbuild from %s on %s for target %s", msbuildPath, safeproject, target)
+            Process.spawnWithNotification msbuildPath "" command outputChannel |> ignore
+        } |> ignore
+
 
     /// discovers the project that the active document belongs to and builds that
-    let buildCurrentProject target = 
+    let buildCurrentProject target =
         logger.Debug("discovering project")
         match window.activeTextEditor.document with
         | Document.FSharp | Document.CSharp | Document.VB ->
             let currentProject = Project.getLoaded () |> Seq.where (fun p -> p.Files |> List.exists (String.endWith window.activeTextEditor.document.fileName)) |> Seq.tryHead
             match currentProject with
-            | Some p -> 
+            | Some p ->
                 logger.Debug("found project %s", p.Project)
                 invokeMSBuild p.Project target
-            | None -> 
+            | None ->
                 logger.Debug("could not find a project that contained the file %s", window.activeTextEditor.document.fileName)
                 ()
         | Document.Other -> logger.Debug("I don't know how to handle a project of type %s", window.activeTextEditor.document.languageId)
-        
+
     /// prompts the user to choose a project and builds that project
     let buildProject target =
         promise {
@@ -50,19 +57,22 @@ module MSBuild =
                 opts.placeHolder <- Some "Project to build"
                 let! chosen = window.showQuickPick(projects |> Case1, opts)
                 logger.Debug("user chose project %s", chosen)
-                if JS.isDefined chosen 
-                then 
+                if JS.isDefined chosen
+                then
                     invokeMSBuild chosen target
         }
-        
-    let activate disposables = 
+
+    let activate disposables =
         let registerCommand com (action : unit -> _) = vscode.commands.registerCommand(com, unbox<Func<obj, obj>> action) |> ignore
-        logger.Debug("MSBuild found at %s", msbuildLocation)
+        msbuildLocation
+        |> Promise.map (fun p ->
+            logger.Debug("MSBuild found at %s", p)
+            logger.Debug("MSBuild activated")
+        )
+        |> ignore
         registerCommand "MSBuild.buildCurrent" (fun _ -> buildCurrentProject "Build")
         registerCommand "MSBuild.buildSelected" (fun _ -> buildProject "Build")
         registerCommand "MSBuild.rebuildCurrent" (fun _ -> buildCurrentProject "Rebuild")
         registerCommand "MSBuild.rebuildSelected" (fun _ -> buildProject "Rebuild")
         registerCommand "MSBuild.cleanCurrent" (fun _ -> buildCurrentProject "Clean")
         registerCommand "MSBuild.cleanSelected" (fun _ -> buildProject "Clean")
-        logger.Debug("MSBuild activated")
-        ()    


### PR DESCRIPTION
The msbuild functionality wasn't working at all on non-windows systems for two reasons:

1. in `Environment.fs` we were defaulting to `xbuild`, which is fine except we have to use the shell to resolve that binary out to a full path before we can use it, and
1. the mechanism that we would normally use to get around this, the `FSharp.msbuildLocation` config setting, was only being consulted if the `Environment.msbuild` value was `None`, which was never the case on non-windows systems.

This PR does two things:

1. Addresses point 1 by probing the for msbuild/xbuild so that we have sane defaults, and 
1. Addresses point 2 by changing the order of msbuild resolution so that we always consult the user configuration before we do any probing at all.  This should help head off any potential errors and give users a way out in case of the world exploding.

This also helps ensure that various tools that want to use msbuild (eg the Expecto integration) are resolving the same way all the time, instead of what they were doing before setting disparate default values.