### PR TITLE
move excepto default arg '--summary-location' to customArgs config

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1074,7 +1074,7 @@
 				},
 				"Expecto.customArgs": {
 					"type": "string",
-					"default": "",
+					"default": "--summary-location",
 					"description": "Run Expecto tests with additional custom arguments"
 				},
 				"Expecto.autoshow": {

--- a/src/Components/Expecto.fs
+++ b/src/Components/Expecto.fs
@@ -301,7 +301,7 @@ module Expecto =
                         Promise.empty)
             else Promise.empty)
 
-    let private runAll watchMode = runExpecto watchMode "--summary-location"
+    let private runAll watchMode = runExpecto watchMode ""
 
     let private getTestCases () =
         buildExpectoProjects false
@@ -348,7 +348,7 @@ module Expecto =
         window.showQuickPick (U2.Case2 (getTestLists() ))
         |> Promise.bind(fun n ->
             if JS.isDefined n then
-                (sprintf "--filter \"%s\" --summary-location" n) |> runExpecto false
+                (sprintf "--filter \"%s\"" n) |> runExpecto false
             else
                 Promise.empty
         )
@@ -357,7 +357,7 @@ module Expecto =
         getFailed ()
         |> Seq.map fst
         |> String.concat " "
-        |> sprintf "--run %s --summary-location"
+        |> sprintf "--run %s"
         |> runExpecto false
 
     let private onFileChanged (uri : Uri) =


### PR DESCRIPTION
so the default behavior does not change, but user can decide whether
or not they want to show the summary info. they can change the
customArgs in config as they want.

which can cover issue like this:  #631 

**should take with https://github.com/ionide/ionide-vscode-helpers/pull/17 , because this dependency is reference as github file**

e.g. :  https://gist.github.com/lust4life/1a4c25ec3b0fdec0056172cf62cd135e

without `Expecto.customArgs` configed, just the same like previous version: 
![image](https://user-images.githubusercontent.com/3074328/32891961-92c1dfb2-cb0f-11e7-849d-ba1a468dd23d.png)

with `Expecto.customArgs` configed:  `"Expecto.customArgs": ""`

![image](https://user-images.githubusercontent.com/3074328/32891589-1a5ce8d8-cb0e-11e7-9660-65cd6371ee54.png)

in the one below ,I can easily know that there is 1 passed, 16 ignored, 1 failed. and jump to the source code location of the failed one.

maybe helpful for some people.