### PR TITLE
Fix activate and deactivate signature

### DIFF
--- a/src/Components/Autocomplete.fs
+++ b/src/Components/Autocomplete.fs
@@ -82,5 +82,5 @@ module Autocomplete =
 
     let activate selector (context: ExtensionContext) =
         languages.registerCompletionItemProvider (selector, createProvider(), ".")
-        |> ignore
+        |> context.subscriptions.Add
         ()

--- a/src/Components/Autocomplete.fs
+++ b/src/Components/Autocomplete.fs
@@ -80,7 +80,7 @@ module Autocomplete =
                 } |> Case2
             }
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerCompletionItemProvider (selector, createProvider(), ".")
         |> ignore
         ()

--- a/src/Components/CodeLens.fs
+++ b/src/Components/CodeLens.fs
@@ -156,7 +156,6 @@ module CodeLens =
 
         fileOpenedHandler window.activeTextEditor
 
-
-        languages.registerCodeLensProvider(selector, createProvider()) |> ignore
+        languages.registerCodeLensProvider(selector, createProvider()) |> context.subscriptions.Add
         refresh.fire (1)
         ()

--- a/src/Components/CodeLens.fs
+++ b/src/Components/CodeLens.fs
@@ -149,10 +149,10 @@ module CodeLens =
 
         ()
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         refresh.event.Invoke(fun (n) -> version <- n; null) |> ignore
-        workspace.onDidChangeTextDocument $ (textChangedHandler,(), disposables) |> ignore
-        window.onDidChangeActiveTextEditor $ (fileOpenedHandler, (), disposables) |> ignore
+        workspace.onDidChangeTextDocument $ (textChangedHandler,(), context.subscriptions) |> ignore
+        window.onDidChangeActiveTextEditor $ (fileOpenedHandler, (), context.subscriptions) |> ignore
 
         fileOpenedHandler window.activeTextEditor
 

--- a/src/Components/Definition.fs
+++ b/src/Components/Definition.fs
@@ -148,7 +148,7 @@ module Definition =
                 } |> Case2
         }
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerDefinitionProvider(selector, createProvider())
         |> ignore
 

--- a/src/Components/Definition.fs
+++ b/src/Components/Definition.fs
@@ -150,6 +150,6 @@ module Definition =
 
     let activate selector (context: ExtensionContext) =
         languages.registerDefinitionProvider(selector, createProvider())
-        |> ignore
+        |> context.subscriptions.Add
 
         ()

--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -93,10 +93,10 @@ module Errors =
     //         if window.activeTextEditor.document.fileName <> file then
     //             currentDiagnostic.set(Uri.file file, errors |> Seq.map fst |> ResizeArray))
 
-    let activate (disposables: Disposable[]) =
-        workspace.onDidChangeTextDocument $ (handler,(), disposables) |> ignore
-        workspace.onDidSaveTextDocument $ (handlerSave , (), disposables) |> ignore
-        window.onDidChangeActiveTextEditor $ (handlerOpen, (), disposables) |> ignore
+    let activate (context: ExtensionContext) =
+        workspace.onDidChangeTextDocument $ (handler,(), context.subscriptions) |> ignore
+        workspace.onDidSaveTextDocument $ (handlerSave , (), context.subscriptions) |> ignore
+        window.onDidChangeActiveTextEditor $ (handlerOpen, (), context.subscriptions) |> ignore
         //LanguageService.registerNotify handleNotification
 
         match window.visibleTextEditors |> Seq.toList with

--- a/src/Components/Expecto.fs
+++ b/src/Components/Expecto.fs
@@ -384,12 +384,10 @@ module Expecto =
         statusBar.text <- "$(eye) Watch Mode Off"
         watcherEnabled <- false
 
-
-
-    let activate disposables =
+    let activate (context: ExtensionContext) =
         let registerCommand com (f: unit-> _) =
             vscode.commands.registerCommand(com, unbox<Func<obj,obj>> f)
-            |> ignore
+            |> context.subscriptions.Add
 
         registerCommand "Expecto.run" (fun _ -> runAll false)
         registerCommand "Expecto.runSingle" runSingle
