### PR TITLE
Enhance `F# language service` panel logging

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -5,10 +5,10 @@ NUGET
     Octokit (0.24)
 GIT
   remote: https://github.com/fsharp/FsAutoComplete.git
-     (9b91ed87d298cd32551b5cbfa79fef0f1169f026)
+     (c016144fb81d5be96e9c08fc8967ae9737288843)
       build: build.cmd LocalRelease
       os: windows
-     (9b91ed87d298cd32551b5cbfa79fef0f1169f026)
+     (c016144fb81d5be96e9c08fc8967ae9737288843)
       build: build.sh LocalRelease
       os: mono
   remote: https://github.com/fsharp-editing/Forge.git

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -181,6 +181,24 @@ module DTO =
     }
 
 
+    type ResponseError<'T> = {
+        Code: int
+        Message: string
+        AdditionalData: 'T
+    }
+
+    [<RequireQualifiedAccess>]
+    type ErrorCodes =
+       | GenericError = 1
+       | ProjectNotRestored = 100
+
+    module ErrorDataTypes =
+        type ProjectNotRestoredData = { Project: ProjectFilePath }
+
+    [<RequireQualifiedAccess>]
+    type ErrorData =
+       | GenericError
+       | ProjectNotRestored of ErrorDataTypes.ProjectNotRestoredData
 
     type Result<'T> = {Kind : string; Data : 'T}
     type CompilerLocationResult = Result<CompilerLocation>

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -58,11 +58,13 @@ module LanguageService =
             | Level.DEBUG, Some _ -> Some (window.createOutputChannel (channelName + " (server)"))
             | _, _ -> None
 
-        let level = logLanguageServiceRequestsOutputWindowLevel ()
+        let editorSideLogger = ConsoleAndOutputChannelLogger(Some source, (logLanguageServiceRequestsOutputWindowLevel ()), channel, Some consoleMinLevel)
 
-        let editorSideLogger = ConsoleAndOutputChannelLogger(Some source, level, channel, Some consoleMinLevel)
-        if level <> Level.DEBUG then
-            editorSideLogger.Info ("Logging to output at level %s. If you want detailed messages, try level DEBUG.", (level.ToString()))
+        let showCurrentLevel level =
+            if level <> Level.DEBUG then
+                editorSideLogger.Info ("Logging to output at level %s. If you want detailed messages, try level DEBUG.", (level.ToString()))
+        
+        editorSideLogger.ChanMinLevel |> showCurrentLevel
 
         let fsacStdOutWriter text =
             match serverStdoutChannel with

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -66,6 +66,12 @@ module LanguageService =
         
         editorSideLogger.ChanMinLevel |> showCurrentLevel
 
+        vscode.workspace.onDidChangeConfiguration
+        |> Event.invoke (fun () ->
+            editorSideLogger.ChanMinLevel <- logLanguageServiceRequestsOutputWindowLevel ()
+            editorSideLogger.ChanMinLevel |> showCurrentLevel )
+        |> ignore
+
         let fsacStdOutWriter text =
             match serverStdoutChannel with
             | None -> ()

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -100,19 +100,15 @@ module LanguageService =
             else None, None
 
         match extraPropInfo with
-        | None, None -> log.Info (makeOutgoingLogPrefix(requestId) + " {%s}\nData=%j", fsacAction, obj)
-        | Some extraTmpl, Some extraArg -> log.Info (makeOutgoingLogPrefix(requestId) + " {%s}" + extraTmpl + "\nData=%j", fsacAction, extraArg, obj)
+        | None, None -> log.Debug (makeOutgoingLogPrefix(requestId) + " {%s}\nData=%j", fsacAction, obj)
+        | Some extraTmpl, Some extraArg -> log.Debug (makeOutgoingLogPrefix(requestId) + " {%s}" + extraTmpl + "\nData=%j", fsacAction, extraArg, obj)
         | _, _ -> failwithf "cannot happen %A" extraPropInfo
 
     let private logIncomingResponse requestId fsacAction (started: DateTime) (r: Axios.AxiosXHR<_>) (res: _ option) (ex: exn option) =
         let elapsed = DateTime.Now - started
         match res, ex with
         | Some res, None ->
