### PR TITLE
Fix infinite restore loop

### DIFF
--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -71,7 +71,7 @@ module Errors =
             | Choice2Of3 () -> Promise.lift None
             | Choice3Of3 (Some p) ->
                 p
-                |> Project.load
+                |> Project.load false
                 |> Promise.bind (fun _ -> parse file)
             | Choice3Of3 None -> parse file
         | _ -> Promise.lift None

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -11,9 +11,6 @@ open Ionide.VSCode.Helpers
 open DTO
 
 module Project =
-    let outputChannel = window.createOutputChannel "project"
-    let private logger = ConsoleAndOutputChannelLogger(Some "project", Level.DEBUG, Some outputChannel, Some Level.DEBUG)
-
     [<RequireQualifiedAccess>]
     type ProjectLoadingState =
         | Loading of path: string
@@ -40,7 +37,7 @@ module Project =
     let workspaceChanged = EventEmitter<WorkspacePeekFound>()
     let projectNotRestoredLoaded = EventEmitter<string>()
     let projectLoaded = EventEmitter<Project>()
-    let workspaceLoaded = EventEmitter<unit>() 
+    let workspaceLoaded = EventEmitter<unit>()
 
     let excluded = "FSharp.excludeProjectDirectories" |> Configuration.get [| ".git"; "paket-files" |]
     let deepLevel = "FSharp.workspaceModePeekDeepLevel" |> Configuration.get 2 |> max 0
@@ -132,7 +129,6 @@ module Project =
             let (msg: string), (err: ErrorData) = unbox b
             match err with
             | ErrorData.ProjectNotRestored _d when not commingFromFailedRestore ->
-                logger.Debug("ProjectNotRestored %A", path)
                 projectNotRestoredLoaded.fire path
                 Some (path, ProjectLoadingState.NotRestored (path, msg) )
             | _ ->
@@ -455,11 +451,11 @@ module Project =
                     Some (true, d.Project, ProjectLoadingState.Failed (d.Project, msg) )
                 | _ ->
                     None
-            | Choice4Of4 msg -> 
+            | Choice4Of4 msg ->
                 match msg with
-                | "finished" -> 
-                    workspaceLoaded.fire () 
-                    None 
+                | "finished" ->
+                    workspaceLoaded.fire ()
+                    None
                 | _ -> None
 
         match projStatus with

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -12,7 +12,7 @@ open Debugger
 
 type Api = {
     ProjectLoadedEvent: Event<DTO.Project>
-    BuildProject: DTO.Project -> Fable.Import.JS.Promise<string>
+    BuildProject: DTO.Project -> Fable.Import.JS.Promise<bool>
     GetProjectLauncher: OutputChannel -> DTO.Project -> (string -> Fable.Import.JS.Promise<ChildProcess>) option
     DebugProject: DTO.Project -> string [] -> Fable.Import.JS.Promise<unit>
 }


### PR DESCRIPTION
This avoid the case where a restore failed, triggering a project load, triggering a restore, and looping infinitely like that.

I had noticed the high CPU usage but never really cared. But I investigated as it triggered https://github.com/enricosada/dotnet-proj-info/issues/13