### PR TITLE
Use icons from theme in project explorer

### DIFF
--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -229,7 +229,6 @@ module SolutionExplorer =
 
     let activate () =
         let emiter = EventEmitter<Model>()
-        let fireEmiter () = emiter.fire (unbox ())
         let provider = createProvider emiter
 
         Project.projectChanged.event.Invoke(fun proj ->

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -13,7 +13,6 @@ open DTO
 open Ionide.VSCode.Helpers
 
 module SolutionExplorer =
-
     type Model =
         | Workspace of Projects : Model list
         | ReferenceList of References: Model list * projectPath : string
@@ -28,6 +27,8 @@ module SolutionExplorer =
         Key : string
         Children : Dictionary<string, NodeEntry>
     }
+
+    let mutable loadedTheme: VsCodeIconTheme.Loaded option = None
 
     let rec add' (state : NodeEntry) (entry : string) index =
         let sep = "\\"
@@ -137,7 +138,11 @@ module SolutionExplorer =
         | ProjectReference (_, name, _) -> name
 
     let private createProvider (emiter : EventEmitter<Model>) : TreeDataProvider<Model> =
-
+        let plugPath =
+            try
+                (VSCode.getPluginPath "Ionide.ionide-fsharp")
+            with
+            | _ ->  (VSCode.getPluginPath "Ionide.Ionide-fsharp")
 
         { new TreeDataProvider<Model>
           with
@@ -179,27 +184,26 @@ module SolutionExplorer =
                     | Reference _  -> Some "ionide.projectExplorer.reference"
                     | _ -> None
                 ti.contextValue <- context
-                let plugPath =
-                    try
-                        (VSCode.getPluginPath "Ionide.ionide-fsharp")
-                    with
-                    | _ ->  (VSCode.getPluginPath "Ionide.Ionide-fsharp")
 
                 let p = createEmpty<TreeIconPath>
+
+                let iconFromTheme (f: VsCodeIconTheme.Loaded -> VsCodeIconTheme.ResolvedIcon) light dark =
+                    let fromTheme = loadedTheme |> Option.map f
+                    p.light <- defaultArg (fromTheme |> Option.bind (fun x -> x.light)) (plugPath + light)
+                    p.dark <- defaultArg (fromTheme |> Option.bind (fun x -> x.dark)) (plugPath + dark)
+                    VsCodeIconTheme.logger.Info("ICON %s", p.dark)
+                    Some p
+
                 let icon =
                     match node with
-                    | File _ ->
-                        p.light <- plugPath + "/images/file-code-light.svg"
-                        p.dark <- plugPath + "/images/file-code-dark.svg"
-                        Some p
-                    | Project _ ->
-                        p.light <- plugPath + "/images/project-light.svg"
-                        p.dark <- plugPath + "/images/project-dark.svg"
-                        Some p
-                    | Folder _  ->
-                        p.light <- plugPath + "/images/folder-light.svg"
-                        p.dark <- plugPath + "/images/folder-dark.svg"
-                        Some p
+                    | File (path, _, _) ->
+                        let fileName = Node.path.basename(path)
+                        iconFromTheme (VsCodeIconTheme.getFileIcon fileName None) "/images/file-code-light.svg" "/images/file-code-dark.svg"
+                    | Project (path, _, _, _, _) ->
+                        let fileName = Node.path.basename(path)
+                        iconFromTheme (VsCodeIconTheme.getFileIcon fileName None) "/images/project-light.svg" "/images/project-dark.svg"
+                    | Folder (name, _)  ->
+                        iconFromTheme (VsCodeIconTheme.getFolderIcon name) "/images/folder-light.svg" "/images/folder-dark.svg"
                     | Reference _ | ProjectReference _ ->
                         p.light <- plugPath + "/images/circuit-board-light.svg"
                         p.dark <- plugPath + "/images/circuit-board-dark.svg"
@@ -210,8 +214,23 @@ module SolutionExplorer =
                 ti
         }
 
