### PR TITLE
Optionally disables parsing of dependent projects in the background 

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1163,6 +1163,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enables Code Outline tree view. Requires restart"
+				},
+				"FSharp.minimizeBackgroundParsing": {
+					"type": "boolean",
+					"default": false,
+					"description": "Minimize the amount of background type-checking of dependent projects. Requires restart.\nThis is a performance workaround that will increase intellisense responsiveness for projects that are referenced by many other projects in the solution."
 				}
 			}
 		},

--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -146,7 +146,7 @@ module Errors =
 
 
     let activate (context: ExtensionContext) =
-        let allowBackgroundParsing = "FSharp.minimizeBackgroundParsing" |> Configuration.get true
+        let allowBackgroundParsing = not ("FSharp.minimizeBackgroundParsing" |> Configuration.get false)
         
         workspace.onDidChangeTextDocument $ (handler,(), context.subscriptions) |> ignore
         window.onDidChangeActiveTextEditor $ (handlerOpen allowBackgroundParsing, (), context.subscriptions) |> ignore


### PR DESCRIPTION
... on file open/save. This is a workaround for intellisense performance issues in large solutions where some projects are referenced by many other projects.