### PR TITLE
Fixes "Full name" emphasis markdown in Tooltip

### DIFF
--- a/src/Components/Tooltip.fs
+++ b/src/Components/Tooltip.fs
@@ -35,7 +35,7 @@ module Tooltip =
                         match lines |> Array.splitAt (lines.Length - 1) with
                         | (h, [| StartsWith "Full name:" fullName |]) ->
                             [| yield fsharpBlock h
-                               yield U3.Case2 ("_" + fullName + "_") |]
+                               yield U3.Case1 (MarkdownString("*").appendText(fullName).appendMarkdown("*")) |]
                         | _ -> [| fsharpBlock lines |]
 
                     let commentContent =


### PR DESCRIPTION
I noticed an error in rendering the markdown for the "Full name" block in the Tooltip. If an identifier contained underscores, it would only apply emphasis to the characters between the final 2 underscores. This changes how the markdown is applied in two ways:

1. Uses MarkdownString to escape the `fullName` text
2. Replaces the `_` with `*` for applying emphasis, described [here](http://spec.commonmark.org/0.28/#emphasis-and-strong-emphasis)

I attempted to use `_`, but it doesn't work even when appropriately escaping any characters in `fullName`; it ended up with all `_` being shown, including the leading and trailing ones. Because `*` isn't an allowable character in identifiers (per [Section 3.4](http://fsharp.org/specs/language-spec/4.0/FSharpSpec-4.0-latest.pdf)), I don't think this issue will occur again.

Old:
![name underscore error](https://user-images.githubusercontent.com/8585995/31319781-1ee99734-ac37-11e7-871d-b99bb677e6a2.png)
![name underscore error2](https://user-images.githubusercontent.com/8585995/31319780-1ee95800-ac37-11e7-9052-dee8d42f70f8.png)

Fixed:
![name underscore fix](https://user-images.githubusercontent.com/8585995/31319784-24afaff0-ac37-11e7-84ee-92f87b9566a5.png)
![name underscore fix2](https://user-images.githubusercontent.com/8585995/31319783-24af91b4-ac37-11e7-8b4d-b0d6291e94f8.png)

Edit: Issue found on macOS 10.13, VSCode 1.17, Ionide-fsharp 3.5.1