### PR TITLE
solution support, using fsac workspaces

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,10 +1,10 @@
 framework: net45
 source https://nuget.org/api/v2
 
-git https://github.com/fsharp/FsAutoComplete.git fsac14 build:"build.cmd LocalRelease", OS: windows
+git https://github.com/fsharp/FsAutoComplete.git master build:"build.cmd LocalRelease", OS: windows
 git https://github.com/fsharp-editing/Forge.git 1f87695d813ee521b50c671ed430184b01a25b81 build:"build.cmd Build", OS: windows
 
-git https://github.com/fsharp/FsAutoComplete.git fsac14 build:"build.sh LocalRelease", OS: mono
+git https://github.com/fsharp/FsAutoComplete.git master build:"build.sh LocalRelease", OS: mono
 git https://github.com/fsharp-editing/Forge.git 1f87695d813ee521b50c671ed430184b01a25b81 build:"build.sh Build", OS: mono
 
 git https://github.com/ionide/ionide-fsgrammar.git

--- a/paket.lock
+++ b/paket.lock
@@ -5,10 +5,10 @@ NUGET
     Octokit (0.25)
 GIT
   remote: https://github.com/fsharp/FsAutoComplete.git
-     (8ee553315fad3813a7081418267c7475e5f7857f)
+     (1adfdd6c60041ae4d98214af6de27281df976b83)
       build: build.cmd LocalRelease
       os: windows
-     (8ee553315fad3813a7081418267c7475e5f7857f)
+     (1adfdd6c60041ae4d98214af6de27281df976b83)
       build: build.sh LocalRelease
       os: mono
   remote: https://github.com/fsharp-editing/Forge.git

--- a/release/package.json
+++ b/release/package.json
@@ -161,6 +161,10 @@
         "title": "F#: Clear Cache"
       },
       {
+        "command": "fsharp.changeWorkspace",
+        "title": "F#: Change Workspace or Solution"
+      },
+      {
         "command": "Expecto.run",
         "title": "Expecto: Run"
       },
@@ -231,6 +235,14 @@
       {
         "command": "fsharp.explorer.removeFile",
         "title": "Remove file"
+      },
+      {
+        "command": "fsharp.explorer.showProjectLoadFailedInfo",
+        "title": "Show info about failed project loading"
+      },
+      {
+        "command": "fsharp.explorer.showProjectStatus",
+        "title": "Show project status"
       },
       {
         "command": "fsharp.explorer.renameFile",
@@ -466,6 +478,14 @@
           "group": "2_modification@1"
         },
         {
+          "command": "fsharp.explorer.showProjectLoadFailedInfo",
+          "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectLoadFailed"
+        },
+        {
+          "command": "fsharp.explorer.showProjectStatus",
+          "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectLoading"
+        },
+        {
           "command": "fsharp.explorer.addProjecRef",
           "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectRefList"
         },
@@ -477,6 +497,11 @@
           "command": "fsharp.explorer.openProjectFile",
           "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
           "group": "2_modification@1"
