### PR TITLE
wip touchbar commands

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -672,6 +672,33 @@
           "group": "1_modification",
           "when": "editorTextFocus && editorLangId == 'fsharp'"
         }
+      ],
+      "touchBar": [
+        {
+          "command": "fsharp.debugDefaultProject",
+          "group": "fsharp.project",
+          "when": "editorLangId == 'fsharp'"
+        },
+        {
+          "command": "fsharp.runDefaultProject",
+          "group": "fsharp.project",
+          "when": "editorLangId == 'fsharp'"
+        },
+        {
+          "command": "fsharp.NewProject",
+          "group": "fsharp.project",
+          "when": "editorLangId == 'fsharp'"
+        },
+        {
+          "command": "fsi.Start",
+          "group": "fsi",
+          "when": "editorLangId == 'fsharp'"
+        },
+        {
+          "command": "fsi.SendFile",
+          "group": "fsi",
+          "when": "editorLangId == 'fsharp'"
+        }
       ]
     },
     "outputChannels": [


### PR DESCRIPTION
All icons are activated when in the fsharp context only.  Addresses #574.

![img_20171005_150030](https://user-images.githubusercontent.com/573979/31249779-38bb7a2a-a9de-11e7-94dd-c1782ceb69db.jpg)
