### PR TITLE
Better QuickInfo

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -81,17 +81,18 @@ Target "YarnInstall" <| fun () ->
 Target "DotNetRestore" <| fun () ->
     DotNetCli.Restore (fun p -> { p with WorkingDir = "src" } )
 
-let runFable additionalArgs =
+let runFable additionalArgs noTimeout =
     let cmd = "fable webpack -- --config webpack.config.js " + additionalArgs
-    DotNetCli.RunCommand (fun p -> { p with WorkingDir = "src" } ) cmd
+    let timeout = if noTimeout then TimeSpan.MaxValue else TimeSpan.FromMinutes 30.
+    DotNetCli.RunCommand (fun p -> { p with WorkingDir = "src"; TimeOut = timeout } ) cmd
 
 Target "RunScript" (fun _ ->
     // Ideally we would want a production (minized) build but UglifyJS fail on PerMessageDeflate.js as it contains non-ES6 javascript.
-    runFable ""
+    runFable "" false
 )
 
 Target "Watch" (fun _ ->
-    runFable "--watch"
+    runFable "--watch" true
 )
 
 Target "CopyFSAC" (fun _ ->

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -634,12 +634,12 @@ module SolutionExplorer =
                     // let addedProject = Project.getLoaded () |> List.map (fun p -> p.Project)
                     // let toAdd = projects |> List.where (fun n -> addedProject |> List.contains n |> not) |> ResizeArray
                     if projects.Length = 0 then
-                        window.showInformationMessage "No projects in workspace that can be added to the solution"
+                        window.showInformationMessage "No projects in workspace that can be added to the solution" |> ignore
                     else
                         let projs = projects |> ResizeArray
                         let! proj = window.showQuickPick (unbox projs)
                         if JS.isDefined proj then
-                            Project.execWithDotnet MSBuild.outputChannel (sprintf "sln %s add %s" name proj)
+                            Project.execWithDotnet MSBuild.outputChannel (sprintf "sln %s add %s" name proj) |> ignore
                 }
                 |> unbox
             | _ -> unbox ()

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -138,6 +138,8 @@ module JS =
         [<Emit("{}")>]
         static member empty: JsObjectAsDictionary<'a> = jsNative
 
+    let inline undefined<'a> = unbox<'a> ()
+
 [<AutoOpen>]
 module Patterns =
     let (|StartsWith|_|) (pat: string) (str: string)  =

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -40,7 +40,6 @@
     <Compile Include="Components/CodeOutline.fs" />
     <Compile Include="Components/Fsi.fs" />
     <Compile Include="Components/LegacyFsi.fs" />
-    <Compile Include="Components/QuickInfo.fs" />
     <Compile Include="Components/Forge.fs" />
     <Compile Include="Components/Linter.fs" />
     <Compile Include="Components/CodeLens.fs" />
@@ -49,6 +48,7 @@
     <Compile Include="Components/UnionCaseGenerator.fs" />
     <Compile Include="Components/Errors.fs" />
     <Compile Include="Components/LineLens.fs" />
+    <Compile Include="Components/QuickInfo.fs" />
     <Compile Include="Components/Expecto.fs" />
     <Compile Include="Components/MSBuild.fs" />
     <Compile Include="Components/Help.fs" />


### PR DESCRIPTION
* Hide QuickInfo when there is no signature to display (Not F# or not on something with a signature)
* Hide QuickInfo when the document is closed (Important for the last one)
* Update QuickInfo when a document is parse (They show when the F# project finishes loading and update when the type of the thing under the cursor is known/changed)

Also:
* Fix 30min max on watch mode