@@ -398,7 +396,6 @@ module Expecto =
         registerCommand "Expecto.startWatchMode" startWatchMode
         registerCommand "Expecto.stopWatchMode" stopWatchMode
         registerCommand "Expecto.watchMode" (fun _ -> outputChannel.show () )
-
 
         statusBar.text <- "$(eye) Watch Mode Off"
         statusBar.tooltip <- "Expecto continuous testing"
@@ -410,7 +407,8 @@ module Expecto =
             else
                 statusBar.show()
             unbox ()
-        ) |> ignore
+        ) |> context.subscriptions.Add
 
-        let _ = vscode.window.onDidChangeActiveTextEditor $ setDecorations
+        vscode.window.onDidChangeActiveTextEditor.Invoke(unbox setDecorations)
+        |> context.subscriptions.Add
         ()

--- a/src/Components/Forge.fs
+++ b/src/Components/Forge.fs
@@ -316,23 +316,23 @@ module Forge =
 
 
 
-    let activate disposables =
+    let activate (context: ExtensionContext) =
         let watcher = workspace.createFileSystemWatcher ("**/*.fs")
 
-        watcher.onDidCreate $ (onFsFileCreateHandler, null, disposables) |> ignore
-        watcher.onDidDelete $ (onFsFileRemovedHandler, null, disposables) |> ignore
-        commands.registerCommand("fsharp.MoveFileUp", moveFileUp |> unbox<Func<obj,obj>> ) |> ignore
-        commands.registerCommand("fsharp.MoveFileDown", moveFileDown |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsharp.NewProject", newProject |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsharp.NewProjectNoFake", newProjectNoFake |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsharp.NewProjectScaffold", newProjectScaffold |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsharp.RefreshProjectTemplates", refreshTemplates |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerTextEditorCommand("fsharp.AddFileToProject", addCurrentFileToProject |> unbox) |> ignore
-        commands.registerTextEditorCommand("fsharp.RemoveFileFromProject", removeCurrentFileFromProject |> unbox) |> ignore
-        commands.registerCommand("fsharp.AddProjectReference", addProjectReference |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsharp.RemoveProjectReference", removeProjectReference |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsharp.AddReference", addReference |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsharp.RemoveReference", removeReference |> unbox<Func<obj,obj>>) |> ignore
-        if fs.existsSync templateLocation |> not then refreshTemplates () |> ignore
+        watcher.onDidCreate $ (onFsFileCreateHandler, null, context.subscriptions) |> ignore
+        watcher.onDidDelete $ (onFsFileRemovedHandler, null, context.subscriptions) |> ignore
+        commands.registerCommand("fsharp.MoveFileUp", moveFileUp |> unbox<Func<obj,obj>> ) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.MoveFileDown", moveFileDown |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.NewProject", newProject |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.NewProjectNoFake", newProjectNoFake |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.NewProjectScaffold", newProjectScaffold |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.RefreshProjectTemplates", refreshTemplates |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerTextEditorCommand("fsharp.AddFileToProject", addCurrentFileToProject |> unbox) |> context.subscriptions.Add
+        commands.registerTextEditorCommand("fsharp.RemoveFileFromProject", removeCurrentFileFromProject |> unbox) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.AddProjectReference", addProjectReference |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.RemoveProjectReference", removeProjectReference |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.AddReference", addReference |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.RemoveReference", removeReference |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        if fs.existsSync templateLocation |> not then refreshTemplates ()
 
         ()

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -186,11 +186,11 @@ module Fsi =
         window.onDidChangeActiveTextEditor $ ((fun n -> if JS.isDefined n then sendCd()), (), context.subscriptions) |> ignore
         window.onDidCloseTerminal $ (handleCloseTerminal, (), context.subscriptions) |> ignore
 
-        commands.registerCommand("fsi.Start", start |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.SendLine", sendLine |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.SendSelection", sendSelection |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.SendLastSelection", sendLastSelection |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.SendFile", sendFile |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.SendProjectReferences", sendReferences |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.GenerateProjectReferences", generateProjectReferences |> unbox<Func<obj,obj>>) |> ignore
+        commands.registerCommand("fsi.Start", start |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.SendLine", sendLine |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.SendSelection", sendSelection |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.SendLastSelection", sendLastSelection |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.SendFile", sendFile |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.SendProjectReferences", sendReferences |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.GenerateProjectReferences", generateProjectReferences |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
 

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -182,9 +182,9 @@ module Fsi =
 
 
 
-    let activate (disposables: Disposable[]) =
-        window.onDidChangeActiveTextEditor $ ((fun n -> if JS.isDefined n then sendCd()), (), disposables) |> ignore
-        window.onDidCloseTerminal $ (handleCloseTerminal, (), disposables) |> ignore
+    let activate (context: ExtensionContext) =
+        window.onDidChangeActiveTextEditor $ ((fun n -> if JS.isDefined n then sendCd()), (), context.subscriptions) |> ignore
+        window.onDidCloseTerminal $ (handleCloseTerminal, (), context.subscriptions) |> ignore
 
         commands.registerCommand("fsi.Start", start |> unbox<Func<obj,obj>>) |> ignore
         commands.registerCommand("fsi.SendLine", sendLine |> unbox<Func<obj,obj>>) |> ignore

--- a/src/Components/Help.fs
+++ b/src/Components/Help.fs
@@ -33,7 +33,7 @@ module Help =
         } |> ignore
 
 
-    let activate (disposables: Disposable[]) =
+    let activate (context: ExtensionContext) =
         let registerCommand com (f: unit-> _) =
             vscode.commands.registerCommand(com, unbox<Func<obj,obj>> f)
             |> ignore

--- a/src/Components/Help.fs
+++ b/src/Components/Help.fs
@@ -36,6 +36,6 @@ module Help =
     let activate (context: ExtensionContext) =
         let registerCommand com (f: unit-> _) =
             vscode.commands.registerCommand(com, unbox<Func<obj,obj>> f)
-            |> ignore
+            |> context.subscriptions.Add
 
         registerCommand "FSharp.getHelp" getHelp

--- a/src/Components/Highlights.fs
+++ b/src/Components/Highlights.fs
@@ -36,7 +36,7 @@ module Highlights =
                 } |> Case2
         }
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerDocumentHighlightProvider(selector, createProvider())
         |> ignore
 

