### PR TITLE
workspace load

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -975,6 +975,15 @@
 						"ionideSearch"
 					]
 				},
+				"FSharp.workspaceLoader": {
+					"type": "string",
+					"default": "projects",
+					"description": "Choose the FSAC workspace loader",
+					"enum": [
+						"projects",
+						"workspaceLoad"
+					]
+				},
 				"FSharp.workspaceModePeekDeepLevel": {
 					"type": "integer",
 					"default": 2,

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -9,6 +9,7 @@ module DTO =
     type PositionRequest = {FileName : string; Line : int; Column : int; Filter : string}
     type CompletionRequest = {FileName : string; SourceLine : string; Line : int; Column : int; Filter : string; IncludeKeywords : bool; IncludeExternal: bool}
     type WorkspacePeekRequest = {Directory: string; Deep: int; ExcludedDirs: string[] }
+    type WorkspaceLoadRequest = { Files: string[] }
 
     type OverloadSignature = {
         Signature: string
@@ -162,6 +163,10 @@ module DTO =
     type SourceFilePath = string
     type ProjectReferencePath = string
 
+    type ProjectLoading = {
+        Project: ProjectFilePath
+    }
+
     [<RequireQualifiedAccess>]
     type ProjectResponseInfo =
       | DotnetSdk of ProjectResponseInfoDotnetSdk
@@ -272,14 +277,17 @@ module DTO =
     type ErrorCodes =
        | GenericError = 1
        | ProjectNotRestored = 100
+       | ProjectParsingFailed = 101
 
     module ErrorDataTypes =
         type ProjectNotRestoredData = { Project: ProjectFilePath }
+        type ProjectParsingFailedData = { Project: ProjectFilePath }
 
     [<RequireQualifiedAccess>]
     type ErrorData =
        | GenericError
        | ProjectNotRestored of ErrorDataTypes.ProjectNotRestoredData
+       | ProjectParsingFailed of ErrorDataTypes.ProjectParsingFailedData
 
     type UnusedDeclaration = {
         Range: Range
@@ -315,6 +323,7 @@ module DTO =
     type DeclarationResult = Result<Symbols[]>
     type LintResult = Result<Lint[]>
     type ProjectResult = Result<Project>
+    type ProjectLoadingResult = Result<ProjectLoading>
     type ResolveNamespaceResult = Result<ResolveNamespace>
     type UnionCaseGeneratorResult = Result<UnionCaseGenerator>
     type SignatureDataResult = Result<SignatureData>

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -403,8 +403,12 @@ module LanguageService =
                 res?Data |> parseError |> Choice3Of3 |> cb
             | _ ->
                 ()
-        socketNotifyWorkspace
-        |> Option.iter (registerNotifyAll onMessage) 
+
+        match socketNotifyWorkspace with
+        | None -> false
+        | Some ws ->
+            ws |> registerNotifyAll onMessage
+            true
 
     let private startSocket notificationEvent =
         let address = sprintf "ws://localhost:%s/%s" port notificationEvent

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -435,7 +435,6 @@ module LanguageService =
             )
             |> ignore
         )
-        |> Promise.onSuccess (fun _ -> startSocket ())
         |> Promise.onFail (fun err ->
             log.Error("Failed to start language services. %s", err)
             if Process.isMono () then
@@ -453,7 +452,9 @@ module LanguageService =
             with
             | _ -> (VSCode.getPluginPath "Ionide.Ionide-fsharp") + "/bin/fsautocomplete.exe"
 
-         if devMode then Promise.empty else start' path
+         let startByDevMode = if devMode then Promise.empty else start' path
+         startByDevMode
+         |> Promise.onSuccess (fun _ -> startSocket ())
 
     let stop () =
         service |> Option.iter (fun n -> n.kill "SIGKILL")


### PR DESCRIPTION
use new FSAC `workspaceLoad` command, instead of multiple `project` command

command is async, and project loading status (inprogress/loaded/failed) is back
as notification

add setting `FSharp.workspaceLoader` :

- `projects` send to FSAC multiple "project" command (default, old behaviour)
- `workspaceLoad` send to FSAC the "workspaceLoad" command and use notifications
