### PR TITLE
Linelens colors

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -831,11 +831,6 @@
           "type": "string",
           "description": "The prefix displayed before the signature",
           "default": "  // "
-        },
-        "FSharp.lineLens.color": {
-          "type": "string",
-          "description": "Color of the line lens, any css syntax or 'theme(...)' for a theme color.",
-          "default": "theme(editorCodeLens.foreground)"
         }
       }
     },
@@ -882,7 +877,8 @@
         "description": "Foreground color for F# LineLenses",
         "defaults": {
           "dark": "#525252",
-          "light": "#C2C2C2"
+          "light": "#C2C2C2",
+          "highContrast": "#A2E2A2"
         }
       }
     ]

--- a/release/package.json
+++ b/release/package.json
@@ -875,6 +875,16 @@
           "message": 7
         }
       }
+    ],
+    "colors": [
+      {
+        "id": "fsharp.linelens",
+        "description": "Foreground color for F# LineLenses",
+        "defaults": {
+          "dark": "#525252",
+          "light": "#C2C2C2"
+        }
+      }
     ]
   },
   "activationEvents": [

--- a/src/Components/LineLens.fs
+++ b/src/Components/LineLens.fs
@@ -33,25 +33,16 @@ module LineLensConfig =
     type LineLensConfig = {
         enabled: EnabledMode
         codeLensEnabled: bool
-        color: U2<string, ThemeColor>
         prefix: string
     }
 
     let defaultConfig = {
         enabled = ReplaceCodeLens
         codeLensEnabled = true
-        color = "editorCodeLens.foreground" |> ThemeColor |> U2.Case2
         prefix = " //  "
     }
 
     let private themeRegex = Regex("\s*theme\((.+)\)\s*")
-
-    let private parseColor (color: string) =
-        let m = themeRegex.Match(color)
-        if m.Success then
-            U2.Case2 (ThemeColor (m.Groups.[1].Value))
-        else
-            U2.Case1 color
 
     let getConfig () =
         let cfg = workspace.getConfiguration()
@@ -62,7 +53,6 @@ module LineLensConfig =
             enabled = cfg.get("FSharp.lineLens.enabled", "replacecodelens") |> parseEnabledMode
             codeLensEnabled = codeLensEnabled
             prefix = cfg.get("FSharp.lineLens.prefix", defaultConfig.prefix)
-            color = cfg.get("FSharp.lineLens.color", "theme(editorCodeLens.foreground)") |> parseColor
         }
 
     let isEnabled conf =
@@ -135,7 +125,7 @@ module LineLensDecorations =
     let create range text =
         // What we add after the range
         let attachment = createEmpty<ThemableDecorationAttachmentRenderOptions>
-        attachment.color <- Some config.color
+        attachment.color <- Some (U2.Case2 (ThemeColor "fsharp.linelens"))
         attachment.contentText <- Some text
 
         // Theme for the range


### PR DESCRIPTION
This move the linelens color configuration from a custom configuration to a standard themable color.

I also selected colors for light/dark/highContrast that blend better that reusing CodeLens ones by default.


![2017-09-22 11_59_21- extension development host - fluentroslyn fs stidgen visual studio code](https://user-images.githubusercontent.com/131878/30739572-30e55186-9f8e-11e7-91a0-198c167c0010.png)
![2017-09-22 11_59_42- extension development host - fluentroslyn fs stidgen visual studio code](https://user-images.githubusercontent.com/131878/30739575-32f4f724-9f8e-11e7-9b70-ba32e5d45cdc.png)
![2017-09-22 11_59_57- extension development host - fluentroslyn fs stidgen visual studio code](https://user-images.githubusercontent.com/131878/30739579-35f7111e-9f8e-11e7-91ae-d5771adcab93.png)


*(No effort has been made to port from the old config, sorry)*