### PR TITLE
add `Debug` and `Set at startup project` commands

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -743,10 +743,10 @@ GIT
      (826aa0690b4a1fb536485cc2806fa73b451fcee7)
 GITHUB
   remote: ionide/ionide-vscode-helpers
-    src/Fable.Import.Axios.fs (87fd2b0e2fb6e5b909fc607f7239f73abd8dcd07)
-    src/Fable.Import.VSCode.fs (87fd2b0e2fb6e5b909fc607f7239f73abd8dcd07)
-    src/Fable.Import.ws.fs (87fd2b0e2fb6e5b909fc607f7239f73abd8dcd07)
-    src/Helpers.fs (87fd2b0e2fb6e5b909fc607f7239f73abd8dcd07)
+    src/Fable.Import.Axios.fs (381544e5fc0c30ec2ad9663a1b5222fc0aee2f6a)
+    src/Fable.Import.VSCode.fs (381544e5fc0c30ec2ad9663a1b5222fc0aee2f6a)
+    src/Fable.Import.ws.fs (381544e5fc0c30ec2ad9663a1b5222fc0aee2f6a)
+    src/Helpers.fs (381544e5fc0c30ec2ad9663a1b5222fc0aee2f6a)
 GROUP build
 NUGET
   remote: https://www.nuget.org/api/v2

--- a/release/package.json
+++ b/release/package.json
@@ -245,6 +245,10 @@
         "title": "Show project status"
       },
       {
+        "command": "fsharp.explorer.setLaunchSettings",
+        "title": "Set as startup project"
+      },
+      {
         "command": "fsharp.explorer.renameFile",
         "title": "Rename file"
       },
@@ -568,6 +572,11 @@
           "group": "3_modification@2"
         },
         {
+          "command": "fsharp.explorer.setLaunchSettings",
+          "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+          "group": "3_modification@3"
+        },
+        {
           "command": "fsharp.explorer.msbuild.build",
           "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
           "group": "2_navigation@1"
@@ -586,6 +595,11 @@
           "command": "fsharp.explorer.project.run",
           "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
           "group": "1_run@1"
+        },
+        {
+          "command": "fsharp.explorer.project.debug",
+          "when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+          "group": "1_run@2"
         }
       ],
       "editor/context": [


### PR DESCRIPTION
to F# project explorer, if project is a console app

- `Debug` will run the debugger of selected project. no launch.json needed. this just fix a bug in the previous @Krzysztof-Cieslak implementation

![lookma_nolaunchjson](https://user-images.githubusercontent.com/147243/30713027-46f20a30-9f0e-11e7-91e0-0598dc4e6367.gif)

NOTE the gif is not updated, the `Debug` is below `Run` in the context menu

- `Set at startup project` update launch.json or create it if not exists

![setasstartup](https://user-images.githubusercontent.com/147243/30713012-4060a064-9f0e-11e7-9a87-b5d9591af703.gif)

**NOTE** for .NET full (`"type": "clr") the debugging on windows works like before (for old or new sdk). but project must be configured as x64 and portable pdb

```xml
<PlatformTarget>x64</PlatformTarget>
<DebugType>portable</DebugType>
```
