### PR TITLE
Move 'Add project' to navigation commands with an icon

### DIFF
--- a/release/images/add-dark.svg
+++ b/release/images/add-dark.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg3723"
+   sodipodi:docname="add-dark.svg"
+   inkscape:version="0.92.1 r15371">
+  <metadata
+     id="metadata3727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>project</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#000000"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1177"
+     id="namedview3725"
+     showgrid="true"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="11.431233"
+     inkscape:cy="5.7300641"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3723">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3729" />
+  </sodipodi:namedview>
+  <!-- Generator: Sketch 40.3 (33839) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title3714">project</title>
+  <desc
+     id="desc3716">Created with Sketch.</desc>
+  <defs
+     id="defs3718" />
+  <rect
+     style="fill:#89d185;fill-opacity:1;stroke-width:1.27357495"
+     id="rect3733"
+     width="12"
+     height="4"
+     x="2"
+     y="6" />
+  <rect
+     style="fill:#89d185;fill-opacity:1;stroke-width:1.26545429"
+     id="rect3733-8"
+     width="3.9491525"
+     height="12"
+     x="6.0508475"
+     y="2" />
+</svg>

--- a/release/images/add-light.svg
+++ b/release/images/add-light.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg3723"
+   sodipodi:docname="add-light.svg"
+   inkscape:version="0.92.1 r15371">
+  <metadata
+     id="metadata3727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>project</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#000000"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1177"
+     id="namedview3725"
+     showgrid="true"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="11.431233"
+     inkscape:cy="5.7300641"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3723">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3729" />
+  </sodipodi:namedview>
+  <!-- Generator: Sketch 40.3 (33839) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title3714">project</title>
+  <desc
+     id="desc3716">Created with Sketch.</desc>
+  <defs
+     id="defs3718" />
+  <rect
+     style="fill:#388a34;fill-opacity:1;stroke-width:1.27357495"
+     id="rect3733"
+     width="12"
+     height="4"
+     x="2"
+     y="6" />
+  <rect
+     style="fill:#388a34;fill-opacity:1;stroke-width:1.26545429"
+     id="rect3733-8"
+     width="3.9491525"
+     height="12"
+     x="6.0508475"
+     y="2" />
+</svg>

--- a/release/package.json
+++ b/release/package.json
@@ -106,7 +106,11 @@
       },
       {
         "command": "fsharp.NewProject",
-        "title": "F#: New Project"
+        "title": "F#: New Project",
+        "icon": {
+          "light": "./images/add-light.svg",
+          "dark": "./images/add-dark.svg"
+        }
       },
       {
         "command": "fsharp.NewProjectNoFake",
@@ -336,6 +340,7 @@
       "view/title": [
         {
           "command": "fsharp.NewProject",
+          "group": "navigation",
           "when": "view == ionide.projectExplorer"
         }
       ],


### PR DESCRIPTION
While i'm playing with icons. "navigation" group commands are shown directly on top of the tree without the "..." menu. The text-only display is ugly but the icon one is nice so I created a small icon.

I took the "+" colors from the "add new file" icon in official vscode

![2017-08-15 01_03_39- extension development host - welcome ionide-paket visual studio code](https://user-images.githubusercontent.com/131878/29295688-087dec68-8156-11e7-9b3d-8ad331a54687.png)
![2017-08-15 01_03_56- extension development host - welcome ionide-paket visual studio code](https://user-images.githubusercontent.com/131878/29295689-08813f1c-8156-11e7-97c3-d0761371ccc2.png)
