### PR TITLE
Remove the files level in explorer

### DIFF
--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -17,9 +17,8 @@ module SolutionExplorer =
     type Model =
         | Workspace of Projects : Model list
         | ReferenceList of References: Model list * projectPath : string
-        | FileList of Files: Model list * projectPath : string
         | ProjectReferencesList of Projects : Model list * ProjectPath : string
-        | Project of path: string * name: string * FileList: Model  * ProjectReferencesList : Model  * ReferenceList: Model
+        | Project of path: string * name: string * Files: Model list * ProjectReferencesList : Model  * ReferenceList: Model
         | Folder of name : string * Files : Model list
         | File of path: string * name: string * projectPath : string
         | Reference of path: string * name: string * projectPath : string
@@ -91,11 +90,10 @@ module SolutionExplorer =
         //         File(p, n, proj.Project))
 
 
-        let fls =  FileList(files, proj.Project)
         let refs = proj.References |> List.map (fun p -> Reference(p, path.basename p, proj.Project)) |> fun n -> ReferenceList(n, proj.Project)
         let projs = proj.References |> List.choose (fun r -> projects |> Seq.tryFind (fun pr -> pr.Output = r)) |> List.map (fun p -> ProjectReference(p.Project, path.basename(p.Project, ".fsproj"), proj.Project)) |> fun n -> ProjectReferencesList(n, proj.Project)
         let name = path.basename(proj.Project, ".fsproj")
-        Project(proj.Project, name,fls, projs, refs)
+        Project(proj.Project, name,files, projs, refs)
 
     let private getModel() =
         let projects = Project.getLoaded ()
@@ -105,13 +103,18 @@ module SolutionExplorer =
         |> Workspace
 
 
-    let private getSubmodel node =
+    let rec private getSubmodel node =
         match node with
             | Workspace projects -> projects
-            | Project (_, _, files, projs, refs) -> [yield refs; yield projs; yield files] // SHOLD REFS BE DISPLAYED AT ALL? THOSE ARE RESOLVED BY MSBUILD REFS
+            | Project (_, _, files, projs, refs) ->
+                [
+                     // SHOULD REFS BE DISPLAYED AT ALL? THOSE ARE RESOLVED BY MSBUILD REFS
+                    yield refs
+                    yield projs
+                    yield! files
+                ]
             | ReferenceList (refs, _) -> refs
             | ProjectReferencesList (refs, _) -> refs
-            | FileList (files, _) -> files
             | Folder (name,files) -> files
             | File _ -> []
             | Reference _ -> []
@@ -124,7 +127,6 @@ module SolutionExplorer =
         | Project (_, name,_, _,_) -> name
         | ReferenceList _ -> "References"
         | ProjectReferencesList (refs, _) -> "Project References"
-        | FileList _ -> "Files"
         | Folder (n, _) -> n
         | File (_, name, _) -> name
         | Reference (_, name, _) -> name
@@ -151,7 +153,7 @@ module SolutionExplorer =
                 let collaps =
                     match node with
                     | File _ | Reference _ | ProjectReference _ -> None
-                    | Workspace _ | FileList _ | Project _ -> Some 2
+                    | Workspace _ | Project _ -> Some 2
                     | _ ->  Some 1
                 ti.collapsibleState <- collaps
                 let command =
@@ -167,7 +169,6 @@ module SolutionExplorer =
                 let context =
                     match node with
                     | File _  -> Some "ionide.projectExplorer.file"
-                    | FileList _  -> Some "ionide.projectExplorer.fileList"
                     | ProjectReferencesList _  -> Some "ionide.projectExplorer.projectRefList"
                     | ReferenceList _  -> Some "ionide.projectExplorer.referencesList"
                     | Project _  -> Some "ionide.projectExplorer.project"


### PR DESCRIPTION
Potentially the most controversial of this series of small PRs (follow #489 in the target of looking more like other editors  like VS or Rider)

Change the tree to have files & folder under the project without an intermediate "File" level.

![2017-08-12 21_44_56- extension development host - blackfox coloredprintf tests fsproj coloredprin](https://user-images.githubusercontent.com/131878/29243767-82158456-7fa7-11e7-8ab6-00dfdbebc1ac.png)
