### PR TITLE
update for fsac single console

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -726,10 +726,10 @@ NUGET
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
 GIT
   remote: https://github.com/fsharp/FsAutoComplete.git
-     (1adfdd6c60041ae4d98214af6de27281df976b83)
+     (414332e20c540b71c6b32366916c87a65b040294)
       build: build.cmd LocalRelease
       os: windows
-     (1adfdd6c60041ae4d98214af6de27281df976b83)
+     (414332e20c540b71c6b32366916c87a65b040294)
       build: build.sh LocalRelease
       os: mono
   remote: https://github.com/fsharp-editing/Forge.git

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -394,7 +394,10 @@ module LanguageService =
                         spawnLogged mono [ yield path; yield! args ]
                     else
                         spawnLogged path args
-                fsac ["--mode"; "http"; "--port"; port]
+                fsac
+                  [ "--mode"; "http"
+                    "--port"; port
+                    sprintf "--hostPID=%i" (int Globals.``process``.pid) ]
 
             let mutable isResolvedAsStarted = false
             child


### PR DESCRIPTION
ref https://github.com/fsharp/FsAutoComplete/pull/212

now fsac has one single console app `fsautocomplete.exe`

to enable old suave mode:

`--mode http --port <PORT>`

This pr also add the usage of `--hostPID` argument 
ref https://github.com/fsharp/FsAutoComplete/pull/190
this enable FSAC to track vscode process, and quit when that process is
terminated (so will avoid zombies if vscode is not terminated gracefully)