--- a/src/Components/Highlights.fs
+++ b/src/Components/Highlights.fs
@@ -38,6 +38,6 @@ module Highlights =
 
     let activate selector (context: ExtensionContext) =
         languages.registerDocumentHighlightProvider(selector, createProvider())
-        |> ignore
+        |> context.subscriptions.Add
 
         ()

--- a/src/Components/LegacyFsi.fs
+++ b/src/Components/LegacyFsi.fs
@@ -114,9 +114,9 @@ module LegacyFsi =
         }
 
     let activate (context: ExtensionContext) =
-        commands.registerCommand("fsi.Start", start |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.SendLine", sendLine |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.SendSelection", sendSelection |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.SendFile", sendFile |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.SendProjectReferences", sendReferences |> unbox<Func<obj,obj>>) |> ignore
-        commands.registerCommand("fsi.GenerateProjectReferences", generateProjectReferences |> unbox<Func<obj,obj>>) |> ignore
+        commands.registerCommand("fsi.Start", start |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.SendLine", sendLine |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.SendSelection", sendSelection |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.SendFile", sendFile |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.SendProjectReferences", sendReferences |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
+        commands.registerCommand("fsi.GenerateProjectReferences", generateProjectReferences |> unbox<Func<obj,obj>>) |> context.subscriptions.Add

--- a/src/Components/LegacyFsi.fs
+++ b/src/Components/LegacyFsi.fs
@@ -113,7 +113,7 @@ module LegacyFsi =
                 return ()
         }
 
-    let activate (disposables: Disposable[]) =
+    let activate (context: ExtensionContext) =
         commands.registerCommand("fsi.Start", start |> unbox<Func<obj,obj>>) |> ignore
         commands.registerCommand("fsi.SendLine", sendLine |> unbox<Func<obj,obj>>) |> ignore
         commands.registerCommand("fsi.SendSelection", sendSelection |> unbox<Func<obj,obj>>) |> ignore