+    let loadCurrentTheme (reloadTree: EventEmitter<Model>) = promise {
+        let configured = VsCodeIconTheme.getConfigured() |> Option.bind VsCodeIconTheme.getInfo
+        match configured with
+        | Some configured ->
+            if loadedTheme.IsNone || loadedTheme.Value.info.id <> configured.id then
+                let! loaded = VsCodeIconTheme.load configured
+                loadedTheme <- loaded
+                reloadTree.fire (unbox ())
+        | None ->
+            if loadedTheme.IsSome then
+                loadedTheme <- None
+                reloadTree.fire (unbox ())
+    }
+
     let activate () =
         let emiter = EventEmitter<Model>()
+        let fireEmiter () = emiter.fire (unbox ())
         let provider = createProvider emiter
 
         Project.projectChanged.event.Invoke(fun proj ->
@@ -269,4 +288,8 @@ module SolutionExplorer =
         window.registerTreeDataProvider("ionide.projectExplorer", provider )
         |> ignore
 
+        workspace.onDidChangeConfiguration.Invoke(fun _ ->
+            loadCurrentTheme emiter |> ignore
+            null) |> ignore
+        loadCurrentTheme emiter |> ignore
         ()

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -191,17 +191,16 @@ module SolutionExplorer =
                     let fromTheme = loadedTheme |> Option.map f
                     p.light <- defaultArg (fromTheme |> Option.bind (fun x -> x.light)) (plugPath + light)
                     p.dark <- defaultArg (fromTheme |> Option.bind (fun x -> x.dark)) (plugPath + dark)
-                    VsCodeIconTheme.logger.Info("ICON %s", p.dark)
                     Some p
 
                 let icon =
                     match node with
                     | File (path, _, _) ->
                         let fileName = Node.path.basename(path)
-                        iconFromTheme (VsCodeIconTheme.getFileIcon fileName None) "/images/file-code-light.svg" "/images/file-code-dark.svg"
+                        iconFromTheme (VsCodeIconTheme.getFileIcon fileName None false) "/images/file-code-light.svg" "/images/file-code-dark.svg"
                     | Project (path, _, _, _, _) ->
                         let fileName = Node.path.basename(path)
-                        iconFromTheme (VsCodeIconTheme.getFileIcon fileName None) "/images/project-light.svg" "/images/project-dark.svg"
+                        iconFromTheme (VsCodeIconTheme.getFileIcon fileName None false) "/images/project-light.svg" "/images/project-dark.svg"
                     | Folder (name, _)  ->
                         iconFromTheme (VsCodeIconTheme.getFolderIcon name) "/images/folder-light.svg" "/images/folder-dark.svg"
                     | Reference _ | ProjectReference _ ->

--- a/src/Components/VsCodeIconTheme.fs
+++ b/src/Components/VsCodeIconTheme.fs
@@ -44,13 +44,13 @@ module VsCodeIconTheme =
 
         Option.ofObj themeId
 
-    let private fallback fallbackFunc opt = match opt with |Some x -> Some x |None -> fallbackFunc ()
-    let private fallbackValue fallback opt = match opt with |Some x -> Some x |None -> fallback
+    let inline private fallback fallbackFunc opt = match opt with |Some x -> Some x |None -> fallbackFunc ()
+    let inline private fallbackValue fallback opt = match opt with |Some x -> Some x |None -> fallback
 
     type JsObjectAsDictionary<'a> =
         [<Emit("$0[$1]")>]
         member __.get(key: string): 'a = jsNative
-        [<Emit("($0[$1]||null)")>]
+        [<Emit("$0.hasOwnProperty($1)?$0[$1]:null")>]
         member __.tryGet(key: string): Option<'a> = jsNative
         [<Emit("$0.hasOwnProperty($1)")>]
         member __.hasOwnProperty(key: string): bool = jsNative
@@ -90,38 +90,38 @@ module VsCodeIconTheme =
 
         result
 
-    let private findByFileName (name: string) (theme: SpecificIconTheme) =
+    let inline private findByFileName (name: string) (theme: SpecificIconTheme) =
         if JS.isDefined theme.fileNames then theme.fileNames.tryGet name else None
 
-    let private findByFolderName (name: string) (theme: SpecificIconTheme) =
+    let inline private findByFolderName (name: string) (theme: SpecificIconTheme) =
         if JS.isDefined theme.folderNames then theme.folderNames.tryGet name else None
 
-    let private findByExpandedFolderName (name: string) (theme: SpecificIconTheme) =
+    let inline private findByExpandedFolderName (name: string) (theme: SpecificIconTheme) =
         if JS.isDefined theme.folderNamesExpanded then theme.folderNamesExpanded.tryGet name else None
 
-    let private findByLanguageId (languageId: string Option) (theme: SpecificIconTheme) =
-        if JS.isDefined theme.languageIds && languageId.IsSome && theme.languageIds.hasOwnProperty(languageId.Value) then
-            Some (theme.languageIds.get (languageId.Value))
+    let inline private findByLanguageId (languageId: string Option) (theme: SpecificIconTheme) =
+        if JS.isDefined theme.languageIds && languageId.IsSome then
+            theme.languageIds.tryGet (languageId.Value)
         else
             None
 
-    let private findByExtension (name: string) (theme: SpecificIconTheme) =
+    let inline private findByExtension (name: string) (theme: SpecificIconTheme) =
         if JS.isDefined theme.fileExtensions then
             let exts = getPossibleFileExtensions name
             let matching = exts |> Seq.tryFind theme.fileExtensions.hasOwnProperty
             match matching with
-            | Some matching -> Some (theme.fileExtensions.get matching)
+            | Some matching -> theme.fileExtensions.tryGet matching
             | None -> None
         else
             None
 
-    let private fileDefault (theme: SpecificIconTheme) =
+    let inline private fileDefault (theme: SpecificIconTheme) =
         if JS.isDefined theme.file then Some theme.file else None
 
-    let private folderDefault (theme: SpecificIconTheme) =
+    let inline private folderDefault (theme: SpecificIconTheme) =
         if JS.isDefined theme.folder then Some theme.folder else None
 
-    let private folderExpandedDefault (theme: SpecificIconTheme) =
+    let inline private folderExpandedDefault (theme: SpecificIconTheme) =
         if JS.isDefined theme.folderExpanded then Some theme.folderExpanded else None
 
     let private getFileIconKey (name: string) (languageId: string Option) (useDefault: bool) (theme: SpecificIconTheme) =

--- a/src/Components/VsCodeIconTheme.fs
+++ b/src/Components/VsCodeIconTheme.fs
@@ -124,12 +124,12 @@ module VsCodeIconTheme =
     let private folderExpandedDefault (theme: SpecificIconTheme) =
         if JS.isDefined theme.folderExpanded then Some theme.folderExpanded else None
 
-    let private getFileIconKey (name: string) (languageId: string Option) (theme: SpecificIconTheme) =
+    let private getFileIconKey (name: string) (languageId: string Option) (useDefault: bool) (theme: SpecificIconTheme) =
         if JS.isDefined theme then
             findByFileName name theme
             |> fallback (fun () -> findByLanguageId languageId theme)
             |> fallback (fun () -> findByExtension name theme)
-            |> fallback (fun () -> fileDefault theme)
+            |> fallback (fun () -> if useDefault then fileDefault theme else None)
         else
             None
 
@@ -208,9 +208,9 @@ module VsCodeIconTheme =
             highContrast = loaded.theme |> getIconPath highContrastId |> Option.map (resolveLoadedPath loaded)
         }
 
