### PR TITLE
More infinite loop avoidance

### DIFF
--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -2,6 +2,8 @@ namespace Ionide.VSCode.FSharp
 
 [<AutoOpen>]
 module Logging =
+    open Fable.Core
+    open Fable.Core.JsInterop
     open Fable.Import.Node
     open Fable.Import.vscode
     open Ionide.VSCode.FSharp.Node.Util
@@ -18,17 +20,25 @@ module Logging =
 
     let getIonideLogs () = ionideLogsMemory |> String.concat "\n"
 
-    let private writeDevToolsConsole (level: Level) (source: string option) (template: string) (args: obj[]) =
+    [<Emit("console[$0]($1...)")>]
+    let private consoleLog (_level: string, [<ParamListAttribute>] _args: obj list): unit = failwith "JS only"
+
+    let getConsoleLogArgs (level: Level) (source: string option) (template: string) (args: obj[]) =
         // just replace %j (Util.format->JSON specifier --> console->OBJECT %O specifier)
         // the other % specifiers are basically the same
         let browserLogTemplate = String.Format("[{0}] {1}", source.ToString(), template.Replace("%j", "%O"))
-        match args.Length with
-        | 0 -> Fable.Import.Browser.console.log (browserLogTemplate)
-        | 1 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0])
-        | 2 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1])
-        | 3 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1], args.[2])
-        | 4 -> Fable.Import.Browser.console.log (browserLogTemplate, args.[0], args.[1], args.[2], args.[3])
-        | _ -> Fable.Import.Browser.console.log (browserLogTemplate, args)
+        let nameOnConsoleObject =
+            match level with
+            | DEBUG -> "debug"
+            | INFO -> "info"
+            | WARN -> "warn"
+            | ERROR -> "error"
+        let argList = args |> List.ofArray
+        nameOnConsoleObject, (List.append [ box browserLogTemplate ] argList)
+
+    let inline private writeDevToolsConsole (level: Level) (source: string option) (template: string) (args: obj[]) =
+        let nameOnConsoleObject, logArgs = getConsoleLogArgs level source template args
+        consoleLog(nameOnConsoleObject, logArgs)
 
     let private writeOutputChannel (out: OutputChannel) level source template args =
         let formattedMessage = Util.format(template, args)
@@ -44,16 +54,12 @@ module Logging =
         else
             ionideLogsMemory <- ionideLogsMemory @ [formattedLogLine]
 
-    let private writeBothIfConfigured (out: OutputChannel option)
+    let private writeOutputChannelIfConfigured (out: OutputChannel option)
               (chanMinLevel: Level)
-              (consoleMinLevel: Level option)
               (level: Level)
               (source: string option)
               (template: string)
               (args: obj[]) =
-        if consoleMinLevel.IsSome && level.isGreaterOrEqualTo(consoleMinLevel.Value) then
-            writeDevToolsConsole level source template args
-
         if out.IsSome && level.isGreaterOrEqualTo(chanMinLevel) then
             writeOutputChannel out.Value level source template args
 
@@ -64,6 +70,18 @@ module Logging =
                     writeToFile level template args
             with
                 | _ -> () // Do nothing
+
+    let inline private writeBothIfConfigured (out: OutputChannel option)
+              (chanMinLevel: Level)
+              (consoleMinLevel: Level option)
+              (level: Level)
+              (source: string option)
+              (template: string)
+              (args: obj[]) =
+        if consoleMinLevel.IsSome && level.isGreaterOrEqualTo(consoleMinLevel.Value) then
+            writeDevToolsConsole level source template args
+
+        writeOutputChannelIfConfigured out chanMinLevel level source template args
 
     /// The templates may use node util.format placeholders: %s, %d, %j, %%
     /// https://nodejs.org/api/util.html#util_util_format_format

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -116,7 +116,7 @@ module Project =
         loadedProjects <- emptyProjectsMap
         setAnyProjectContext false
 
-    let load commingFromFailedRestore (path:string) =
+    let load commingFromRestore (path:string) =
         updateInWorkspace path (ProjectLoadingState.Loading path)
 
         let loaded (pr:ProjectResult) =
@@ -128,7 +128,7 @@ module Project =
         let failed (b: obj) =
             let (msg: string), (err: ErrorData) = unbox b
             match err with
-            | ErrorData.ProjectNotRestored _d when not commingFromFailedRestore ->
+            | ErrorData.ProjectNotRestored _d when not commingFromRestore ->
                 projectNotRestoredLoaded.fire path
                 Some (path, ProjectLoadingState.NotRestored (path, msg) )
             | _ ->


### PR DESCRIPTION
This solve the infinite loop problem for me (🙌 🙌 🙌)

2 Main changes:
* If a restore failed, load isn't called, it will fail with "restore missing" anyway.
* If a restore succeed but load fail due to "restore missing" (Should not happens but happens on at least one of our projects) restore isn't called again.

Another change is that the logs to the dev console are now tagged with their level so they can be filtered with the normal filtering UI of the devtools