### PR TITLE
"LineLens"

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -25,7 +25,7 @@ GITHUB
     modules/Octokit/Octokit.fsx (291f58cc70aba6dd871cf18e66d2d88357e4f208)
       Octokit (>= 0.20)
   remote: Ionide/ionide-vscode-helpers
-    Fable.Import.Axios.fs (42949401319091b80cd8038524335a54491e4fe1)
-    Fable.Import.VSCode.fs (42949401319091b80cd8038524335a54491e4fe1)
-    Fable.Import.ws.fs (42949401319091b80cd8038524335a54491e4fe1)
-    Helpers.fs (42949401319091b80cd8038524335a54491e4fe1)
+    Fable.Import.Axios.fs (84f4fb08ebc2b8eab40c851cb046e440c0646c2b)
+    Fable.Import.VSCode.fs (84f4fb08ebc2b8eab40c851cb046e440c0646c2b)
+    Fable.Import.ws.fs (84f4fb08ebc2b8eab40c851cb046e440c0646c2b)
+    Helpers.fs (84f4fb08ebc2b8eab40c851cb046e440c0646c2b)

--- a/release/package.json
+++ b/release/package.json
@@ -519,7 +519,7 @@
           "group": "1_run@1"
         }
       ],
-      "editor/context":[
+      "editor/context": [
         {
           "command": "fsharp.generateDoc",
           "group": "1_modification",
@@ -695,13 +695,13 @@
           "description": "Automatically shows Expecto output panel"
         },
         "FSharp.msbuildLocation": {
-          "type":"string",
-          "default":"",
+          "type": "string",
+          "default": "",
           "description": "Use a specific version of msbuild to build this project."
         },
         "FSharp.msbuildAutoshow": {
-          "type":"boolean",
-          "default":true,
+          "type": "boolean",
+          "default": true,
           "description": "Automatically shows Expecto output panel"
         },
         "FSharp.msbuildHost": {
@@ -716,7 +716,7 @@
           ]
         },
         "FSharp.resolveNamespaces": {
-          "type":"boolean",
+          "type": "boolean",
           "default": false,
           "description": "Enables `resolve unopened namespaces and modules` code fix. Not stable, can crash FSAC - use at your own risk."
         },
@@ -726,9 +726,32 @@
           "description": "Enables solution explorer - experimental feature."
         },
         "FSharp.excludeProjectDirectories": {
-          "type":"array",
-          "default": [".git", "paket-files"],
+          "type": "array",
+          "default": [
+            ".git",
+            "paket-files"
+          ],
           "description": "Directories in the array are excluded from project file search. Requires restart"
+        },
+        "FSharp.lineLens.enabled": {
+          "type": "string",
+          "description": "Usage mode for LineLens",
+          "enum": [
+            "never",
+            "replaceCodeLens",
+            "always"
+          ],
+          "default": "never"
+        },
+        "FSharp.lineLens.prefix": {
+          "type": "string",
+          "description": "The prefix displayed before the signature",
+          "default": "  // "
+        },
+        "FSharp.lineLens.color": {
+          "type": "string",
+          "description": "Color of the line lens, any css syntax or 'theme(...)' for a theme color.",
+          "default": "theme(editorCodeLens.foreground)"
         }
       }
     },
@@ -750,22 +773,22 @@
         "fileLocation": "absolute",
         "background": {
           "activeOnStart": true,
-          "beginsPattern":{
-              "regexp": "webpack: Compiling"
+          "beginsPattern": {
+            "regexp": "webpack: Compiling"
           },
-          "endsPattern":{
-              "regexp": "webpack: (Compiled successfully|Failed to compile)"
+          "endsPattern": {
+            "regexp": "webpack: (Compiled successfully|Failed to compile)"
           }
         },
         "pattern": {
-            "regexp": "(.*)\\((\\d+),(\\d+),(\\d+),(\\d+)\\)\\s*:\\s*(warning|error) FABLE\\s*:\\s*(.*)$",
-            "file": 1,
-            "line": 2,
-            "column": 3,
-            "endLine": 4,
-            "endColumn": 5,
-            "severity": 6,
-            "message": 7
+          "regexp": "(.*)\\((\\d+),(\\d+),(\\d+),(\\d+)\\)\\s*:\\s*(warning|error) FABLE\\s*:\\s*(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "endLine": 4,
+          "endColumn": 5,
+          "severity": 6,
+          "message": 7
         }
       }
     ]
