### PR TITLE
Don't specify full path to vscode.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -63,7 +63,7 @@ let vsceTool =
     platformTool "vsce" "vsce.cmd"
 
 let codeTool =
-    platformTool "code" (ProgramFilesX86  </> "Microsoft VS Code" </> "bin/code.cmd")
+    platformTool "code" "code.cmd"
 
 
 let releaseBin      = "release/bin"


### PR DESCRIPTION
The latest (as of July 20th) VSCode Windows installer installs to "Program Files", not to "Program Files (x86)", so the `platformTool "code"` call fails now. At the same time, the modern installer does put `code.cmd` on path.