--- a/src/Components/Linter.fs
+++ b/src/Components/Linter.fs
@@ -87,5 +87,5 @@ module Linter =
             | Document.FSharp -> refresh.fire window.activeTextEditor.document.fileName
             | _ -> ()
 
-        languages.registerCodeActionsProvider (selector, createProvider()) |> ignore
-        commands.registerCommand("fsharp.lintFix",Func<obj,obj,obj,obj>(fun a b c -> applyQuickFix(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore
+        languages.registerCodeActionsProvider (selector, createProvider()) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.lintFix",Func<obj,obj,obj,obj>(fun a b c -> applyQuickFix(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> context.subscriptions.Add

--- a/src/Components/Linter.fs
+++ b/src/Components/Linter.fs
@@ -80,8 +80,8 @@ module Linter =
         workspace.applyEdit edit
         |> Promise.onSuccess (fun _ -> lintDocument doc.fileName)
 
-    let activate selector (disposables: Disposable[]) =
-        refresh.event $ (handler,(), disposables) |> ignore
+    let activate selector (context: ExtensionContext) =
+        refresh.event $ (handler,(), context.subscriptions) |> ignore
         if JS.isDefined window.activeTextEditor then
             match window.activeTextEditor.document with
             | Document.FSharp -> refresh.fire window.activeTextEditor.document.fileName

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -209,9 +209,9 @@ module MSBuild =
         let host = tryGetRightHost project
         invokeMSBuild project.Project target (Some host)
 
-    let activate disposables =
-        let registerCommand com (action : unit -> _) = vscode.commands.registerCommand(com, unbox<Func<obj, obj>> action) |> ignore
-        let registerCommand2 com (action : obj -> obj -> _) = vscode.commands.registerCommand(com, Func<obj, obj, obj>(fun a b -> action a b |> unbox)) |> ignore
+    let activate (context: ExtensionContext) =
+        let registerCommand com (action : unit -> _) = vscode.commands.registerCommand(com, unbox<Func<obj, obj>> action) |> context.subscriptions.Add
+        let registerCommand2 com (action : obj -> obj -> _) = vscode.commands.registerCommand(com, Func<obj, obj, obj>(fun a b -> action a b |> unbox)) |> context.subscriptions.Add
 
         /// typed msbuild cmd. Optional project and msbuild host
         let typedMsbuildCmd f projOpt hostOpt =
@@ -244,7 +244,7 @@ module MSBuild =
                 logger.Info("Dotnet cli (.NET Core) activated")
             | Some MSbuildHost.Auto | None ->
                 logger.Info("Active msbuild: not choosen yet") )
-        |> ignore
+        |> context.subscriptions.Add
 
         let reloadCfg = loadMSBuildHostCfg >> Promise.map (fun h -> host.value <- h)
 
@@ -256,7 +256,7 @@ module MSBuild =
 
         vscode.workspace.onDidChangeConfiguration
         |> Event.invoke reloadCfg
-        |> ignore
+        |> context.subscriptions.Add
 
         registerCommand "MSBuild.buildCurrent" (fun _ -> buildCurrentProject "Build")
         registerCommand "MSBuild.rebuildCurrent" (fun _ -> buildCurrentProject "Rebuild")

--- a/src/Components/ParameterHints.fs
+++ b/src/Components/ParameterHints.fs
@@ -49,7 +49,7 @@ module ParameterHints =
 
                 } |> Case2 }
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerSignatureHelpProvider(selector, createProvider(), "(", ",")
         |> ignore
 

--- a/src/Components/ParameterHints.fs
+++ b/src/Components/ParameterHints.fs
@@ -51,6 +51,6 @@ module ParameterHints =
 
     let activate selector (context: ExtensionContext) =
         languages.registerSignatureHelpProvider(selector, createProvider(), "(", ",")
-        |> ignore
+        |> context.subscriptions.Add
 
         ()

