### PR TITLE
fix forge project creation if choosen directory name is blank

### DIFF
--- a/src/Components/Forge.fs
+++ b/src/Components/Forge.fs
@@ -258,7 +258,7 @@ module Forge =
                             if JS.isDefined dir && JS.isDefined name then
                                 if name <> "" then
                                     let msg = window.setStatusBarMessage "Creating project..."
-                                    sprintf "new project -n %s -t %s --folder %s" name template.label dir
+                                    sprintf """new project -n "%s" -t %s --folder "%s" """ name template.label dir
                                     |> spawnForge
                                     |> Process.toPromise
                                     |> Promise.bind (fun _ ->


### PR DESCRIPTION
fix https://github.com/ionide/ionide-vscode-fsharp/issues/652

@Krzysztof-Cieslak as a note, i tried to not pass `--folder` is was choosen dir name empty (so forge can choose the default), but forge waited for the dirname as input in the doutput panel (i think the `--no-prompt` was not considered)
