### PR TITLE
Support .net core msbuild

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -208,6 +208,10 @@
       {
         "command": "MSBuild.cleanSelected",
         "title": "MSBuild: Clean project"
+      },
+      {
+        "command": "MSBuild.switchMSbuildHostType",
+        "title": "MSBuild: Switch host type"
       }
     ],
     "views": {

--- a/release/package.json
+++ b/release/package.json
@@ -210,6 +210,10 @@
         "title": "MSBuild: Clean project"
       },
       {
+        "command": "MSBuild.restoreSelected",
+        "title": "MSBuild: Restore project"
+      },
+      {
         "command": "MSBuild.switchMSbuildHostType",
         "title": "MSBuild: Switch host type"
       }

--- a/release/package.json
+++ b/release/package.json
@@ -402,6 +402,16 @@
           "default":true,
           "description": "Automatically shows Expecto output panel"
         },
+        "FSharp.msbuildHost": {
+          "type": "string",
+          "default": ".net",
+          "description": "MSBuild host",
+          "enum": [
+            ".net",
+            ".net core",
+            "ask at first use"
+          ]
+        },
         "FSharp.resolveNamespaces": {
           "type":"boolean",
           "default": false,

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -74,7 +74,7 @@ module MSBuild =
             logger.Debug "No MSBuild host selected yet"
             let cfg = vscode.workspace.getConfiguration()
             let p =
-                match cfg.get ("FSharp.msbuildHost", "auto") with
+                match cfg.get ("FSharp.msbuildHost", ".net") with
                 | ".net" -> Some MSbuildHost.MSBuildExe |> Promise.lift
                 | ".net core" -> Some MSbuildHost.DotnetCli |> Promise.lift
                 | "ask at first use" -> pickMSbuildHostType ()

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -184,7 +184,6 @@ module MSBuild =
     let activate disposables =
         let registerCommand com (action : unit -> _) = vscode.commands.registerCommand(com, unbox<Func<obj, obj>> action) |> ignore
         let registerCommand2 com (action : obj -> obj -> _) = vscode.commands.registerCommand(com, Func<obj, obj, obj>(fun a b -> action a b |> unbox)) |> ignore
-        let onDidChangeConfiguration (action : unit -> _) = vscode.workspace.onDidChangeConfiguration.Invoke(unbox<Func<_, obj>>(fun _ -> action ())) |> ignore
 
         /// typed msbuild cmd. Optional project and msbuild host
         let typedMsbuildCmd f projOpt hostOpt =

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -14,20 +14,99 @@ module MSBuild =
     let private outputChannel = window.createOutputChannel "msbuild"
     let private logger = ConsoleAndOutputChannelLogger(Some "msbuild", Level.DEBUG, Some outputChannel, Some Level.DEBUG)
 
-    let invokeMSBuild project target =
+    type MSbuildHost = 
+        | MSBuildExe // .net on win, mono on non win
+        | DotnetCli
+
+    let mutable private msbuildHostType : MSbuildHost option = None
+
+    let pickMSbuildHostType () =
+        promise {
+            let hosts =
+                [ ".NET", MSbuildHost.MSBuildExe
+                  ".NET Core", MSbuildHost.DotnetCli ]
+                |> Map.ofList
+
+            let hostsLabels = hosts |> Map.toList |> List.map fst |> ResizeArray
+            let opts = createEmpty<QuickPickOptions>
+            opts.placeHolder <- Some "The msbuild host to use"
+            let! chosen = window.showQuickPick(hostsLabels |> Case1, opts)
+            return
+                if JS.isDefined chosen
+                then
+                    logger.Debug("user choose host %s", chosen)
+                    hosts |> Map.tryFind chosen
+                else
+                    logger.Debug("user cancelled host pick")
+                    None
+        }
+
+    let switchMSbuildHostType () = 
+        logger.Debug "switching msbuild host (msbuild <-> dotnet cli)"
+        let next =
+            match msbuildHostType with
+            | Some MSbuildHost.MSBuildExe ->
+                Some MSbuildHost.DotnetCli |> Promise.lift
+            | Some MSbuildHost.DotnetCli ->
+                Some MSbuildHost.MSBuildExe |> Promise.lift
+            | None ->
+                logger.Debug("not yet choosen, try pick one")
+                pickMSbuildHostType ()
+        next
+        |> Promise.map (fun h ->
+            msbuildHostType <- h
+            match msbuildHostType with
+            | Some MSbuildHost.MSBuildExe ->
+                logger.Debug("using msbuild")
+            | Some MSbuildHost.DotnetCli ->
+                logger.Debug("using cli")
+            | None ->
+                logger.Debug("not choosen yet")
+            )
+
+    let getMSbuildHostType () =
+        match msbuildHostType with
+        | Some h -> Some h |> Promise.lift
+        | None ->
+            //TODO add from configuration
+            logger.Debug "No MSBuild host selected yet"
+            pickMSbuildHostType ()
+
+    let invokeMSBuildPromise project hostPreference target =
         let autoshow =
             let cfg = vscode.workspace.getConfiguration()
             cfg.get ("FSharp.msbuildAutoshow", true)
 
         let safeproject = sprintf "\"%s\"" project
         let command = sprintf "%s /t:%s" safeproject target
-        promise {
-            let! msbuildPath = Environment.msbuild
-            logger.Debug("invoking msbuild from %s on %s for target %s", msbuildPath, safeproject, target)
-            Process.spawnWithNotification msbuildPath "" command outputChannel |> ignore
-            if autoshow then outputChannel.show()
-        } |> ignore
+        let executeWithHost host =
+            promise {
+                let! msbuildPath =
+                    match host with
+                    | MSbuildHost.MSBuildExe -> Environment.msbuild
+                    | MSbuildHost.DotnetCli -> Environment.dotnet
+                let cmd =
+                    match host with
+                    | MSbuildHost.MSBuildExe -> command
+                    | MSbuildHost.DotnetCli -> sprintf "msbuild %s" command
+                logger.Debug("invoking msbuild from %s on %s for target %s", msbuildPath, safeproject, target)
+                let _ =
+                    if autoshow then outputChannel.show()
+                return! Process.spawnWithNotification msbuildPath "" cmd outputChannel
+                        |> Process.toPromise
+            }
 
+        let theMSbuildHostType =
+            match hostPreference with
+            | Some h -> Promise.lift (Some h)
+            | None -> getMSbuildHostType ()
+        
+        theMSbuildHostType
+        |> Promise.bind (function None -> Promise.empty | Some h -> executeWithHost h)
+
+    let invokeMSBuild project target =
+        invokeMSBuildPromise project None target
+        |> ignore
 
     /// discovers the project that the active document belongs to and builds that
     let buildCurrentProject target =
@@ -67,9 +146,28 @@ module MSBuild =
             logger.Debug("MSBuild activated")
         )
         |> ignore
