### PR TITLE
Fix run Expecto tests unquoted project file path bug.

### DIFF
--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -337,13 +337,13 @@ module Project =
     let buildWithMsbuild outputChannel (project:Project) =
         promise {
             let! msbuild = Environment.msbuild
-            return! Process.spawnWithNotification msbuild "" project.Project outputChannel
+            return! Process.spawnWithNotification msbuild "" project.ProjectQuoted outputChannel
             |> Process.toPromise
         }
 
     let buildWithDotnet outputChannel (project:Project) =
         promise {
-            let! childProcess = execWithDotnet outputChannel ("build " + project.Project)
+            let! childProcess = execWithDotnet outputChannel ("build " + project.ProjectQuoted)
             return!
                 childProcess
                 |> Process.toPromise
@@ -351,7 +351,7 @@ module Project =
 
     let getLauncher outputChannel (project:Project) =
         let execDotnet = fun args ->
-            let cmd = "run -p " + project.Project + if String.IsNullOrEmpty args then "" else " -- " + args
+            let cmd = "run -p " + project.ProjectQuoted + if String.IsNullOrEmpty args then "" else " -- " + args
             execWithDotnet outputChannel cmd
         match project.Output, isANetCoreAppProject project with
         | _, true -> Some execDotnet
@@ -360,7 +360,7 @@ module Project =
 
     let getLauncherWithShell  (project:Project) =
         let execDotnet = fun args ->
-            let cmd = "run -p " + project.Project + if String.IsNullOrEmpty args then "" else " -- " + args
+            let cmd = "run -p " + project.ProjectQuoted + if String.IsNullOrEmpty args then "" else " -- " + args
             execWithDotnetWithShell cmd
         match project.Output, isANetCoreAppProject project with
         | _, true -> Some execDotnet

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -337,13 +337,13 @@ module Project =
     let buildWithMsbuild outputChannel (project:Project) =
         promise {
             let! msbuild = Environment.msbuild
-            return! Process.spawnWithNotification msbuild "" project.ProjectQuoted outputChannel
+            return! Process.spawnWithNotification msbuild "" (String.quote project.Project) outputChannel
             |> Process.toPromise
         }
 
     let buildWithDotnet outputChannel (project:Project) =
         promise {
-            let! childProcess = execWithDotnet outputChannel ("build " + project.ProjectQuoted)
+            let! childProcess = execWithDotnet outputChannel ("build " + (String.quote project.Project))
             return!
                 childProcess
                 |> Process.toPromise
@@ -351,7 +351,7 @@ module Project =
 
     let getLauncher outputChannel (project:Project) =
         let execDotnet = fun args ->
-            let cmd = "run -p " + project.ProjectQuoted + if String.IsNullOrEmpty args then "" else " -- " + args
+            let cmd = "run -p " + (String.quote project.Project) + if String.IsNullOrEmpty args then "" else " -- " + args
             execWithDotnet outputChannel cmd
         match project.Output, isANetCoreAppProject project with
         | _, true -> Some execDotnet
@@ -360,7 +360,7 @@ module Project =
 
     let getLauncherWithShell  (project:Project) =
         let execDotnet = fun args ->
-            let cmd = "run -p " + project.ProjectQuoted + if String.IsNullOrEmpty args then "" else " -- " + args
+            let cmd = "run -p " + (String.quote project.Project) + if String.IsNullOrEmpty args then "" else " -- " + args
             execWithDotnetWithShell cmd
         match project.Output, isANetCoreAppProject project with
         | _, true -> Some execDotnet

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -53,7 +53,14 @@ module String =
     let endWith ending (s : string) = s.EndsWith ending
 
     let startWith ending (s : string) = s.StartsWith ending
-    let quote (s: string) = sprintf @"""%s""" s
+    let quote (s : string) =
+        let isQuoted (s : string) = s.StartsWith @"""" && s.EndsWith @"""" 
+        let containsWhitespace = Seq.exists Char.IsWhiteSpace
+        let quote = sprintf @"""%s"""
+        match s with
+        | s when s |> isQuoted |> not && s |> containsWhitespace -> quote s
+        | s -> s
+
 
 [<RequireQualifiedAccess>]
 module Option =
@@ -84,9 +91,6 @@ module Utils =
     type System.Collections.Generic.Dictionary<'key, 'value> with
         [<Emit("$0.has($1) ? $0.get($1) : null")>]
         member this.TryGet(key: 'key): 'value option = jsNative
-
-    type DTO.Project with
-        member this.ProjectQuoted = String.quote this.Project
 
 [<AutoOpen>]
 module JS =

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -53,7 +53,7 @@ module String =
     let endWith ending (s : string) = s.EndsWith ending
 
     let startWith ending (s : string) = s.StartsWith ending
-
+    let quote (s: string) = sprintf @"""%s""" s
 
 [<RequireQualifiedAccess>]
 module Option =
@@ -84,6 +84,9 @@ module Utils =
     type System.Collections.Generic.Dictionary<'key, 'value> with
         [<Emit("$0.has($1) ? $0.get($1) : null")>]
         member this.TryGet(key: 'key): 'value option = jsNative
+
+    type DTO.Project with
+        member this.ProjectQuoted = String.quote this.Project
 
 [<AutoOpen>]
 module JS =


### PR DESCRIPTION
Fixes #680.

Tested with core and classic .net framework projects with Expecto tests and previously failing path.

If we decide to merge it in this form then it would probably be better to change `MSBuild.invokeMSBuild` as it does the quoting thing on it's own.