### PR TITLE
Fix typo in command name. 

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -317,7 +317,7 @@
           "when": "false"
         },
         {
-          "command": "fsharp.explorer.refreesh",
+          "command": "fsharp.explorer.refresh",
           "when": "false"
         },
         {


### PR DESCRIPTION
Fix #499 

This is generating a warning:

*Translated from french*
`[C:\Users\mange\.vscode\extensions\Ionide.ionide-fsharp-2.33.0]: Element of menu make reference to command 'fsharp.explorer.refreesh' which is not defined in section 'commands'.
`

I tested it locally and it's seems to fix the issue. We probably need to report it to VSCode as a warning is breaking others extensions.