@@ -785,7 +808,7 @@
     "vscode.fsharp"
   ],
   "scripts": {
-    "prebuild":"npm update",
+    "prebuild": "npm update",
     "build": "fable ../src/Ionide.FSharp.fsproj -o ../release -m commonjs --verbose"
   },
   "dependencies": {

--- a/src/Components/CodeLens.fs
+++ b/src/Components/CodeLens.fs
@@ -22,42 +22,58 @@ module CodeLens =
         let newHeight = change.text.ToCharArray() |> Seq.sumBy (fun n -> if n = '\n' then 1 else 0)
         newHeight - oldHeight
 
+    let formatSignature (sign : string) : string =
+        let sign =
+            match sign with
+            | StartsWith "val" _
+            | StartsWith "member" _
+            | StartsWith "abstract" _
+            | StartsWith "static" _
+            | StartsWith "override" _ -> sign
+            | _ ->
+                match sign.IndexOf "(" with
+                | i when i > 0 ->
+                    sign.Substring(0, i) + ":" + sign.Substring(i+1)
+                | _ -> sign
+
+        let sign = if sign.Contains ":" then sign.Split(':').[1 ..] |> String.concat ":" else sign
+        let parms = sign.Split([|"->"|], StringSplitOptions.RemoveEmptyEntries)
+        parms
+        |> Seq.map (function
+            | Contains "(requires" p -> p
+            | Contains "*" p ->
+                p.Split '*' |> Seq.map (fun z -> if z.Contains ":" then z.Split(':').[1] else z) |> String.concat "* "
+            | Contains ":" p ->
+                p.Split(':').[1]
+            | p -> p)
+        |> Seq.map String.trim
+        |> String.concat " -> "
+
+    let interestingSymbolPositions (symbols: Symbols[]): DTO.Range[] =
+        symbols |> Array.collect(fun syms ->
+            let interestingNested = syms.Nested |> Array.choose (fun sym ->
+                if sym.GlyphChar <> "Fc"
+                   && sym.GlyphChar <> "M"
+                   && sym.GlyphChar <> "F"
+                   && sym.GlyphChar <> "P"
+                   || sym.IsAbstract
+                   || sym.EnclosingEntity = "I"  // interface
+                   || sym.EnclosingEntity = "R"  // record
+                   || sym.EnclosingEntity = "D"  // DU
+                   || sym.EnclosingEntity = "En" // enum
+                   || sym.EnclosingEntity = "E"  // exception
+                then None
+                else Some sym.BodyRange)
+
+            if syms.Declaration.GlyphChar <> "Fc" then
+                interestingNested
+            else
+                interestingNested |> Array.append [|syms.Declaration.BodyRange|])
+
     let private createProvider () =
         let symbolsToCodeLens (doc : TextDocument) (symbols: Symbols[]) : CodeLens[] =
-             symbols |> Array.collect (fun syms ->
-                let range = CodeRange.fromDTO syms.Declaration.BodyRange
-                let codeLens = CodeLens range
-
-                let codeLenses =  syms.Nested |> Array.choose (fun sym ->
-                    if sym.GlyphChar <> "Fc"
-                       && sym.GlyphChar <> "M"
-                       && sym.GlyphChar <> "F"
-                       && sym.GlyphChar <> "P"
-                       || sym.IsAbstract
-                       || sym.EnclosingEntity = "I"  // interface
-                       || sym.EnclosingEntity = "R"  // record
-                       || sym.EnclosingEntity = "D"  // DU
-                       || sym.EnclosingEntity = "En" // enum
-                       || sym.EnclosingEntity = "E"  // exception
-                    then None
-                    else Some (CodeLens (CodeRange.fromDTO sym.BodyRange)))
-
-                if syms.Declaration.GlyphChar <> "Fc" then codeLenses
-                else
-                    codeLenses |> Array.append [|codeLens|])
-
-        let formatSignature (sign : SignatureData) : string =
-            let args =
-                sign.Parameters
-                |> List.map (fun group ->
-                    group |> List.map (fun p ->
-                        p.Type
-                    )
-                    |> String.concat " * "
-                )
-                |> String.concat " -> "
-
-            if String.IsNullOrEmpty args then sign.OutputType else args + " -> " + sign.OutputType
+            interestingSymbolPositions symbols
+                |> Array.map (CodeRange.fromDTO >> CodeLens)
 
         { new CodeLensProvider with
             member __.provideCodeLenses(doc, _) =
@@ -135,8 +151,6 @@ module CodeLens =
             changes <- [yield! changes; yield! event.contentChanges]
             refresh.fire(-1)
         ()
-
-
 
     let private fileOpenedHandler (event : TextEditor) =
         if isNotNull event then

--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -13,16 +13,17 @@ open System.Text.RegularExpressions
 
 
 module Errors =
+    let private logger = ConsoleAndOutputChannelLogger(Some "Errors", Level.DEBUG, None, Some Level.DEBUG)
+
     let mutable private currentDiagnostic = languages.createDiagnosticCollection ()
 
     let private mapResult (ev : ParseResult) =
-
         let errors =
             ev.Data.Errors
             |> Seq.distinctBy (fun error -> error.Severity, error.StartLine, error.StartColumn)
             |> Seq.choose (fun error ->
                 try
-                    if window.activeTextEditor.document.fileName |> String.startWith "\\" then None else
+                    if error.FileName |> String.startWith "\\" then None else
                     let range = CodeRange.fromError error
                     let loc = Location (Uri.file error.FileName, range |> Case1)
                     let severity = if error.Severity = "Error" then 0 else 1
@@ -32,15 +33,30 @@ module Errors =
             |> ResizeArray
         ev.Data.File, errors
 
-    let private parse path text version =
-        LanguageService.parse path text version
-        |> Promise.map (fun (ev : ParseResult) ->
-            if isNotNull ev then
+    type DocumentParsedEvent = {
+        fileName: string
+        text: string
+        version: float
+        /// BEWARE: Live object, might have changed since the parsing
+        document: TextDocument
+        result: ParseResult
+    }
+
+    let private onDocumentParsedEmitter = EventEmitter<DocumentParsedEvent>()
+    let onDocumentParsed = onDocumentParsedEmitter.event;
+
+    let private parse (document : TextDocument) =
+        let fileName = document.fileName
+        let text = document.getText()
+        let version = document.version
+        LanguageService.parse document.fileName (document.getText()) document.version
+        |> Promise.map (fun (result : ParseResult) ->
+            if isNotNull result then
+                onDocumentParsedEmitter.fire { fileName = fileName; text = text; version = version; document = document; result = result }
                 // printf "CodeLens - File parsed"
                 CodeLens.refresh.fire (unbox version)
-                Linter.refresh.fire path
-                (Uri.file path, (mapResult ev |> snd |> Seq.map fst |> ResizeArray)) |> currentDiagnostic.set  )
-
+                Linter.refresh.fire fileName
+                (Uri.file fileName, (mapResult result |> snd |> Seq.map fst |> ResizeArray)) |> currentDiagnostic.set  )
 
     let private parseFile (file : TextDocument) =
         match file with
@@ -50,19 +66,20 @@ module Errors =
             match prom with
             | Some p -> p
                         |> Project.load
-                        |> Promise.bind (fun _ -> parse path (file.getText ()) file.version)
-            | None -> parse path (file.getText ()) file.version
+                        |> Promise.bind (fun _ -> parse file)
+            | None -> parse file
         | _ -> Promise.lift (null |> unbox)
 
     let mutable private timer = None
 
     let private handler (event : TextDocumentChangeEvent) =
         timer |> Option.iter(clearTimeout)
-        timer <- Some (setTimeout((fun _ ->
+        timer <- Some (setTimeout (fun _ ->
             match event.document with
             | Document.FSharp ->
-                parse (event.document.fileName) (event.document.getText ()) event.document.version
-            | _ -> promise { () } ), 1000.))
+                parse event.document
+                |> ignore
+            | _ -> () ) 1000.)
 
     let private handlerSave (doc : TextDocument) =
         match doc with

--- a/src/Components/Expecto.fs
+++ b/src/Components/Expecto.fs
@@ -154,7 +154,7 @@ module Expecto =
             | _ ->  (VSCode.getPluginPath "Ionide.Ionide-fsharp") + "/images/" + file |> Uri.file
         opt.gutterIconPath <- unbox path
         opt.overviewRulerLane <- Some OverviewRulerLane.Full
-        opt.overviewRulerColor <- Some "rgba(224, 64, 6, 0.7)"
+        opt.overviewRulerColor <- Some (Case1 "rgba(224, 64, 6, 0.7)")
         window.createTextEditorDecorationType opt
 
     let passedDecorationType =
@@ -167,7 +167,7 @@ module Expecto =
             | _ ->  (VSCode.getPluginPath "Ionide.Ionide-fsharp") + "/images/" + file |> Uri.file
         opt.gutterIconPath <- unbox path
         opt.overviewRulerLane <- Some OverviewRulerLane.Full
-        opt.overviewRulerColor <- Some "rgba(166, 215, 133, 0.7)"
+        opt.overviewRulerColor <- Some (Case1 "rgba(166, 215, 133, 0.7)")
         window.createTextEditorDecorationType opt
 
     let ignoredDecorationType =
@@ -180,7 +180,7 @@ module Expecto =
             | _ ->  (VSCode.getPluginPath "Ionide.Ionide-fsharp") + "/images/" + file |> Uri.file
         opt.gutterIconPath <- unbox path
         opt.overviewRulerLane <- Some OverviewRulerLane.Full
-        opt.overviewRulerColor <- Some "rgba(255, 188, 64, 0.7)"
+        opt.overviewRulerColor <- Some (Case1 "rgba(255, 188, 64, 0.7)")
         window.createTextEditorDecorationType opt
 
 

--- a/src/Components/LineLens.fs
+++ b/src/Components/LineLens.fs
@@ -1,0 +1,329 @@
+module Ionide.VSCode.FSharp.LineLens
+
+open System
+open System.Collections.Generic
+open Fable.Core
+open Fable.Import
+open Fable.Import.vscode
+open Fable.Import.Node
+open Fable.Core.JsInterop
+open DTO
+open Ionide.VSCode.Helpers
+
+type Number = float
+
+let private logger = ConsoleAndOutputChannelLogger(Some "LineLens", Level.DEBUG, None, Some Level.DEBUG)
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module LineLensConfig =
+    open System.Text.RegularExpressions
+
+    type EnabledMode =
+    | Never
+    | ReplaceCodeLens
+    | Always
+
+    let private parseEnabledMode (s: string) =
+        match s.ToLowerInvariant() with
+        | "never" -> Never
+        | "always" -> Always
+        | "replacecodelens"
+        | _ -> ReplaceCodeLens
+
+    type LineLensConfig = {
+        enabled: EnabledMode
+        codeLensEnabled: bool
+        color: U2<string, ThemeColor>
+        prefix: string
+    }
+
+    let defaultConfig = {
+        enabled = ReplaceCodeLens
+        codeLensEnabled = true
+        color = "editorCodeLens.foreground" |> ThemeColor |> U2.Case2
+        prefix = " //  "
+    }
+
+    let private themeRegex = Regex("\s*theme\((.+)\)\s*")
+
+    let private parseColor (color: string) =
+        let m = themeRegex.Match(color)
+        if m.Success then
+            U2.Case2 (ThemeColor (m.Groups.[1].Value))
+        else
+            U2.Case1 color
+
+    let getConfig () =
+        let cfg = workspace.getConfiguration()
+        let fsharpCodeLensConfig = cfg.get("[fsharp]", JsObject.empty).tryGet<bool>("editor.codeLens")
+        let globalCodeLensConfig = cfg.get("editor.codeLens", defaultConfig.codeLensEnabled)
+        let codeLensEnabled = defaultArg fsharpCodeLensConfig globalCodeLensConfig
+        {
+            enabled = cfg.get("FSharp.lineLens.enabled", "replacecodelens") |> parseEnabledMode
+            codeLensEnabled = codeLensEnabled
+            prefix = cfg.get("FSharp.lineLens.prefix", defaultConfig.prefix)
+            color = cfg.get("FSharp.lineLens.color", "theme(editorCodeLens.foreground)") |> parseColor
+        }
+
+    let isEnabled conf =
+        match conf.enabled, conf.codeLensEnabled with
+        | Always, _ -> true
+        | ReplaceCodeLens, false -> true
+        | _ -> false
+
+module Documents =
+    type Cached = {
+        /// vscode document version that was parsed
+        version: Number
+        /// Decorations
+        decorations: ResizeArray<DecorationOptions>
+        /// Text editors where the decorations are shown
+        textEditors: ResizeArray<TextEditor>
+    }
+
+    type DocumentInfo = {
+        /// Full path of the document
+        fileName: string
+        /// Current decoration cache
+        cache: Cached option
+    }
+
+    type Documents = Dictionary<string, DocumentInfo>
+
+    let inline create () = Documents()
+
+    let inline tryGet fileName (documents: Documents) = documents.TryGet fileName
+
+    let inline getOrAdd fileName (documents: Documents) =
+        match tryGet fileName documents with
+        | Some x -> x
+        | None ->
+            let value = { fileName = fileName; cache = None }
+            documents.Add(fileName, value)
+            value
+
+    let inline set fileName value (documents: Documents) = documents.Add(fileName, value)
+
+    let update info (decorations: ResizeArray<DecorationOptions>) version (documents: Documents) =
+        let updated =
+            { info with
+                cache =
+                    Some {
+                        version = version
+                        decorations = decorations
+                        textEditors = ResizeArray() } }
+        documents |> set info.fileName updated
+        updated
+
+    let inline tryGetCached fileName (documents: Documents) =
+        documents
+        |> tryGet fileName
+        |> Option.bind(fun info -> info.cache |> Option.map(fun c -> info, c))
+
+    let inline tryGetCachedAtVersion fileName version (documents: Documents) =
+        documents
+        |> tryGet fileName
+        |> Option.bind(fun info ->
+            match info.cache with
+            | Some cache when cache.version = version -> Some (info, cache)
+            | _ -> None
+            )
+
+let mutable private config = LineLensConfig.defaultConfig
+
+module LineLensDecorations =
+    let create range text =
+        // What we add after the range
+        let attachment = createEmpty<ThemableDecorationAttachmentRenderOptions>
+        attachment.color <- Some config.color
+        attachment.contentText <- Some text
+
+        // Theme for the range
+        let renderOptions = createEmpty<DecorationInstanceRenderOptions>
+        renderOptions.after <- Some attachment
+
+        let decoration = createEmpty<DecorationOptions>
+        decoration.range <- range
+        decoration.renderOptions <- Some renderOptions
+        decoration
+
+    let decorationType =
+        let opt = createEmpty<DecorationRenderOptions>
+        opt.isWholeLine <- Some true
+        opt
+
+type State = {
+    documents: Documents.Documents
+    decorationType: TextEditorDecorationType
+    disposables: ResizeArray<Disposable>
+    }
+
+module DecorationUpdate =
+    let private lineRange (doc: TextDocument) (range: DTO.Range) : CodeRange.CodeRange =
+        let lineNumber = float range.StartLine - 1.
+        let textLine = doc.lineAt lineNumber
+        textLine.range
+
+    let private getSignature (fileName: string) (range: DTO.Range) = promise {
+        let! signaturesResult =
+            LanguageService.signature
+                fileName
+                range.StartLine
+                range.StartColumn
+        let signaturesResult = if isNotNull signaturesResult then Some signaturesResult else None
+        return signaturesResult |> Option.map (fun r -> range, CodeLens.formatSignature r.Data)
+    }
+
+    let private signatureToDecoration (doc: TextDocument) (range:DTO.Range, signature:string) =
+        LineLensDecorations.create (lineRange doc range) (config.prefix + signature)
+
+    let private onePerLine (ranges: Range[]) =
+        ranges
+        |> Array.groupBy(fun r -> r.StartLine)
+        |> Array.choose (fun (_, ranges) -> if ranges.Length = 1 then Some (ranges.[0]) else None)
+
+    let private needUpdate (fileName: string) (version: Number) { documents = documents }=
+        (documents |> Documents.tryGetCachedAtVersion fileName version).IsSome
+
+
+    let private declarationsResultToSignatures declarationsResult fileName = promise {
+            let interesting = declarationsResult.Data |> CodeLens.interestingSymbolPositions
+            let interesting = onePerLine interesting
+            let! signatures = interesting |> Array.map (getSignature fileName) |> Promise.all
+            return signatures |> Seq.choose id
+    }
+
+    /// Update the decorations stored for the document.
+    /// * If the info is already in cache, return that
+    /// * If it change during the process nothing is done and it return None, if a real change is done it return the new state
+    let updateDecorationsForDocument (document: TextDocument) (version: float) state = promise {
+        let fileName = document.fileName
+
+        match state.documents |> Documents.tryGetCachedAtVersion fileName version with
+        | Some (info, _) ->
+            logger.Debug("Found existing decorations in cache for '%s' @%d", fileName, version)
+            return Some info
+        | None when document.version = version ->
+            let! declarationsResult = LanguageService.declarations fileName (unbox version)
+            if document.version = version && isNotNull declarationsResult then
+                let! signatures = declarationsResultToSignatures declarationsResult fileName
+                let info = state.documents |> Documents.getOrAdd fileName
+                if document.version = version && info.cache.IsNone || info.cache.Value.version <> version then
+                    let decorations = signatures |> Seq.map (signatureToDecoration document) |> ResizeArray
+
+                    logger.Debug("New decorations generated for '%s' @%d", fileName, version)
+                    return Some (state.documents |> Documents.update info decorations version)
+                else
+                    return None
+            else
+                return None
+        | _ ->
+            return None
+    }
+
+    /// Set the decorations for the editor, filtering lines where the user recently typed
+    let setDecorationsForEditor (textEditor : TextEditor) (info: Documents.DocumentInfo) state =
+        match info.cache with
+        | Some cache when not (cache.textEditors.Contains(textEditor))->
+            cache.textEditors.Add(textEditor)
+            logger.Debug("Setting decorations for '%s' @%d", info.fileName, cache.version)
+            textEditor.setDecorations(state.decorationType, U2.Case2(cache.decorations))
+        | _ -> ()
+
+    /// Set the decorations for the editor if we have them for the current version of the document
+    let setDecorationsForEditorIfCurrentVersion (textEditor : TextEditor) state =
+        let fileName = textEditor.document.fileName
+        let version = textEditor.document.version
+
+        match Documents.tryGetCachedAtVersion fileName version state.documents with
+        | None -> () // An event will arrive later when we have generated decorations
+        | Some (info, _) -> setDecorationsForEditor textEditor info state
+
+    let documentClosed (fileName: string) state =
+        // We can/must drop all caches as versions are unique only while a document is open.
+        // If it's re-opened later versions will start at 1 again.
+        state.documents.Remove(fileName) |> ignore
+
+let inline private isFsharpFile (doc: TextDocument) =
+    match doc with
+    | Document.FSharp when doc.uri.scheme = "file" -> true
+    | _ -> false
+
+let mutable private state: State option = None
+
+let private textEditorsChangedHandler (textEditors : ResizeArray<TextEditor>) =
+    match state with
+    | Some state ->
+        for textEditor in textEditors do
+            if isFsharpFile textEditor.document then
+                DecorationUpdate.setDecorationsForEditorIfCurrentVersion textEditor state
+    | None -> ()
+
+let private documentParsedHandler (event: Errors.DocumentParsedEvent) =
+    match state with
+    | None -> ()
+    | Some state ->
+        promise {
+            let! updatedInfo = DecorationUpdate.updateDecorationsForDocument event.document event.version state
+            match updatedInfo with
+            | Some info ->
+                // Update all text editors where this document is shown (potentially more than one)
+                window.visibleTextEditors
+                |> Seq.filter (fun editor -> editor.document = event.document)
+                |> Seq.iter(fun editor -> DecorationUpdate.setDecorationsForEditor editor info state)
+            | _ -> ()
+        } |> logger.ErrorOnFailed "Updating after parse failed"
+
+let private closedTextDocumentHandler (textDocument: TextDocument) =
+    state |> Option.iter (DecorationUpdate.documentClosed textDocument.fileName)
+
+let install () =
+    logger.Debug "Installing"
+
+    let decorationType = window.createTextEditorDecorationType(LineLensDecorations.decorationType)
+    let disposables = ResizeArray<Disposable>()
+
+    disposables.Add(window.onDidChangeVisibleTextEditors.Invoke(unbox textEditorsChangedHandler))
+    disposables.Add(Errors.onDocumentParsed.Invoke(unbox documentParsedHandler))
+    disposables.Add(workspace.onDidCloseTextDocument.Invoke(unbox closedTextDocumentHandler))
+
+    let newState = { decorationType = decorationType; disposables = disposables; documents = Documents.create() }
+
+    state <- Some newState
+
+    logger.Debug "Installed"
+
+let uninstall () =
+    logger.Debug "Uninstalling"
+
+    match state with
+    | None -> ()
+    | Some state ->
+        for disposable in state.disposables do
+            disposable.dispose() |> ignore
+
+        state.decorationType.dispose()
+
+    state <- None
+    logger.Debug "Uninstalled"
+
+let configChangedHandler () =
+    logger.Debug("Config Changed event")
+
+    let wasEnabled = LineLensConfig.isEnabled config
+    config <- LineLensConfig.getConfig ()
+    let isEnabled = LineLensConfig.isEnabled config
+
+    if wasEnabled <> isEnabled then
+        if isEnabled then
+            install ()
+        else
+            uninstall ()
+
+let activate (context: ExtensionContext) =
+    logger.Info "Activating"
+
+    workspace.onDidChangeConfiguration $ (configChangedHandler, (), context.subscriptions) |> ignore
+
+    configChangedHandler ()
+    ()

--- a/src/Components/Linter.fs
+++ b/src/Components/Linter.fs
@@ -44,8 +44,7 @@ module Linter =
 
     let private handler filename =
         timer |> Option.iter(clearTimeout)
-        timer <- Some (setTimeout((fun _ -> lintDocument filename), 1000.))
-
+        timer <- Some (setTimeout (fun _ -> lintDocument filename) 1000.)
 
     let private createProvider () =
 

--- a/src/Components/QuickInfo.fs
+++ b/src/Components/QuickInfo.fs
@@ -39,7 +39,7 @@ module QuickInfo =
 
     let private handle (event : TextEditorSelectionChangeEvent) =
         timer |> Option.iter(clearTimeout)
-        timer <- Some (setTimeout((fun n -> handle' event), 500.) )
+        timer <- Some (setTimeout (fun n -> handle' event |> ignore) 500.)
 
     let activate (context: ExtensionContext) =
         window.onDidChangeTextEditorSelection $ (handle, (), context.subscriptions) |> ignore

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -165,9 +165,9 @@ module SolutionExplorer =
                 let collaps =
                     match node with
                     | File _ | Reference _ | ProjectReference _ -> None
-                    | Workspace _ | Project _ -> Some 2
-                    | _ ->  Some 1
-                ti.collapsibleState <- unbox collaps
+                    | Workspace _ | Project _ -> Some TreeItemCollapsibleState.Expanded
+                    | _ ->  Some TreeItemCollapsibleState.Collapsed
+                ti.collapsibleState <- collaps
                 let command =
                     match node with
                     | File (p, _, _)  ->

--- a/src/Components/VsCodeIconTheme.fs
+++ b/src/Components/VsCodeIconTheme.fs
@@ -47,14 +47,6 @@ module VsCodeIconTheme =
     let inline private fallback fallbackFunc opt = match opt with |Some x -> Some x |None -> fallbackFunc ()
     let inline private fallbackValue fallback opt = match opt with |Some x -> Some x |None -> fallback
 
-    type JsObjectAsDictionary<'a> =
-        [<Emit("$0[$1]")>]
-        member __.get(key: string): 'a = jsNative
-        [<Emit("$0.hasOwnProperty($1)?$0[$1]:null")>]
-        member __.tryGet(key: string): Option<'a> = jsNative
-        [<Emit("$0.hasOwnProperty($1)")>]
-        member __.hasOwnProperty(key: string): bool = jsNative
-
     type IconDefinition =
         abstract iconPath: string option with get, set
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -264,7 +264,7 @@ module LanguageService =
 
     let declarations fn version=
         {DeclarationsRequest.FileName = handleUntitled fn; Version = version}
-        |> request "declarations" 0 (makeRequestId())
+        |> request<_, Result<Symbols[]>> "declarations" 0 (makeRequestId())
 
 
     let declarationsProjects () =

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -88,3 +88,9 @@ module Logging =
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.Warn (template, [<ParamArray>]args:obj[]) =
             writeBothIfConfigured out this.ChanMinLevel consoleMinLevel WARN source template args
+        /// Logs a message that should/could be seen by the user in the output channel if the promise fail.
+        /// The templates may use node util.format placeholders: %s, %d, %j, %%
+        /// https://nodejs.org/api/util.html#util_util_format_format
+        member this.ErrorOnFailed text (p: Fable.Import.JS.Promise<_>) =
+            p.catch(Func<obj,unit>(fun err -> this.Error(text + ": %O", err)))
+            |> ignore

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -69,20 +69,74 @@ module Configuration =
 
 [<AutoOpen>]
 module Utils =
+    open Fable.Core
+
     let isNotNull o = o |> unbox <> null
+
+    type System.Collections.Generic.Dictionary<'key, 'value> with
+        [<Emit("$0.has($1) ? $0.get($1) : null")>]
+        member this.TryGet(key: 'key): 'value option = jsNative
 
 [<AutoOpen>]
 module JS =
     open Fable.Core
+    open Fable.Import.Node
 
-    [<Emit("setTimeout($0,$1)")>]
-    let setTimeout(cb, delay) : obj = failwith "JS Only"
+    /// Schedules execution of a one-time callback after delay milliseconds.
+    /// Returns a Timeout for use with `clearTimeout`.
+    [<Emit("setTimeout($0, $1)")>]
+    let setTimeout (callback: unit -> unit) (delay: float): NodeJS.Timer = jsNative
 
+    /// Cancels a Timeout object created by `setTimeout`.
     [<Emit("clearTimeout($0)")>]
-    let clearTimeout(timer) : unit = failwith "JS Only"
+    let clearTimeout (timeout: NodeJS.Timer): unit = jsNative
 
     [<Emit("debugger")>]
     let debugger () : unit = failwith "JS Only"
+
+    type JsObject =
+        [<Emit("$0[$1]")>]
+        member __.get<'a>(key: string): 'a = jsNative
+
+        [<Emit("$0.hasOwnProperty($1)?$0[$1]:null")>]
+        member __.tryGet<'a>(key: string): Option<'a> = jsNative
+
+        [<Emit("$0.hasOwnProperty($1)")>]
+        member __.hasOwnProperty(key: string): bool = jsNative
+
+        [<Emit("$0[$1]=$2")>]
+        member __.set<'a>(key: string, value: 'a) = jsNative
+
+        [<Emit("$0[$1]=$2")>]
+        member __.set<'a>(key: string, value: 'a option) = jsNative
+
+        [<Emit("delete $0[$1]")>]
+        member __.delete(key: string): unit = jsNative
+
+        [<Emit("{}")>]
+        static member empty: JsObject = jsNative
+
+    type JsObjectAsDictionary<'a> =
+        [<Emit("$0[$1]")>]
+        member __.get(key: string): 'a = jsNative
+
+        [<Emit("$0.hasOwnProperty($1)?$0[$1]:null")>]
+        member __.tryGet(key: string): Option<'a> = jsNative
+
+        [<Emit("$0.hasOwnProperty($1)")>]
+        member __.hasOwnProperty(key: string): bool = jsNative
+
+        [<Emit("$0[$1]=$2")>]
+        member __.set(key: string, value: 'a) = jsNative
+
+        [<Emit("$0[$1]=$2")>]
+        member __.set(key: string, value: 'a option) = jsNative
+
+        [<Emit("delete $0[$1]")>]
+        member __.delete(key: string): unit = jsNative
+
+        [<Emit("{}")>]
+        static member empty: JsObjectAsDictionary<'a> = jsNative
 
 [<AutoOpen>]
 module Patterns =

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -89,6 +89,7 @@
     <Compile Include="Components/ResolveNamespaces.fs" />
     <Compile Include="Components/UnionCaseGenerator.fs" />
     <Compile Include="Components/Errors.fs" />
+    <Compile Include="Components/LineLens.fs" />
     <Compile Include="Components/Expecto.fs" />
     <Compile Include="Components/MSBuild.fs" />
     <Compile Include="Components/Help.fs" />

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -30,6 +30,7 @@ let activate (context: ExtensionContext) =
             let pm = createEmpty<ProgressMessage>
             pm.message <- "Loading current project"
             p.report pm
+            LineLens.activate context
             Errors.activate context
             |> Promise.onSuccess(fun _ ->
                 pm.message <- "Loading all projects"


### PR DESCRIPTION
Mostly opening the PR to get some feedback :) *The name is not very original ("On the line CodeLens" -> "LineLens") i'm open to suggestion if it's not good*

The concept is to show type signatures at the end of the line like the vscode debugger is showing variable values (See https://github.com/Microsoft/vscode/pull/16129)

![linelens1](https://user-images.githubusercontent.com/131878/29744831-5aafaac0-8aad-11e7-8205-670aa8b65f8e.gif)

How to test:

For now it's enabled by default when code lenses are disabled :

```json
{
    "editor.codeLens": false,
    "FSharp.lineLens.enabled": "replaceCodeLens",
    "FSharp.lineLens.color": "theme(editorCodeLens.foreground)",
    "FSharp.lineLens.prefix": "  // ",
    "FSharp.lineLens.refreshAfter": 1000,
    "workbench.colorCustomizations": {
        "editorCodeLens.foreground": "#4C4B4B"
    }
}
```

A few things I need to do / know for this PR :
* [x] Dispose the decoration type when disabled instead of the current hack
* [x] Cleanup line in CodeLens.fs
* [x] Remove the hack to disable `npm update` during build. I don't think update should run during build but I can open another PR/issue for that.
* [x] Wait for https://github.com/ionide/ionide-vscode-helpers/pull/11 & update paket lock
* [x] Disable them by default until we're sure it's working well ?
* [x] Determine if I need to call parse on FSAC or can wait for a parse somehow

Regarding the last one it's mostly a question for @Krzysztof-Cieslak I think, i'm currently calling `LanguageService.parse` manually but isn't it done automatically somehow when file change ? (CodeLens seem to get the change directly) I added this step as otherwise when a file is opened for the first time `LanguageService.declarations` return an error that the file is not yet parsed.

Is it the correct way or will I trigger extra parsing of the opened file ? What I would like is an event from FSAC telling me that the file has changed and been parsed but I didn't find one.