-            let debugLog : string*obj[] = makeIncomingLogPrefix(requestId) + " {%s} in %s ms: Kind={\"%s\"}\nData=%j",
-                                          [| fsacAction; elapsed.TotalMilliseconds; res?Kind; res?Data |]
-            let infoLog : string*obj[] = makeIncomingLogPrefix(requestId) + " {%s} in %s ms: Kind={\"%s\"} ",
-                                          [| fsacAction; elapsed.TotalMilliseconds; res?Kind |]
-            log.DebugOrInfo debugLog infoLog
+            log.Debug(makeIncomingLogPrefix(requestId) + " {%s} in %s ms: Kind={\"%s\"}\nData=%j", fsacAction, elapsed.TotalMilliseconds, res?Kind, res?Data)
         | None, Some ex ->
             log.Error (makeIncomingLogPrefix(requestId) + " {%s} ERROR in %s ms: {%j}, Data=%j", fsacAction, elapsed.TotalMilliseconds, ex.ToString(), obj)
         | _, _ -> log.Error(makeIncomingLogPrefix(requestId) + " {%s} ERROR in %s ms: %j, %j, %j", fsacAction, elapsed.TotalMilliseconds, res, ex.ToString(), obj)

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -45,7 +45,8 @@ module Logging =
 
     /// The templates may use node util.format placeholders: %s, %d, %j, %%
     /// https://nodejs.org/api/util.html#util_util_format_format
-    type ConsoleAndOutputChannelLogger(source: string option, chanMinLevel: Level, out:OutputChannel option, consoleMinLevel: Level option) =
+    type ConsoleAndOutputChannelLogger(source: string option, chanDefaultMinLevel: Level, out:OutputChannel option, consoleMinLevel: Level option) =
+        member val ChanMinLevel = chanDefaultMinLevel with get, set
 
         /// Logs a different message in either DEBUG (if enabled) or INFO (otherwise).
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
@@ -55,9 +56,9 @@ module Logging =
                         (infoTemplateAndArgs: string * obj[]) =
             // OutputChannel: when at DEBUG level, use the DEBUG template and args, otherwise INFO
             if out.IsSome then
-                if chanMinLevel.isLessOrEqualTo(Level.DEBUG) then
+                if this.ChanMinLevel.isLessOrEqualTo(Level.DEBUG) then
                     writeOutputChannel out.Value DEBUG source (fst debugTemplateAndArgs) (snd debugTemplateAndArgs)
-                elif chanMinLevel.isLessOrEqualTo(Level.INFO) then
+                elif this.ChanMinLevel.isLessOrEqualTo(Level.INFO) then
                     writeOutputChannel out.Value INFO source (fst infoTemplateAndArgs) (snd infoTemplateAndArgs)
 
             // Console: when at DEBUG level, use the DEBUG template and args, otherwise INFO
@@ -71,19 +72,19 @@ module Logging =
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Debug (template, [<ParamArray>]args:obj[]) =
-            writeBothIfConfigured out chanMinLevel consoleMinLevel DEBUG source template args
+            writeBothIfConfigured out this.ChanMinLevel consoleMinLevel DEBUG source template args
         /// Logs a message that should/could be seen by the user in the output channel.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Info (template, [<ParamArray>]args:obj[]) =
-            writeBothIfConfigured out chanMinLevel consoleMinLevel INFO source template args
+            writeBothIfConfigured out this.ChanMinLevel consoleMinLevel INFO source template args
         /// Logs a message that should/could be seen by the user in the output channel when a problem happens.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Error (template, [<ParamArray>]args:obj[]) =
-            writeBothIfConfigured out chanMinLevel consoleMinLevel ERROR source template args
+            writeBothIfConfigured out this.ChanMinLevel consoleMinLevel ERROR source template args
         /// Logs a message that should/could be seen by the user in the output channel when a problem happens.
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Warn (template, [<ParamArray>]args:obj[]) =
-            writeBothIfConfigured out chanMinLevel consoleMinLevel WARN source template args
+            writeBothIfConfigured out this.ChanMinLevel consoleMinLevel WARN source template args


### PR DESCRIPTION
Enhance `F# language service` panel logging

**bump FSAC, to use new detailed error messages**

Previous behaviour:

- FSAC log was really verbose, useful errors buried in debug of request/response chatting
- by default, no info to user, who need to enable that verbose logging (and usually doesnt know how and worse that the option exists), for see errors (like failed loading of projects)

New behaviour:

- FSAC request/response log is now DEBUG
- default  (`INFO` like before) show useful info (not yet) and error
- new FSAC etailed errors are pretty printed
- hot update the current log level when configuration change, without need to restart code

Some examples:

### project not restored

![image](https://user-images.githubusercontent.com/147243/28216546-5e3946c8-68b2-11e7-9099-e8cf3cde3279.png)

### some error running msbuild

![image](https://user-images.githubusercontent.com/147243/28216577-79c52ed4-68b2-11e7-907b-4ca9df440d55.png)

### hot reload config

![enh_log](https://user-images.githubusercontent.com/147243/28216854-591dd3a6-68b3-11e7-9801-c822075d5165.gif)
