### PR TITLE
[WIP] handle known errors of FSAC during project parsing

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -208,6 +208,10 @@
       {
         "command": "MSBuild.cleanSelected",
         "title": "MSBuild: Clean project"
+      },
+      {
+        "command": "MSBuild.switchMSbuildHostType",
+        "title": "MSBuild: Switch host type"
       }
     ],
     "views": {

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -181,8 +181,14 @@ module DTO =
     }
 
 
+    type ResponseError<'T> = { 
+        Code: int
+        Message: string
+        Data: 'T
+    }
 
     type Result<'T> = {Kind : string; Data : 'T}
+    type ResponseErrorResult<'T> = Result<ResponseError<'T>>
     type CompilerLocationResult = Result<CompilerLocation>
     type HelptextResult = Result<Helptext>
     type CompletionResult = Result<Completion[]>

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -187,6 +187,10 @@ module DTO =
         Data: 'T
     }
 
+    type ProjectNotRestoredData = {
+        ProjectFullPath : string;
+    }
+
     type Result<'T> = {Kind : string; Data : 'T}
     type ResponseErrorResult<'T> = Result<ResponseError<'T>>
     type CompilerLocationResult = Result<CompilerLocation>
@@ -202,3 +206,9 @@ module DTO =
     type ProjectResult = Result<Project>
     type ResolveNamespaceResult = Result<ResolveNamespace>
     type UnionCaseGeneratorResult = Result<UnionCaseGenerator>
+
+
+    type DetailedErrors =
+        | ProjectNotRestored of ProjectNotRestoredData
+        | ErrorUnknown
+

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -209,8 +209,10 @@ module LanguageService =
                 vscode.window.showErrorMessage(msg, [|"Restore"|])
                 |> Promise.map (function "Restore" -> true | _ -> false)
                 |> Promise.bind (fun shouldRestore ->
+                    log.Debug("user choose to %srestore", (if shouldRestore then "" else "not "))
                     if shouldRestore then
-                        vscode.commands.executeCommand("MSBuild.restore", projectFullPath)
+                        //restore it with .net core msbuild as default for now
+                        vscode.commands.executeCommand("MSBuild.restore", projectFullPath, 2)
                         |> Promise.bind (fun exitCode ->
                             match exitCode with
                             | "0" -> retry ()

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -92,23 +92,15 @@ module Project =
             List.forall2 (=) p1.References p2.References
 
         LanguageService.project path
-        |> Promise.onSuccess (fun (result: Result<obj>) ->
-            match result.Data with
-            | :? ResponseError<obj> as prR when result.Kind = "error" ->
-                printfn "err ResponseError %A" prR
-                // if isNotNull pr then
-                //     match loadedProjects.TryFind (pr.Data.Project.ToUpperInvariant ()) with
-                //     | Some existing when not (projEquals existing pr.Data)  ->
-                //         projectChanged.fire pr.Data
-                //     | None -> projectChanged.fire pr.Data
-                //     | _ -> ()
-                //     loadedProjects <- (pr.Data.Project.ToUpperInvariant (), pr.Data) |> loadedProjects.Add
-            | :? ResponseErrorResult<string> as err ->
-                printfn "err case %A" err
-            | e ->
-                printfn "err catchall n %A" e
-                    )
-
+        |> Promise.onSuccess (fun (pr:ProjectResult) ->
+            if isNotNull pr then
+                match loadedProjects.TryFind (pr.Data.Project.ToUpperInvariant ()) with
+                | Some existing when not (projEquals existing pr.Data)  ->
+                    projectChanged.fire pr.Data
+                | None -> projectChanged.fire pr.Data
+                | _ -> ()
+                loadedProjects <- (pr.Data.Project.ToUpperInvariant (), pr.Data) |> loadedProjects.Add
+                )
 
     let tryFindLoadedProject (path:string) =
          loadedProjects.TryFind (path.ToUpperInvariant ())

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -92,15 +92,23 @@ module Project =
             List.forall2 (=) p1.References p2.References
 
         LanguageService.project path
-        |> Promise.onSuccess (fun (pr:ProjectResult) ->
-            if isNotNull pr then
-                match loadedProjects.TryFind (pr.Data.Project.ToUpperInvariant ()) with
-                | Some existing when not (projEquals existing pr.Data)  ->
-                    projectChanged.fire pr.Data
-                | None -> projectChanged.fire pr.Data
-                | _ -> ()
-                loadedProjects <- (pr.Data.Project.ToUpperInvariant (), pr.Data) |> loadedProjects.Add
-                )
+        |> Promise.onSuccess (fun (result: Result<obj>) ->
+            match result.Data with
+            | :? ResponseError<obj> as prR when result.Kind = "error" ->
+                printfn "err ResponseError %A" prR
+                // if isNotNull pr then
+                //     match loadedProjects.TryFind (pr.Data.Project.ToUpperInvariant ()) with
+                //     | Some existing when not (projEquals existing pr.Data)  ->
+                //         projectChanged.fire pr.Data
+                //     | None -> projectChanged.fire pr.Data
+                //     | _ -> ()
+                //     loadedProjects <- (pr.Data.Project.ToUpperInvariant (), pr.Data) |> loadedProjects.Add
+            | :? ResponseErrorResult<string> as err ->
+                printfn "err case %A" err
+            | e ->
+                printfn "err catchall n %A" e
+                    )
+
 
     let tryFindLoadedProject (path:string) =
          loadedProjects.TryFind (path.ToUpperInvariant ())


### PR DESCRIPTION
now fsac return a specific result for known errors

TODO:


- [x] button to `Restore current project`
  - [x] add a `dotnetcli.restore` command
    - [x] call `dotnet restore /path/to/the.fsproj` (path is returned by FSAC).
- [x] after doing `restore` manually works
  - [x] ~need to invalidate current files error and reask FSAC (otherwise squigges remains until you reopen the file). how?~ wait until project parsing is completed after restore
- [x] button to `Restore ...` asking for what proj/sln use. picker? => done, reused all `MSBuild:` commands
- [ ] autorestore setting (false by default) that will restore without asking user
- [ ] remove progress bar, already exists