### PR TITLE
support .net core FSAC too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ paket-files
 issueList.md
 release/package-lock\.json
 *.vsix
+/release/bin_netcore/

--- a/build.fsx
+++ b/build.fsx
@@ -64,6 +64,8 @@ let vsceTool = lazy (platformTool "vsce" "vsce.cmd")
 let releaseBin      = "release/bin"
 let fsacBin         = "paket-files/github.com/fsharp/FsAutoComplete/bin/release"
 
+let releaseBinNetcore = releaseBin + "_netcore" 
+let fsacBinNetcore = fsacBin + "_netcore"
 
 // --------------------------------------------------------------------------------------
 // Build the Generator project and run it
@@ -101,6 +103,14 @@ Target "CopyFSAC" (fun _ ->
 
     !! (fsacBin + "/*")
     |> CopyFiles releaseBin
+)
+
+Target "CopyFSACNetcore" (fun _ ->
+    ensureDirectory releaseBinNetcore
+    CleanDir releaseBinNetcore
+
+    !! (fsacBinNetcore + "/*")
+    |> CopyFiles releaseBinNetcore
 )
 
 let releaseForge = "release/bin_forge"
@@ -243,6 +253,7 @@ Target "Release" DoNothing
 "Clean"
 ==> "RunScript"
 ==> "CopyFSAC"
+==> "CopyFSACNetcore"
 ==> "CopyForge"
 ==> "CopyGrammar"
 ==> "CopySchemas"

--- a/release/package.json
+++ b/release/package.json
@@ -965,6 +965,15 @@
 			"type": "object",
 			"title": "FSharp configuration",
 			"properties": {
+				"FSharp.fsacRuntime": {
+					"type": "string",
+					"default": "net",
+					"description": "Choose the runtime of FsAutocomplete (FSAC). Require restart",
+					"enum": [
+						"net",
+						"netcore"
+					]
+				},
 				"FSharp.workspaceMode": {
 					"type": "string",
 					"default": "sln",


### PR DESCRIPTION
**NOTE this require (atm) that vscode is started with `msbuild` in PATH**

fix #78

This add fsac running on .net core. that mean atm:

- run as FDD .net core 2.0 app. same binaries, run xplat.
- if fsproj target `netstandard`/`netcoreapp`, .net core sdk is the only requirement (no need for mono)
- new project parser for old fsproj, replace `projectcracker`. Require anyway .net/mono installed, because old sdk proj require .NET Full and .NET full sdk.
- new fsx args references parser for BCL references (like `system`). Require anyway mono installed, because fsx/fsi require .NET Full. But works better
- different way to see what are the .net version installed (on mono too)
- use suave v2 instead of v1

add new setting `FSharp.fsacRuntime`:

- `net` -> the .net version (default, previous behaviour)
- `netcore` -> the .net core version

the FSAC .net core is a FDD .net core console app, started as

```
dotnet release/bin_netcore/fsautocomplete.dll
```

and bundled inside ionide (like other fsac in `release/bin`)


![ionide_fsac_netcore](https://user-images.githubusercontent.com/147243/32116548-5a506712-bb4b-11e7-8948-1c1a9d508b4b.gif)
