### PR TITLE
Add debug flag to get stack traces on mono

### DIFF
--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -391,12 +391,11 @@ module LanguageService =
                 let fsac args =
                     if Process.isMono () then
                         let mono = "FSharp.monoPath" |> Configuration.get "mono"
-                        spawnLogged mono [ yield path; yield! args ]
+                        spawnLogged mono [ yield "--debug"; yield path; yield! args ]
                     else
                         spawnLogged path args
                 fsac
-                  [ "--debug"
-                    "--mode"; "http"
+                  [ "--mode"; "http"
                     "--port"; port
                     sprintf "--hostPID=%i" (int Globals.``process``.pid) ]
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -395,7 +395,8 @@ module LanguageService =
                     else
                         spawnLogged path args
                 fsac
-                  [ "--mode"; "http"
+                  [ "--debug"
+                    "--mode"; "http"
                     "--port"; port
                     sprintf "--hostPID=%i" (int Globals.``process``.pid) ]
 


### PR DESCRIPTION
if you add --debug then your stack traces have line numbers, yay!