### PR TITLE
fix project loading stuck, if a project was failing to load

### DIFF
--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -153,6 +153,8 @@ module LanguageService =
             match err with
             | ErrorData.GenericError ->
                 ""
+            | ErrorData.ProjectParsingFailed data ->
+                sprintf "'%s'" data.Project
             | ErrorData.ProjectNotRestored data ->
                 sprintf "'%s'" data.Project
         sprintf "%s, %s %s" whenMsg msg d


### PR DESCRIPTION
fix https://github.com/ionide/ionide-vscode-fsharp/issues/662

When F# compiler tell you there is a warning, fix it. Sigh

> WARNING in ./src/Ionide.FSharp.fsproj
e:/github/ionide-vscode-fsharp/src/Core/LanguageService.fs(154,18): (154,21) warning FSHARP: Incomplete pattern matches on this expression. For example, the value 'ProjectParsingFailed (_)' may indicate a case not covered by the pattern(s).