-    let getFileIcon (name: string) (languageId: string option) (loaded: Loaded) =
+    let getFileIcon (name: string) (languageId: string option) (useDefault: bool) (loaded: Loaded) =
         let nameLower = name.ToLowerInvariant()
-        resolve (getFileIconKey nameLower languageId) loaded
+        resolve (getFileIconKey nameLower languageId useDefault) loaded
 
     let getFolderIcon (name: string) (loaded: Loaded) =
         let nameLower = name.ToLowerInvariant()

--- a/src/Components/VsCodeIconTheme.fs
+++ b/src/Components/VsCodeIconTheme.fs
@@ -1,0 +1,217 @@
+namespace Ionide.VSCode.FSharp
+
+open System
+open System.Collections.Generic
+open System.Text.RegularExpressions
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Import
+open Fable.Import.Node
+open Fable.Import.vscode
+open Ionide.VSCode.Helpers
+
+[<RequireQualifiedAccess>]
+module VsCodeIconTheme =
+    let logger = ConsoleAndOutputChannelLogger(Some "icons", Level.DEBUG, None, Some Level.DEBUG)
+
+    type Info = {
+        id: string
+        label: string
+        path: string
+        ext: Extension<obj>
+    }
+
+    let getAllInfo () = seq {
+        for ext in extensions.all do
+            let packageJson = ext.packageJSON
+            let contributes = unbox packageJson?contributes
+            if JS.isDefined contributes then
+                let iconThemes: seq<obj> = unbox contributes?iconThemes
+                if JS.isDefined iconThemes then
+                    for theme in iconThemes do
+                        let id: string = unbox theme?id
+                        let path: string = unbox theme?path
+                        let label: string = unbox theme?label
+                        yield { id = id; path = path; ext = ext; label = label }
+    }
+
+    let getInfo (themeId: string) =
+        getAllInfo () |> Seq.tryFind (fun t -> t.id = themeId)
+
+    let getConfigured () =
+        let workbenchConfig = workspace.getConfiguration("workbench")
+        let themeId = workbenchConfig.get<string>("iconTheme")
+
+        Option.ofObj themeId
+
+    let private fallback fallbackFunc opt = match opt with |Some x -> Some x |None -> fallbackFunc ()
+    let private fallbackValue fallback opt = match opt with |Some x -> Some x |None -> fallback
+
+    type JsObjectAsDictionary<'a> =
+        [<Emit("$0[$1]")>]
+        member __.get(key: string): 'a = jsNative
+        [<Emit("($0[$1]||null)")>]
+        member __.tryGet(key: string): Option<'a> = jsNative
+        [<Emit("$0.hasOwnProperty($1)")>]
+        member __.hasOwnProperty(key: string): bool = jsNative
+
+    type IconDefinition =
+        abstract iconPath: string option with get, set
+
+    type SpecificIconTheme =
+        abstract member file: string with get, set
+        abstract member folder: string with get, set
+        abstract member folderExpanded: string with get, set
+        abstract member folderNames: JsObjectAsDictionary<string> with get, set
+        abstract member folderNamesExpanded: JsObjectAsDictionary<string> with get, set
+        abstract member languageIds: JsObjectAsDictionary<string> with get, set
+        abstract member fileExtensions: JsObjectAsDictionary<string> with get, set
+        abstract member fileNames: JsObjectAsDictionary<string> with get, set
+
+    type IconTheme =
+        inherit SpecificIconTheme
+
+        abstract member iconDefinitions: JsObjectAsDictionary<IconDefinition> with get, set
+        abstract member light: SpecificIconTheme with get, set
+        abstract member highContrast: SpecificIconTheme with get, set
+
+    let private getPossibleFileExtensions (fileName: string) =
+        let result = ResizeArray<string>()
+
+        let mutable dotPos = fileName.IndexOf(".")
+        while dotPos <> -1 do
+            let ext = fileName.Substring(dotPos + 1)
+            result.Add(ext)
+            dotPos <-
+                if dotPos + 1 < fileName.Length then
+                    fileName.IndexOf(".", dotPos + 1)
+                else
+                    -1
+
+        result
+
+    let private findByFileName (name: string) (theme: SpecificIconTheme) =
+        if JS.isDefined theme.fileNames then theme.fileNames.tryGet name else None
+
+    let private findByFolderName (name: string) (theme: SpecificIconTheme) =
+        if JS.isDefined theme.folderNames then theme.folderNames.tryGet name else None
+
+    let private findByExpandedFolderName (name: string) (theme: SpecificIconTheme) =
+        if JS.isDefined theme.folderNamesExpanded then theme.folderNamesExpanded.tryGet name else None
+
+    let private findByLanguageId (languageId: string Option) (theme: SpecificIconTheme) =
+        if JS.isDefined theme.languageIds && languageId.IsSome && theme.languageIds.hasOwnProperty(languageId.Value) then
+            Some (theme.languageIds.get (languageId.Value))
+        else
+            None
+
+    let private findByExtension (name: string) (theme: SpecificIconTheme) =
+        if JS.isDefined theme.fileExtensions then
+            let exts = getPossibleFileExtensions name
+            let matching = exts |> Seq.tryFind theme.fileExtensions.hasOwnProperty
+            match matching with
+            | Some matching -> Some (theme.fileExtensions.get matching)
+            | None -> None
+        else
+            None
+
+    let private fileDefault (theme: SpecificIconTheme) =
+        if JS.isDefined theme.file then Some theme.file else None
+
+    let private folderDefault (theme: SpecificIconTheme) =
+        if JS.isDefined theme.folder then Some theme.folder else None
+
+    let private folderExpandedDefault (theme: SpecificIconTheme) =
+        if JS.isDefined theme.folderExpanded then Some theme.folderExpanded else None
+
+    let private getFileIconKey (name: string) (languageId: string Option) (theme: SpecificIconTheme) =
+        if JS.isDefined theme then
+            findByFileName name theme
+            |> fallback (fun () -> findByLanguageId languageId theme)
+            |> fallback (fun () -> findByExtension name theme)
+            |> fallback (fun () -> fileDefault theme)
+        else
+            None
+
+    let private getFolderIconKey (name: string) (theme: SpecificIconTheme) =
+        if JS.isDefined theme then
+            findByFolderName name theme
+            |> fallback (fun () -> folderDefault theme)
+        else
+            None
+
+    let private getExpandedFolderIconKey (name: string) (theme: SpecificIconTheme) =
+        if JS.isDefined theme then
+            findByExpandedFolderName name theme
+            |> fallback (fun () -> folderExpandedDefault theme)
+            |> fallback (fun () -> getFolderIconKey name theme)
+        else
+            None
+
+    let private getIconPath (id: string option) (theme: IconTheme) =
+        id |> Option.bind theme.iconDefinitions.tryGet |> Option.bind (fun x -> x.iconPath)
+
+    let private readFile path : JS.Promise<Buffer> =
+        Promise.create(fun resolve reject ->
+            fs.readFile(path, fun err buffer ->
+                if JS.isDefined err then
+                    reject err
+                else
+                    resolve buffer
+            )
+        )
+
+    type Loaded = {
+        info: Info
+        theme: IconTheme
+    }
+
+    let private resolveLoadedPath (loaded: Loaded) path =
+        let themeFileFullPath = Node.path.join(loaded.info.ext.extensionPath, loaded.info.path)
+        let themeFileDir = Node.path.dirname(themeFileFullPath)
+        Node.path.join(themeFileDir, path)
+
+    let private parseMsJson<'a> (str: string) =
+        logger.Info("%s", str)
+        let clean = Regex("//.*$", RegexOptions.Multiline).Replace(str, "")
+        try
+            Some (unbox (JS.JSON.parse(clean)))
+        with
+        | ex ->
+            logger.Error("Failed to parse JSON: %s", str)
+            None
+
+    let load (info: Info) =
+        let fullPath = path.join(info.ext.extensionPath, info.path)
+        logger.Debug("Loading icon theme from %s", fullPath)
+        promise {
+            let! fileBuffer = readFile fullPath
+            let parsed = parseMsJson<IconTheme> (fileBuffer.toString())
+
+            return parsed |> Option.map(fun theme -> { info = info; theme = theme })
+        }
+
+    type ResolvedIcon = {
+        dark: string option
+        light: string option
+        highContrast: string option
+    }
+
+    let private resolve (f: SpecificIconTheme -> string option) (loaded: Loaded) =
+        let darkId = f loaded.theme
+        let lightId = f loaded.theme.light |> fallbackValue darkId
+        let highContrastId = f loaded.theme.highContrast |> fallbackValue darkId
+
+        {
+            dark = loaded.theme |> getIconPath darkId |> Option.map (resolveLoadedPath loaded)
+            light = loaded.theme |> getIconPath lightId |> Option.map (resolveLoadedPath loaded)
+            highContrast = loaded.theme |> getIconPath highContrastId |> Option.map (resolveLoadedPath loaded)
+        }
+
+    let getFileIcon (name: string) (languageId: string option) (loaded: Loaded) =
+        let nameLower = name.ToLowerInvariant()
+        resolve (getFileIconKey nameLower languageId) loaded
+
+    let getFolderIcon (name: string) (loaded: Loaded) =
+        let nameLower = name.ToLowerInvariant()
+        resolve (getFolderIconKey nameLower) loaded

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -91,6 +91,7 @@
     <Compile Include="Components/Expecto.fs" />
     <Compile Include="Components/MSBuild.fs" />
     <Compile Include="Components/Help.fs" />
