### PR TITLE
Fixes autocomplete documentation rendering

### DIFF
--- a/src/Components/Autocomplete.fs
+++ b/src/Components/Autocomplete.fs
@@ -58,7 +58,7 @@ module Autocomplete =
         let mapHelptext (sug : CompletionItem) (o : HelptextResult) =
             if isNotNull o then
                 let res = (o.Data.Overloads |> Array.collect id).[0]
-                sug.documentation <- Markdown.replaceXml res.Comment
+                sug.documentation <- res.Comment |> Markdown.createCommentBlock |> U2.Case2
                 sug.detail <- res.Signature
             sug
 

--- a/src/Components/ParameterHints.fs
+++ b/src/Components/ParameterHints.fs
@@ -20,9 +20,9 @@ module ParameterHints =
                 let sigs = o.Data.Overloads |> Array.choose (fun c ->
                     try
                         let tip = c.Tip.[0].[0]
-                        let signature = SignatureInformation (tip.Signature, tip.Comment)
+                        let signature = SignatureInformation (tip.Signature, U2.Case1 tip.Comment)
                         c.Parameters |> Array.iter (fun p ->
-                            let parameter = ParameterInformation (p.Name, p.CanonicalTypeTextForSorting)
+                            let parameter = ParameterInformation (p.Name, U2.Case1 p.CanonicalTypeTextForSorting)
                             signature.parameters.Add (parameter )
                             |> ignore
                         )

--- a/src/Components/Tooltip.fs
+++ b/src/Components/Tooltip.fs
@@ -12,21 +12,6 @@ open Ionide.VSCode.Helpers
 
 module Tooltip =
     let private createProvider () =
-        let createCommentBlock (comment: string) : MarkedString[] =
-            comment.Split '\n'
-            |> Array.filter(String.IsNullOrWhiteSpace>>not)
-            |> Array.mapi (fun i line ->
-                let v =
-                    if i = 0 && not (String.IsNullOrWhiteSpace line)
-                    then "\n" + line.Trim()
-                    else line.Trim()
-                Markdown.replaceXml v
-               )
-            |> String.concat "\n\n"
-            |> String.trim
-            |> U2.Case1
-            |> Array.singleton
-
         let mapResult (doc : TextDocument) (pos : Position) o =
             let range = doc.getWordRangeAtPosition pos
             if isNotNull o then
@@ -36,7 +21,7 @@ module Tooltip =
                         createObj [
                             "language" ==> lang
                             "value" ==> value.Trim()
-                        ] |> U2.Case2
+                        ] |> U3.Case3
 
                     let fsharpBlock (lines: string[]) : MarkedString =
                         lines |> String.concat "\n" |> markStr "fsharp"
@@ -50,14 +35,14 @@ module Tooltip =
                         match lines |> Array.splitAt (lines.Length - 1) with
                         | (h, [| StartsWith "Full name:" fullName |]) ->
                             [| yield fsharpBlock h
-                               yield U2.Case1 ("_" + fullName + "_") |]
+                               yield U3.Case2 ("_" + fullName + "_") |]
                         | _ -> [| fsharpBlock lines |]
 
                     let commentContent =
                         res.Comment
-                        |> String.replace "&lt;" "<"
-                        |> String.replace "&gt;" ">"
-                        |> createCommentBlock
+                        |> Markdown.createCommentBlock
+                        |> U3.Case1
+                        |> Array.singleton
                     let result = createEmpty<Hover>
                     result.range <- range
                     result.contents <- Array.append sigContent commentContent |> ResizeArray

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -1,5 +1,6 @@
 namespace Ionide.VSCode.FSharp
 
+open System
 open Fable.Import.vscode
 
 [<RequireQualifiedAccess>]
@@ -188,6 +189,23 @@ module Markdown =
         |> List.fold (fun (res: string) pat ->
              res.Replace(pat, "")
         ) res
+
+    let createCommentBlock (comment: string) : MarkdownString =
+        comment
+        |> String.replace "&lt;" "<"
+        |> String.replace "&gt;" ">"
+        |> (fun v -> v.Split '\n')
+        |> Array.filter(String.IsNullOrWhiteSpace>>not)
+        |> Array.mapi (fun i line ->
+            let v =
+                if i = 0 && not (String.IsNullOrWhiteSpace line)
+                then "\n" + line.Trim()
+                else line.Trim()
+            replaceXml v
+            )
+        |> String.concat "\n\n"
+        |> String.trim
+        |> (fun v -> MarkdownString (v))
 
 module Promise =
     open Fable.Import.JS


### PR DESCRIPTION
Should tackle #578 while also fixing the markdown rendering of backticks, for example.

<img width="685" alt="screen shot 2017-10-06 at 6 43 48 pm" src="https://user-images.githubusercontent.com/8585995/31301704-146f6a2c-aaca-11e7-8195-d4de9e784c01.png">

Requires a pull request in ionide-vscode-helpers, [PR#16](https://github.com/ionide/ionide-vscode-helpers/pull/16), which adds support for the type MarkdownString.