+        Environment.dotnet
+        |> Promise.map (fun p ->
+            logger.Debug("Dotnet cli (.NET Core) found at %s", p)
+            logger.Debug("Dotnet cli (.NET Core) activated")
+        )
+        |> ignore
         registerCommand "MSBuild.buildCurrent" (fun _ -> buildCurrentProject "Build")
         registerCommand "MSBuild.buildSelected" (fun _ -> buildProject "Build")
         registerCommand "MSBuild.rebuildCurrent" (fun _ -> buildCurrentProject "Rebuild")
         registerCommand "MSBuild.rebuildSelected" (fun _ -> buildProject "Rebuild")
         registerCommand "MSBuild.cleanCurrent" (fun _ -> buildCurrentProject "Clean")
         registerCommand "MSBuild.cleanSelected" (fun _ -> buildProject "Clean")
+        registerCommand "MSBuild.switchMSbuildHostType" (fun _ -> switchMSbuildHostType ())
+
+        let registerCommand2 com (action : obj -> obj -> _) = vscode.commands.registerCommand(com, Func<obj, obj, obj>(fun a b -> action a b |> unbox)) |> ignore
+        registerCommand2 "MSBuild.restore" (fun a b ->
+            logger.Debug("a %s", a)
+            logger.Debug("b %j", b)
+            let host = //TODO define a shared type to use, or make MSbuildHost more high level
+                let h = if JS.isDefined b then unbox<int>(b) else 0
+                match h with
+                | 1 -> Some MSbuildHost.MSBuildExe
+                | 2 -> Some MSbuildHost.DotnetCli
+                | 0 | _ -> None
+            invokeMSBuildPromise (unbox<string>(a)) host "Restore")

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -146,3 +146,8 @@ module Promise =
         | [x] -> f x
         | x::tail ->
             tail |> List.fold (fun acc next -> acc |> Ionide.VSCode.Helpers.Promise.bind (fun _ -> f next)) (f x)
+
+module Event =
+
+    let invoke (listener: 'T -> _) (event: Fable.Import.vscode.Event<'T>) =
+        event.Invoke(unbox<System.Func<_, _>>(fun a -> listener a))


### PR DESCRIPTION
Currently just the .net msbuild (`msbuild.exe` on win, and `msbuild/xbuild` on
non win) is supported

This add .NET Core msbuild (dotnet msbuild), used by .net core cli (the
`dotnet build` = `dotnet msbuild /t:Build`)

The `MSBuild: ...` commands remains the same, but is possibile to switch between
`.net <-> .net core` msbuild to use with the new `MSBuild: switch msbuild host`
command

Others:

- add `Restore` target
- msbuild commands now return a `Promise` instead of `unit` so is possibile to
  execute and continue, like:

  ```fsharp
  vscode.commands.executeCommand("MSBuild.restore", projectFullPath, 2)
  |> Promise.bind (fun exitCode -> ... )
  ```


fix #423 

TODO:

- [x] default host: atm default host is `None`
     - [x] add configuration `[ ".net"; ".net core"; "ask at first usage" ]`
     - [x] use a sane default (probably `.net msbuild` now for backward compatibility)
- [x] check all msbuild commands return a promise
- [x] create a type of argument to pass optionally to command to specify host/target, so can be run programmatically (not by user choice)

Enable additional work:

- switch default on `autodetect`, and use host based on the fsproj sdk. This require to know what type is the fsproj, so need new info returned from FSAC

