### PR TITLE
Log error details when the language service fail to start

### DIFF
--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -339,18 +339,19 @@ module LanguageService =
             |> Process.onError (fun e ->
                 fsacStdoutWriter (e.ToString())
                 if not isResolvedAsStarted then
-                    reject ()
+                    reject (e.ToString())
             )
             |> Process.onErrorOutput (fun n ->
                 fsacStdoutWriter (n.ToString())
                 if not isResolvedAsStarted then
-                    reject ()
+                    reject (n.ToString())
             )
             |> ignore
         )
         //startSocket ()
 
-        |> Promise.onFail (fun _ ->
+        |> Promise.onFail (fun err ->
+            log.Error("Failed to start language services. %s", err)
             if Process.isMono () then
                 "Failed to start language services. Please check if mono is in PATH"
             else


### PR DESCRIPTION
`FsAutoComplete.Suave.exe` failed to build during paket restore (conflict with a .nupkg already being in use made paket fail the build.cmd for the dependency, I didn't really investigate why the file was in use, maybe AV) and I had the "Failed to start language services" error but no good way to know why.

So I added a log to the console with the error detail.