### PR TITLE
Show the project view only when there are projects to see

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -241,7 +241,8 @@
       "explorer": [
         {
           "id": "ionide.projectExplorer",
-          "name": "Project Explorer"
+          "name": "F# Project Explorer",
+          "when": "fsharp.project.any"
         }
       ]
     },

--- a/src/Components/VsCodeIconTheme.fs
+++ b/src/Components/VsCodeIconTheme.fs
@@ -172,7 +172,6 @@ module VsCodeIconTheme =
         Node.path.join(themeFileDir, path)
 
     let private parseMsJson<'a> (str: string) =
-        logger.Info("%s", str)
         let clean = Regex("//.*$", RegexOptions.Multiline).Replace(str, "")
         try
             Some (unbox (JS.JSON.parse(clean)))

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -15,6 +15,7 @@ open Ionide.VSCode.Helpers
 module Project =
     let private emptyProjectsMap = Map<ProjectFilePath,Project> []
     let mutable private loadedProjects = emptyProjectsMap
+    let setAnyProjectContext = Context.cachedSetter<bool> "fsharp.project.any"
     let projectChanged = EventEmitter<Project>()
 
     let excluded = "FSharp.excludeProjectDirectories" |> Configuration.get [| ".git"; "paket-files" |]
@@ -84,6 +85,7 @@ module Project =
 
     let private clearLoadedProjects () =
         loadedProjects <- emptyProjectsMap
+        setAnyProjectContext false
 
     let load (path:string) =
         let projEquals (p1 : Project) (p2 : Project) =
@@ -100,6 +102,7 @@ module Project =
                 | None -> projectChanged.fire pr.Data
                 | _ -> ()
                 loadedProjects <- (pr.Data.Project.ToUpperInvariant (), pr.Data) |> loadedProjects.Add
+                setAnyProjectContext true
                 )
 
     let tryFindLoadedProject (path:string) =

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -57,9 +57,9 @@ module Option =
 [<RequireQualifiedAccess>]
 module Document =
     let (|FSharp|CSharp|VB|Other|) (document : TextDocument) =
-        if document.languageId = "fsharp" then FSharp 
+        if document.languageId = "fsharp" then FSharp
         else if document.languageId = "csharp" then CSharp
-        else if document.languageId = "vb" then VB 
+        else if document.languageId = "vb" then VB
         else Other
 
 [<RequireQualifiedAccess>]
@@ -151,3 +151,16 @@ module Event =
 
     let invoke (listener: 'T -> _) (event: Fable.Import.vscode.Event<'T>) =
         event.Invoke(unbox<System.Func<_, _>>(fun a -> listener a))
+
+module Context =
+    open Fable.Import
+
+    let set<'a> (name: string) (value: 'a) =
+        vscode.commands.executeCommand("setContext", name, value) |> ignore
+
+    let cachedSetter<'a when 'a : equality> (name: string) =
+        let mutable current: 'a option = None
+        fun (value:'a) ->
+            if current <> Some value then
+                set name value
+                current <- Some value


### PR DESCRIPTION
Don't always show the "Project Explorer" view, only show it when there are some project present (No need to take place on the screen when users aren't doing F# in the workspace).

* Remove a log I forgot in previous PR (oops)
* Rename "Project Explorer" to "F# Project Explorer" (To better distinguish it between the other view when multiple plugins contribute one) *I'm not especially attached to that, but it feel a little better*