--- a/src/Components/QuickFix.fs
+++ b/src/Components/QuickFix.fs
@@ -95,7 +95,7 @@ module QuickFix =
         |> Promise.bind (workspace.applyEdit)
 
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerCodeActionsProvider (selector, createProvider()) |> ignore
         commands.registerCommand("fsharp.quickFix",Func<obj,obj,obj,obj>(fun a b c -> applyQuickFix(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore
         commands.registerCommand("fsharp.renameFix",Func<obj,obj,obj,obj>(fun a b c -> applyRenameFix(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore

--- a/src/Components/QuickFix.fs
+++ b/src/Components/QuickFix.fs
@@ -96,9 +96,9 @@ module QuickFix =
 
 
     let activate selector (context: ExtensionContext) =
-        languages.registerCodeActionsProvider (selector, createProvider()) |> ignore
-        commands.registerCommand("fsharp.quickFix",Func<obj,obj,obj,obj>(fun a b c -> applyQuickFix(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore
-        commands.registerCommand("fsharp.renameFix",Func<obj,obj,obj,obj>(fun a b c -> applyRenameFix(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore
+        languages.registerCodeActionsProvider (selector, createProvider()) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.quickFix",Func<obj,obj,obj,obj>(fun a b c -> applyQuickFix(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.renameFix",Func<obj,obj,obj,obj>(fun a b c -> applyRenameFix(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> context.subscriptions.Add
 
         ()
 

--- a/src/Components/QuickInfo.fs
+++ b/src/Components/QuickInfo.fs
@@ -41,6 +41,6 @@ module QuickInfo =
         timer |> Option.iter(clearTimeout)
         timer <- Some (setTimeout((fun n -> handle' event), 500.) )
 
-    let activate (disposables: Disposable[]) =
-        window.onDidChangeTextEditorSelection $ (handle, (), disposables) |> ignore
+    let activate (context: ExtensionContext) =
+        window.onDidChangeTextEditorSelection $ (handle, (), context.subscriptions) |> ignore
         ()

--- a/src/Components/References.fs
+++ b/src/Components/References.fs
@@ -35,5 +35,5 @@ module Reference =
 
     let activate selector (context: ExtensionContext) =
         languages.registerReferenceProvider(selector, createProvider())
-        |> ignore
+        |> context.subscriptions.Add
         ()

--- a/src/Components/References.fs
+++ b/src/Components/References.fs
@@ -33,7 +33,7 @@ module Reference =
                 } |> Case2
         }
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerReferenceProvider(selector, createProvider())
         |> ignore
         ()

--- a/src/Components/Rename.fs
+++ b/src/Components/Rename.fs
@@ -32,5 +32,5 @@ module Rename =
 
     let activate selector (context: ExtensionContext) =
         languages.registerRenameProvider(selector, createProvider())
-        |> ignore
+        |> context.subscriptions.Add
         ()

--- a/src/Components/Rename.fs
+++ b/src/Components/Rename.fs
@@ -30,7 +30,7 @@ module Rename =
                     return mapResult doc newName res
                 } |> Case2}
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerRenameProvider(selector, createProvider())
         |> ignore
         ()

--- a/src/Components/ResolveNamespaces.fs
+++ b/src/Components/ResolveNamespaces.fs
@@ -128,9 +128,9 @@ module ResolveNamespaces =
 
 
     let activate selector (context: ExtensionContext) =
-        languages.registerCodeActionsProvider (selector, createProvider()) |> ignore
-        commands.registerCommand("fsharp.openNamespace",Func<obj,obj,obj,obj>(fun a b c -> applyOpen(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore
-        commands.registerCommand("fsharp.useNamespace",Func<obj,obj,obj,obj>(fun a b c -> applyQualify(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore
+        languages.registerCodeActionsProvider (selector, createProvider()) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.openNamespace",Func<obj,obj,obj,obj>(fun a b c -> applyOpen(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.useNamespace",Func<obj,obj,obj,obj>(fun a b c -> applyQualify(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> context.subscriptions.Add
 
 
         ()

--- a/src/Components/ResolveNamespaces.fs
+++ b/src/Components/ResolveNamespaces.fs
@@ -127,7 +127,7 @@ module ResolveNamespaces =
 
 
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerCodeActionsProvider (selector, createProvider()) |> ignore
         commands.registerCommand("fsharp.openNamespace",Func<obj,obj,obj,obj>(fun a b c -> applyOpen(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore
         commands.registerCommand("fsharp.useNamespace",Func<obj,obj,obj,obj>(fun a b c -> applyQualify(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore

--- a/src/Components/SignatureData.fs
+++ b/src/Components/SignatureData.fs
@@ -42,7 +42,7 @@ module SignatureData =
             ()
 
 
-    let activate (disposables: Disposable[]) =
+    let activate (context: ExtensionContext) =
         commands.registerCommand("fsharp.generateDoc", generateDoc |> unbox<Func<obj,obj>>) |> ignore
 
         ()

--- a/src/Components/SignatureData.fs
+++ b/src/Components/SignatureData.fs
@@ -43,6 +43,6 @@ module SignatureData =
 
 
     let activate (context: ExtensionContext) =
-        commands.registerCommand("fsharp.generateDoc", generateDoc |> unbox<Func<obj,obj>>) |> ignore
+        commands.registerCommand("fsharp.generateDoc", generateDoc |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
 
         ()

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -232,27 +232,27 @@ module SolutionExplorer =
                 reloadTree.fire (unbox ())
     }
 
-    let activate () =
+    let activate (context: ExtensionContext) =
         let emiter = EventEmitter<Model>()
         let provider = createProvider emiter
 
         Project.projectChanged.event.Invoke(fun proj ->
             emiter.fire (unbox ()) |> unbox)
-        |> ignore
+        |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.refresh", Func<obj, obj>(fun _ ->
             emiter.fire (unbox ()) |> unbox
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.clearCache", Func<obj, obj>(fun _ ->
             Project.clearCache ()
             |> unbox
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.msbuild.pickHost", Func<obj, obj>(fun _ ->
             MSBuild.pickMSbuildHostType ()
             |> unbox
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.moveUp", Func<obj, obj>(fun m ->
             match unbox m with
@@ -260,7 +260,7 @@ module SolutionExplorer =
                 Forge.moveFileUpPath p
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.moveDown", Func<obj, obj>(fun m ->
             match unbox m with
@@ -268,7 +268,7 @@ module SolutionExplorer =
                 Forge.moveFileDownPath p
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.moveToFolder", Func<obj, obj>(fun m ->
             let folders =
@@ -280,7 +280,7 @@ module SolutionExplorer =
                 Forge.moveFileToFolder folders p pp
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.removeFile", Func<obj, obj>(fun m ->
             match unbox m with
@@ -288,7 +288,7 @@ module SolutionExplorer =
                 Forge.removeFilePath p
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.renameFile", Func<obj, obj>(fun m ->
             match unbox m with
@@ -296,7 +296,7 @@ module SolutionExplorer =
                 Forge.renameFilePath old proj
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.addProjecRef", Func<obj, obj>(fun m ->
             match unbox m with
@@ -304,7 +304,7 @@ module SolutionExplorer =
                 Forge.addProjectReferencePath p
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.removeProjecRef", Func<obj, obj>(fun m ->
             match unbox m with
@@ -312,7 +312,7 @@ module SolutionExplorer =
                 Forge.removeProjectReferencePath path p
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.openProjectFile", Func<obj, obj>(fun m ->
             match unbox m with
@@ -320,7 +320,7 @@ module SolutionExplorer =
                 commands.executeCommand("vscode.open", Uri.file(path))
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.msbuild.build", Func<obj, obj>(fun m ->
             match unbox m with
@@ -328,7 +328,7 @@ module SolutionExplorer =
                 MSBuild.buildProjectPath "Build" pr
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.msbuild.rebuild", Func<obj, obj>(fun m ->
             match unbox m with
@@ -336,7 +336,7 @@ module SolutionExplorer =
                 MSBuild.buildProjectPath "Rebuild" pr
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.msbuild.clean", Func<obj, obj>(fun m ->
             match unbox m with
@@ -344,7 +344,7 @@ module SolutionExplorer =
                 MSBuild.buildProjectPath "Clean" pr
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.project.run", Func<obj, obj>(fun m ->
             match unbox m with
@@ -352,7 +352,7 @@ module SolutionExplorer =
                 Debugger.buildAndRun pr
                 |> unbox
             | _ -> unbox ()
-        )) |> ignore
+        )) |> context.subscriptions.Add
 
         // commands.registerCommand("fsharp.explorer.project.debug", Func<obj, obj>(fun m ->
         //     match unbox m with
@@ -360,10 +360,10 @@ module SolutionExplorer =
         //         Debugger.buildAndDebug pr
         //         |> unbox
         //     | _ -> unbox ()
-        // )) |> ignore
+        // )) |> context.subscriptions.Add
 
         window.registerTreeDataProvider("ionide.projectExplorer", provider )
-        |> ignore
+        |> context.subscriptions.Add
 
         workspace.onDidChangeConfiguration.Invoke(fun _ ->
             loadCurrentTheme emiter |> ignore

--- a/src/Components/Symbols.fs
+++ b/src/Components/Symbols.fs
@@ -67,5 +67,5 @@ module Symbols =
 
     let activate selector (context: ExtensionContext) =
         languages.registerDocumentSymbolProvider(selector, createProvider())
-        |> ignore
+        |> context.subscriptions.Add
         ()

--- a/src/Components/Symbols.fs
+++ b/src/Components/Symbols.fs
@@ -65,7 +65,7 @@ module Symbols =
                 } |> Case2
         }
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerDocumentSymbolProvider(selector, createProvider())
         |> ignore
         ()

--- a/src/Components/Tooltip.fs
+++ b/src/Components/Tooltip.fs
@@ -79,5 +79,5 @@ module Tooltip =
 
     let activate selector (context: ExtensionContext) =
         languages.registerHoverProvider(selector, createProvider())
-        |> ignore
+        |> context.subscriptions.Add
         ()

--- a/src/Components/Tooltip.fs
+++ b/src/Components/Tooltip.fs
@@ -77,7 +77,7 @@ module Tooltip =
 
         }
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerHoverProvider(selector, createProvider())
         |> ignore
         ()

--- a/src/Components/UnionCaseGenerator.fs
+++ b/src/Components/UnionCaseGenerator.fs
@@ -53,8 +53,8 @@ module UnionCaseGenerator =
 
 
     let activate selector (context: ExtensionContext) =
-        languages.registerCodeActionsProvider (selector, createProvider()) |> ignore
-        commands.registerCommand("fsharp.insertUnionCases",Func<obj,obj,obj,obj>(fun a b c -> insertText(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore
+        languages.registerCodeActionsProvider (selector, createProvider()) |> context.subscriptions.Add
+        commands.registerCommand("fsharp.insertUnionCases",Func<obj,obj,obj,obj>(fun a b c -> insertText(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> context.subscriptions.Add
 
 
         ()

--- a/src/Components/UnionCaseGenerator.fs
+++ b/src/Components/UnionCaseGenerator.fs
@@ -52,7 +52,7 @@ module UnionCaseGenerator =
 
 
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerCodeActionsProvider (selector, createProvider()) |> ignore
         commands.registerCommand("fsharp.insertUnionCases",Func<obj,obj,obj,obj>(fun a b c -> insertText(a |> unbox, b |> unbox, c |> unbox) |> unbox )) |> ignore
 

--- a/src/Components/WorkspaceSymbols.fs
+++ b/src/Components/WorkspaceSymbols.fs
@@ -65,5 +65,5 @@ module WorkspaceSymbols =
 
     let activate selector (context: ExtensionContext) =
         languages.registerWorkspaceSymbolProvider(createProvider())
-        |> ignore
+        |> context.subscriptions.Add
         ()

--- a/src/Components/WorkspaceSymbols.fs
+++ b/src/Components/WorkspaceSymbols.fs
@@ -63,7 +63,7 @@ module WorkspaceSymbols =
                 } |> Case2
         }
 
-    let activate selector (disposables: Disposable[]) =
+    let activate selector (context: ExtensionContext) =
         languages.registerWorkspaceSymbolProvider(createProvider())
         |> ignore
         ()

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -9,7 +9,8 @@ open Fable.Import.vscode
 open Ionide.VSCode.Helpers
 open Ionide.VSCode.FSharp
 
-let activate(disposables: Disposable[]) =
+let activate (context: ExtensionContext) =
+    context.subscriptions
     let df = createEmpty<DocumentFilter>
     df.language <- Some "fsharp"
     let df' : DocumentSelector = df |> U3.Case2
@@ -30,12 +31,12 @@ let activate(disposables: Disposable[]) =
             let pm = createEmpty<ProgressMessage>
             pm.message <- "Loading current project"
             p.report pm
-            Errors.activate disposables
+            Errors.activate context
             |> Promise.onSuccess(fun _ ->
                 pm.message <- "Loading all projects"
                 p.report pm
-                CodeLens.activate df' disposables
-                Linter.activate df' disposables
+                CodeLens.activate df' context
+                Linter.activate df' context
             )
             |> Promise.onSuccess(fun _ -> if solutionExploer then SolutionExplorer.activate ())
             |> Promise.bind(fun _ -> Project.activate ())
@@ -48,29 +49,29 @@ let activate(disposables: Disposable[]) =
         )
         |> ignore
 
-        Tooltip.activate df' disposables
-        Autocomplete.activate df' disposables
-        ParameterHints.activate df' disposables
-        Definition.activate df' disposables
-        Reference.activate df' disposables
-        Symbols.activate df' disposables
-        Highlights.activate df' disposables
-        Rename.activate df' disposables
-        WorkspaceSymbols.activate df' disposables
-        QuickInfo.activate disposables
-        QuickFix.activate df' disposables
-        if resolve then ResolveNamespaces.activate df' disposables
-        UnionCaseGenerator.activate df' disposables
-        Help.activate disposables
-        Expecto.activate disposables
-        MSBuild.activate disposables
-        SignatureData.activate disposables
+        Tooltip.activate df' context
+        Autocomplete.activate df' context
+        ParameterHints.activate df' context
+        Definition.activate df' context
+        Reference.activate df' context
+        Symbols.activate df' context
+        Highlights.activate df' context
+        Rename.activate df' context
+        WorkspaceSymbols.activate df' context
+        QuickInfo.activate context
+        QuickFix.activate df' context
+        if resolve then ResolveNamespaces.activate df' context
+        UnionCaseGenerator.activate df' context
+        Help.activate context
+        Expecto.activate context
+        MSBuild.activate context
+        SignatureData.activate context
     )
     |> Promise.catch (fun error -> promise { () }) // prevent unhandled rejected promises
     |> ignore
 
-    Forge.activate disposables
-    if legacyFsi then LegacyFsi.activate disposables else Fsi.activate disposables
+    Forge.activate context
+    if legacyFsi then LegacyFsi.activate context else Fsi.activate context
 
     ()
 

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -10,14 +10,13 @@ open Ionide.VSCode.Helpers
 open Ionide.VSCode.FSharp
 
 let activate (context: ExtensionContext) =
-    context.subscriptions
     let df = createEmpty<DocumentFilter>
     df.language <- Some "fsharp"
     let df' : DocumentSelector = df |> U3.Case2
 
     let legacyFsi = "FSharp.legacyFSI" |> Configuration.get false
     let resolve = "FSharp.resolveNamespaces" |> Configuration.get false
-    let solutionExploer = "FSharp.enableTreeView" |> Configuration.get true
+    let solutionExplorer = "FSharp.enableTreeView" |> Configuration.get true
 
     let init = DateTime.Now
 
@@ -38,7 +37,7 @@ let activate (context: ExtensionContext) =
                 CodeLens.activate df' context
                 Linter.activate df' context
             )
-            |> Promise.onSuccess(fun _ -> if solutionExploer then SolutionExplorer.activate ())
+            |> Promise.onSuccess(fun _ -> if solutionExplorer then SolutionExplorer.activate context)
             |> Promise.bind(fun _ -> Project.activate ())
 
 


### PR DESCRIPTION
`activate` take an `ExtensionContext` as single parameter and `deactivate` takes none.

This PR also add all missing Disposables to `ExtensionContext.subscriptions` that I could find.