+        },
+        {
+          "command": "fsharp.explorer.showProjectStatus",
+          "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+          "group": "2_modification@2"
         },
         {
           "command": "fsharp.explorer.msbuild.build",
@@ -497,6 +522,11 @@
           "command": "fsharp.explorer.openProjectFile",
           "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
           "group": "3_modification@1"
+        },
+        {
+          "command": "fsharp.explorer.showProjectStatus",
+          "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+          "group": "3_modification@2"
         },
         {
           "command": "fsharp.explorer.msbuild.build",
@@ -597,6 +627,21 @@
       "type": "object",
       "title": "FSharp configuration",
       "properties": {
+        "FSharp.workspaceMode": {
+          "type": "string",
+          "default": "sln",
+          "description": "Choose the workspace mode",
+          "enum": [
+            "sln",
+            "directory",
+            "ionideSearch"
+          ]
+        },
+        "FSharp.workspaceModePeekDeepLevel": {
+          "type": "integer",
+          "default": 2,
+          "description": "The deep level of directory hierarchy when searching for sln/projects"
+        },
         "FSharp.logLanguageServiceRequests": {
           "type": "string",
           "default": "output",
@@ -797,6 +842,7 @@
     "workspaceContains:**/*.fs",
     "workspaceContains:**/*.fsx",
     "workspaceContains:**/*.fsproj",
+    "workspaceContains:**/*.sln",
     "onLanguage:fsharp",
     "onCommand:fsi.Start",
     "onCommand:fsharp.NewProject",

--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -62,12 +62,14 @@ module Errors =
         match file with
         | Document.FSharp ->
             let path = file.fileName
-            let prom = Project.find path
-            match prom with
-            | Some p -> p
-                        |> Project.load
-                        |> Promise.bind (fun _ -> parse file)
-            | None -> parse file
+            match Project.find path with
+            | Choice1Of3 _ -> parse file
+            | Choice2Of3 () -> Promise.lift (null |> unbox)
+            | Choice3Of3 (Some p) ->
+                p
+                |> Project.load
+                |> Promise.bind (fun _ -> parse file)
+            | Choice3Of3 None -> parse file
         | _ -> Promise.lift (null |> unbox)
 
     let mutable private timer = None

--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -112,12 +112,7 @@ module Errors =
     //         if window.activeTextEditor.document.fileName <> file then
     //             currentDiagnostic.set(Uri.file file, errors |> Seq.map fst |> ResizeArray))
 
-    let activate (context: ExtensionContext) =
-        workspace.onDidChangeTextDocument $ (handler,(), context.subscriptions) |> ignore
-        workspace.onDidSaveTextDocument $ (handlerSave , (), context.subscriptions) |> ignore
-        window.onDidChangeActiveTextEditor $ (handlerOpen, (), context.subscriptions) |> ignore
-        //LanguageService.registerNotify handleNotification
-
+    let parseVisibleTextEditors () =
         match window.visibleTextEditors |> Seq.toList with
         | [] -> Promise.lift (null |> unbox)
         | [x] -> parseFile x.document
@@ -128,4 +123,10 @@ module Errors =
                (parseFile x.document )
             |> Promise.onSuccess (fun _ -> handlerSave x.document |> ignore)
 
+    let activate (context: ExtensionContext) =
+        workspace.onDidChangeTextDocument $ (handler,(), context.subscriptions) |> ignore
+        workspace.onDidSaveTextDocument $ (handlerSave , (), context.subscriptions) |> ignore
+        window.onDidChangeActiveTextEditor $ (handlerOpen, (), context.subscriptions) |> ignore
+        //LanguageService.registerNotify handleNotification
+        Promise.lift parseVisibleTextEditors
 

--- a/src/Components/Expecto.fs
+++ b/src/Components/Expecto.fs
@@ -401,7 +401,7 @@ module Expecto =
         statusBar.tooltip <- "Expecto continuous testing"
         statusBar.command <- "Expecto.watchMode"
 
-        Project.projectChanged.event.Invoke (fun proj ->
+        Project.workspaceChanged.event.Invoke (fun proj ->
             if getExpectoProjects() |> List.isEmpty then
                 statusBar.hide()
             else

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -8,6 +8,7 @@ module DTO =
     type HelptextRequest = {Symbol : string}
     type PositionRequest = {FileName : string; Line : int; Column : int; Filter : string}
     type CompletionRequest = {FileName : string; SourceLine : string; Line : int; Column : int; Filter : string; IncludeKeywords : bool}
+    type WorkspacePeekRequest = {Directory: string; Deep: int; ExcludedDirs: string[] }
 
     type OverloadSignature = {
         Signature: string
@@ -147,12 +148,33 @@ module DTO =
     type SourceFilePath = string
     type ProjectReferencePath = string
 
+    [<RequireQualifiedAccess>]
+    type ProjectResponseInfo =
+      | DotnetSdk of ProjectResponseInfoDotnetSdk
+      | Verbose
+      | ProjectJson
+    and ProjectResponseInfoDotnetSdk = {
+      IsTestProject: bool
+      Configuration: string
+      IsPackable: bool
+      TargetFramework: string
+      TargetFrameworkIdentifier: string
+      TargetFrameworkVersion: string
+      RestoreSuccess: bool
+      TargetFrameworks: string list
+      RunCmd: RunCmd option
+      IsPublishable: bool option }
+    and [<RequireQualifiedAccess>] RunCmd = { Command: string; Arguments: string }
+
     type Project = {
         Project: ProjectFilePath
         Files: SourceFilePath list
         Output: string
         References: ProjectReferencePath list
         Logs: Map<string, string>
+        OutputType: string
+        Info: ProjectResponseInfo
+        AdditionalInfo: Map<string, string>
     }
 
     type OpenNamespace = {
@@ -190,6 +212,41 @@ module DTO =
         Parameters : Parameter list list
     }
 
+    type WorkspacePeek = {
+        Found : WorkspacePeekFound []
+    }
+    and WorkspacePeekFound =
+      | Directory of WorkspacePeekFoundDirectory
+      | Solution of WorkspacePeekFoundSolution
+    and WorkspacePeekFoundDirectory = {
+        Directory: string
+        Fsprojs: string []
+    }
+    and WorkspacePeekFoundSolution = {
+        Path: string
+        Items: WorkspacePeekFoundSolutionItem []
+        Configurations: WorkspacePeekFoundSolutionConfiguration []
+    }
+    and [<RequireQualifiedAccess>] WorkspacePeekFoundSolutionItem = {
+        Guid: string
+        Name: string
+        Kind: WorkspacePeekFoundSolutionItemKind
+    }
+    and WorkspacePeekFoundSolutionItemKind =
+        | MsbuildFormat of WorkspacePeekFoundSolutionItemKindMsbuildFormat
+        | Folder of WorkspacePeekFoundSolutionItemKindFolder
+    and [<RequireQualifiedAccess>] WorkspacePeekFoundSolutionItemKindMsbuildFormat = {
+        Configurations: WorkspacePeekFoundSolutionConfiguration []
+    }
+    and [<RequireQualifiedAccess>] WorkspacePeekFoundSolutionItemKindFolder = {
+        Items: WorkspacePeekFoundSolutionItem []
+        Files: string []
+    }
+    and [<RequireQualifiedAccess>] WorkspacePeekFoundSolutionConfiguration = {
+        Id: string
+        ConfigurationName: string
+        PlatformName: string
+    }
 
     type ResponseError<'T> = {
         Code: int
@@ -225,4 +282,5 @@ module DTO =
     type ResolveNamespaceResult = Result<ResolveNamespace>
     type UnionCaseGeneratorResult = Result<UnionCaseGenerator>
     type SignatureDataResult = Result<SignatureData>
+    type WorkspacePeekResult = Result<WorkspacePeek>
 

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -11,14 +11,35 @@ open Ionide.VSCode.Helpers
 open DTO
 open Ionide.VSCode.Helpers
 
-[<ReflectedDefinition>]
 module Project =
-    let private emptyProjectsMap = Map<ProjectFilePath,Project> []
+
+    [<RequireQualifiedAccess>]
+    type ProjectLoadingState =
+        | Loading of path: string
+        | Loaded of proj: Project
+        | Failed of path: string * error: string
+
+    [<RequireQualifiedAccess>]
+    type FSharpWorkspaceMode =
+        | Directory // prefer the directory
+        | Sln // prefer sln, if any, otherwise directory
+        | IonideSearch // old behaviour, like directory but search is ionide's side
+
+    let private emptyProjectsMap : Map<ProjectFilePath,ProjectLoadingState> = Map.empty
     let mutable private loadedProjects = emptyProjectsMap
+    let mutable private loadedWorkspace : WorkspacePeekFound option = None
     let setAnyProjectContext = Context.cachedSetter<bool> "fsharp.project.any"
-    let projectChanged = EventEmitter<Project>()
+    let workspaceChanged = EventEmitter<WorkspacePeekFound>()
 
     let excluded = "FSharp.excludeProjectDirectories" |> Configuration.get [| ".git"; "paket-files" |]
+    let deepLevel = "FSharp.workspaceModePeekDeepLevel" |> Configuration.get 2 |> max 0
+
+    let getInWorkspace () =
+        loadedProjects |> Map.toList |> List.map snd
+    let tryFindInWorkspace (path:string) =
+        loadedProjects |> Map.tryFind (path.ToUpperInvariant ())
+    let updateInWorkspace (path: string) state =
+        loadedProjects <- loadedProjects |> Map.add (path.ToUpperInvariant ()) state
 
     let find p =
         let rec findFsProj dir =
@@ -41,7 +62,7 @@ module Project =
 
         p |> path.dirname |> findFsProj
 
-    let findAll () =
+    let private findAll () =
         let rec findProjs dir =
             let files = fs.readdirSync dir
             files
@@ -88,39 +109,46 @@ module Project =
         setAnyProjectContext false
 
     let load (path:string) =
-        let projEquals (p1 : Project) (p2 : Project) =
-            p1.Project.ToUpperInvariant() = p2.Project.ToUpperInvariant() &&
-            List.forall2 (=) p1.Files p2.Files &&
-            List.forall2 (=) p1.References p2.References
+        updateInWorkspace path (ProjectLoadingState.Loading path)
+
+        let loaded (pr:ProjectResult) =
+            if isNotNull pr then
+                Some (pr.Data.Project, (ProjectLoadingState.Loaded pr.Data))
+            else
+                None
+        let failed (b: obj) =
+            let (msg: string), (err: ErrorData) = unbox b
+            Some (path, (ProjectLoadingState.Failed (path, msg)))
 
         LanguageService.project path
-        |> Promise.onSuccess (fun (pr:ProjectResult) ->
-            if isNotNull pr then
-                match loadedProjects.TryFind (pr.Data.Project.ToUpperInvariant ()) with
-                | Some existing when not (projEquals existing pr.Data)  ->
-                    projectChanged.fire pr.Data
-                | None -> projectChanged.fire pr.Data
-                | _ -> ()
-                loadedProjects <- (pr.Data.Project.ToUpperInvariant (), pr.Data) |> loadedProjects.Add
+        |> Promise.either (loaded >> Promise.lift) (failed >> Promise.lift)
+        |> Promise.map (fun proj ->
+            match proj with
+            | Some (path, state) ->
+                updateInWorkspace path state
+                loadedWorkspace |> Option.iter (workspaceChanged.fire)
                 setAnyProjectContext true
-                )
+            | None ->
+                () )
 
-    let tryFindLoadedProject (path:string) =
-         loadedProjects.TryFind (path.ToUpperInvariant ())
+    let private chooseLoaded = function ProjectLoadingState.Loaded p -> Some p | _ -> None
+
+    let getLoaded = getInWorkspace >> List.choose chooseLoaded
+    let tryFindLoadedProject = tryFindInWorkspace >> Option.bind chooseLoaded
 
     let tryFindLoadedProjectByFile (filePath:string) =
-        loadedProjects
-        |> Seq.choose (fun kvp ->
+        getLoaded ()
+        |> List.tryPick (fun v ->
             let len =
-                kvp.Value.Files
+                v.Files
                 |> List.filter (fun f -> (f.ToUpperInvariant ()) = (filePath.ToUpperInvariant ()))
                 |> List.length
-            if len > 0 then Some kvp.Value else None )
-        |> Seq.tryHead
+            if len > 0 then Some v else None )
 
-    let getLoaded () = loadedProjects |> Seq.map (fun kv -> kv.Value)
+    let getLoadedSolution () = loadedWorkspace
 
     let getCaches () =
+
         let rec findProjs dir =
             let files = fs.readdirSync dir
             files
@@ -150,12 +178,42 @@ module Project =
                 printf "Cache outdated %s" p
                 fs.unlinkSync p
         )
-
     let clearCache () =
         let cached = getCaches ()
         cached |> Seq.iter fs.unlinkSync
         window.showInformationMessage("Cache cleared")
 
+    let rec foldFsproj (item: WorkspacePeekFoundSolutionItem) =
+        match item.Kind with
+        | WorkspacePeekFoundSolutionItemKind.Folder folder ->
+            folder.Items |> Array.collect foldFsproj
+        | WorkspacePeekFoundSolutionItemKind.MsbuildFormat msbuild ->
+            [| item.Name, msbuild |]
+
+    let countProjectsInSln (sln: WorkspacePeekFoundSolution) =
+        sln.Items |> Array.map foldFsproj|> Array.sumBy Array.length
+
+    let pickFSACWorkspace (ws: WorkspacePeekFound list) =
+        let text (x: WorkspacePeekFound) =
+            match x with
+            | WorkspacePeekFound.Directory dir ->
+                sprintf "[DIR] %s     (%i projects)" dir.Directory dir.Fsprojs.Length
+            | WorkspacePeekFound.Solution sln ->
+                let relativeSln = path.relative (workspace.rootPath, sln.Path)
+                sprintf "[SLN] %s     (%i projects)" relativeSln (countProjectsInSln sln)
+        match ws |> List.map (fun x -> (text x), x) with
+        | [] ->
+            None |> Promise.lift
+        | projects ->
+            promise {
+                let opts = createEmpty<QuickPickOptions>
+                opts.placeHolder <- Some "Place"
+                let chooseFrom = projects |> List.map fst |> ResizeArray
+                let! chosen = window.showQuickPick(chooseFrom |> Case1, opts)
+                return if JS.isDefined chosen
+                       then projects |> Map.ofList |> Map.tryFind chosen 
+                       else None
+            }
 
     let isANetCoreAppProject (project:Project) =
         let projectContent = (fs.readFileSync project.Project).ToString()
@@ -249,12 +307,109 @@ module Project =
         | out, _ when out |> String.endWith ".exe" -> Some (fun args -> execWithShell out args)
         | _ -> None
 
+    let private getWorkspaceForModeIonideSearch () =
+        promise {
+            let fsprojs = findAll ()
+            let wdir =
+                { WorkspacePeekFoundDirectory.Directory = vscode.workspace.rootPath
+                  Fsprojs = fsprojs |> Array.ofList }
+            return WorkspacePeekFound.Directory wdir
+        }
 
-    let activate =
-        let w = workspace.createFileSystemWatcher("**/*.fsproj")
-        commands.registerCommand("fsharp.clearCache", clearCache |> unbox<Func<obj,obj>> ) |> ignore
+    let private workspacePeek () = promise {
+        let! ws = LanguageService.workspacePeek (vscode.workspace.rootPath) deepLevel (excluded |> List.ofArray)
+        return
+            ws.Found
+            |> Array.sortBy (fun x ->
+                match x with
+                | WorkspacePeekFound.Solution sln -> countProjectsInSln sln
+                | WorkspacePeekFound.Directory _ -> -1)
+           |> Array.rev
+           |> List.ofArray
+        }
 
+    let private getWorkspaceForMode mode =
+        match mode with
+        | FSharpWorkspaceMode.Sln ->
+            // prefer the sln, load directly the first one, otherwise ask
+            promise {
+                let! ws = workspacePeek ()
+                let slns =
+                    ws
+                    |> List.choose (fun x -> match x with WorkspacePeekFound.Solution _ -> Some x | _ -> None)
 
+                let! choosen =
+                    match slns with
+                    | [] ->
+                        ws
+                        |> List.tryPick (fun x -> match x with WorkspacePeekFound.Directory _ -> Some x | _ -> None)
+                        |> Promise.lift
+                    | [ sln ] ->
+                        Promise.lift (Some sln)
+                    | _ ->
+                        pickFSACWorkspace ws
+                return choosen
+            }
+        | FSharpWorkspaceMode.Directory ->
+            // prefer the directory, like old behaviour (none) but search is done fsac side
+            promise {
+                let! ws = workspacePeek ()
+                return
+                    ws
+                    |> List.tryPick (fun x -> match x with WorkspacePeekFound.Directory _ -> Some x | _ -> None)
+             }
+        | FSharpWorkspaceMode.IonideSearch | _ ->
+            // old behaviour, initialize all fsproj found (vscode side)
+            getWorkspaceForModeIonideSearch ()
+            |> Promise.map Some
+
+    let getWorkspaceModeFromConfig () =
+        match "FSharp.workspaceMode" |> Configuration.get "sln" with
+        | "directory" -> FSharpWorkspaceMode.Directory
+        | "sln" -> FSharpWorkspaceMode.Sln
+        | "ionideSearch" | _ -> FSharpWorkspaceMode.IonideSearch
+
+    let activate (context: ExtensionContext) =
+        commands.registerCommand("fsharp.clearCache", clearCache |> unbox<Func<obj,obj>> )
+        |> context.subscriptions.Add
+
+        let w = vscode.workspace.createFileSystemWatcher("**/*.fsproj")
         w.onDidCreate.Invoke(fun n -> load n.fsPath |> unbox) |> ignore
         w.onDidChange.Invoke(fun n -> load n.fsPath |> unbox) |> ignore
-        clearLoadedProjects >> findAll >> (Promise.executeForAll load)
+
+        let initWorkspace x =
+            clearLoadedProjects ()
+            loadedWorkspace <- Some x
+            workspaceChanged.fire x
+            let projs =
+                match x with
+                | WorkspacePeekFound.Directory dir ->
+                    dir.Fsprojs
+                | WorkspacePeekFound.Solution sln ->
+                    sln.Items
+                    |> Array.collect foldFsproj
+                    |> Array.map fst
+            match x with
+            | WorkspacePeekFound.Solution _
+            | WorkspacePeekFound.Directory _ when not(projs |> Array.isEmpty) ->
+                setAnyProjectContext true
+                ()
+            | WorkspacePeekFound.Directory _ ->
+                ()
+            projs
+            |> List.ofArray
+            |> Promise.executeForAll load
+            |> Promise.map ignore
+
+        commands.registerCommand("fsharp.changeWorkspace", (fun _ ->
+            workspacePeek ()
+            |> Promise.bind pickFSACWorkspace
+            |> Promise.bind (function Some w -> initWorkspace w | None -> Promise.empty )
+            |> box
+            ))
+        |> context.subscriptions.Add
+
+        getWorkspaceModeFromConfig ()
+        |> getWorkspaceForMode
+        |> Promise.bind (function Some x -> Promise.lift x | None -> getWorkspaceForModeIonideSearch ())
+        |> Promise.bind initWorkspace

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -407,7 +407,7 @@ module Project =
         | "sln" -> FSharpWorkspaceMode.Sln
         | "ionideSearch" | _ -> FSharpWorkspaceMode.IonideSearch
 
-    let activate (context: ExtensionContext) =
+    let activate (context: ExtensionContext) parseVisibleTextEditors =
         commands.registerCommand("fsharp.clearCache", clearCache |> unbox<Func<obj,obj>> )
         |> context.subscriptions.Add
 
@@ -437,6 +437,7 @@ module Project =
             projs
             |> List.ofArray
             |> Promise.executeForAll load
+            |> Promise.bind (fun _ -> parseVisibleTextEditors ())
             |> Promise.map ignore
 
         commands.registerCommand("fsharp.changeWorkspace", (fun _ ->

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -39,7 +39,7 @@ let activate (context: ExtensionContext) =
                 Linter.activate df' context
             )
             |> Promise.onSuccess(fun _ -> if solutionExplorer then SolutionExplorer.activate context)
-            |> Promise.bind(fun _ -> Project.activate context)
+            |> Promise.bind(fun parseVisibleTextEditors -> Project.activate context parseVisibleTextEditors)
 
 
         ))

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -39,7 +39,7 @@ let activate (context: ExtensionContext) =
                 Linter.activate df' context
             )
             |> Promise.onSuccess(fun _ -> if solutionExplorer then SolutionExplorer.activate context)
-            |> Promise.bind(fun _ -> Project.activate ())
+            |> Promise.bind(fun _ -> Project.activate context)
 
 
         ))


### PR DESCRIPTION
**REQUIRE https://github.com/fsharp/FsAutoComplete master who add workspacePeek command to FSAC**

idea is to:

- at start, ask fsac  with `workspacePeek` command what is interesting in that directory
- fsac respond with list of *parsed* sln and list of fsprojs
- based on config, is choosen: a sln or the directory or the user choose from list
- solution explorer will show the *full parsed solution graph*, or the directory fsproj. these fsproj are not yet loaded (but will as lazy loading)

Modes using config `FSharp.workspaceMode`

- `sln`  (**default**) -> prefer sln, if any. Use the sln if only one exists, ask user with list if multiple exists. load the directory if noone
- `directory` -> like before, wild west of fsprojs (no sln needed). but the search is done fsac side
- `ionideSearch`-> previous behaviour, search of fsproj vscode side 

additional configurations:

- `FSharp.workspaceModePeekDeepLevel`: The deep level of directory hierarchy when searching for sln/projects. Default 2 ( so search up to `./src/SomeprojectDir/` )

New commands:

- `F#: Change Workspace or Solution` will show the list to change sln or use the directory

Notes:

- if list is shown (like at start), and is pressed esc, the `ionideSearch` is used. same in case of error of `workspacePeek` command

- Added project loading state to `F# Project Explorer` during `project` command ( not yet loaded ->  loading -> failed -> loaded)

- Right click on failed loaded project in solution explorer -> see error info about loading (same printed to F# panel, but easier to discover)
- Right click on successfully loaded project in solution explorer -> see info

Example ask:

![sln](https://user-images.githubusercontent.com/147243/28883600-4e9cb3ba-77af-11e7-9e41-e9fce93f732f.gif)

NOT IN THIS PR:

- be strict? if a source file is not in the fsac workspace, dont do intellisense (project will be not parsed -> will not work -> squiggles)
