### PR TITLE
Fix #504. Fixes dotnet execution on Mac.

### DIFF
--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -189,7 +189,7 @@ module Project =
     let private execWithDotnet outputChannel cmd =
         promise {
             let! dotnet = Environment.dotnet
-            return Process.spawnWithNotification dotnet dotnet cmd outputChannel
+            return Process.spawnWithNotification dotnet "" cmd outputChannel
         }
 
     let private exec exe outputChannel cmd =


### PR DESCRIPTION
This fixes the Expecto runner on Mac when running against .NET Core. I tried this fix out on Windows and it  doesn't appear to break anything there. It looks like that second argument that I've set to an empty string may only be used when running Mono?

This fix may also apply to the `execWithDotnetWithShell ` function too but I'm not familiar with what calls into that yet.

Thanks for all your work!