### PR TITLE
Improve build.cmd Error message

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -50,7 +50,11 @@ let run cmd args dir =
 
 
 let platformTool tool path =
-    isUnix |> function | true -> tool | _ -> path |> ProcessHelper.tryFindFileOnPath |> fun n -> n.Value
+    match isUnix with
+    | true -> tool 
+    | _ ->  match ProcessHelper.tryFindFileOnPath path with
+            | None -> failwithf "can't find tool %s on PATH" tool 
+            | Some v -> v
 
 let npmTool =
     platformTool "npm"  "npm.cmd"


### PR DESCRIPTION
`build.cmd` failed with a cryptic error.

I looked in the code and found that the missing `vsce` was the reason.

This improves the error message.

I hope the indenting is OK (Is ther a `f#-format` )

Thanks for the great work.

old message
```
FsiEvaluationException:

Error: System.NullReferenceException: Object reference not set to an instance of an object.
           at FSI_0005.Build.platformTool(String tool, String path) in C:\open\ionide-vscode-fsharp\build.fsx:line 53
           at <StartupCode$FSI_0005>.$FSI_0005_Build$fsx.main@() in C:\open\ionide-vscode-fsharp\build.fsx:line 58
        Stopped due to error
```
new failure
```
FsiEvaluationException:

Error: System.Exception: can't find tool vsce on PATH
           at Microsoft.FSharp.Core.Operators.FailWith[T](String message)
           at <StartupCode$FSI_0005>.$FSI_0005_Build$fsx.main@() in c:\open\ionide-vscode-fsharp\build.fsx:line 64
        Stopped due to error
```


