### PR TITLE
Don't show .dll extension for references

### DIFF
--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -127,7 +127,11 @@ module SolutionExplorer =
         | FileList _ -> "Files"
         | Folder (n, _) -> n
         | File (_, name, _) -> name
-        | Reference (_, name, _) -> name
+        | Reference (_, name, _) ->
+            if name.ToLowerInvariant().EndsWith(".dll") then
+                name.Substring(0, name.Length - 4)
+            else
+                name
         | ProjectReference (_, name, _) -> name
 
 


### PR DESCRIPTION
This produce a tree that is nearer to what's in VS with the references appearing without their ".dll" extension

*Not sure you want that but I was playing a little bit with the tree.*

![2017-08-12 21_36_04- extension development host - blackfox coloredprintf tests fsproj coloredprin](https://user-images.githubusercontent.com/131878/29243714-5470b8be-7fa6-11e7-8460-176c8917f5df.png)