+    <Compile Include="Components/VsCodeIconTheme.fs" />
     <Compile Include="Components/SolutionExplorer.fs" />
     <Compile Include="fsharp.fs" />
   </ItemGroup>


### PR DESCRIPTION
This PR use the icons from the icon theme (When possible, see limitations) in the project explorer pane

![2017-08-13 22_30_35- extension development host - assemblyinfo fs markdownf visual studio code](https://user-images.githubusercontent.com/131878/29253213-77dde0c0-8077-11e7-916b-a9b051fa4744.png)

* Use the icons for .fs & .fsproj extensions if defined but still use the embeded icons if the theme doesn't define a more specific icon
* Use the icons for folders
* Handle light/dark icons
* Reload the icons when the theme change

### Limitations

* When the icon theme change the tree is reloaded (like when the project change) losing what folders are opened or closed.
* The specific icon for when a folder is expanded isn't used. (I don't know how to do that)
* Icon themes that use icons in Fonts (like seti-icons) are NOT supported, and there don't seem to be any way to support them.

### Sample with a few themes

![2017-08-13 22_31_20- extension development host - assemblyinfo fs markdownf visual studio code](https://user-images.githubusercontent.com/131878/29253254-2577f608-8078-11e7-8953-43161f272fc6.png) ![2017-08-13 22_27_56- extension development host - assemblyinfo fs markdownf visual studio code](https://user-images.githubusercontent.com/131878/29253255-25786c14-8078-11e7-80b2-85deefb1a8ec.png) ![2017-08-13 22_28_23- extension development host - assemblyinfo fs markdownf visual studio code](https://user-images.githubusercontent.com/131878/29253257-257bb626-8078-11e7-80c4-c0abe5fc0420.png) ![2017-08-13 22_29_09- extension development host - assemblyinfo fs markdownf visual studio code](https://user-images.githubusercontent.com/131878/29253256-257b311a-8078-11e7-8f0f-b4ce8118a3ed.png) ![2017-08-13 22_30_15- extension development host - assemblyinfo fs markdownf visual studio code](https://user-images.githubusercontent.com/131878/29253259-257c98ca-8078-11e7-8757-f873cadbc9c9.png) ![2017-08-13 22_30_35- extension development host - assemblyinfo fs markdownf visual studio code](https://user-images.githubusercontent.com/131878/29253258-257bf9e2-8078-11e7-8a2e-bd9ba6090f90.png)
