### PR TITLE
Fix #773 --no-prompt project directory.

### DIFF
--- a/src/Components/Forge.fs
+++ b/src/Components/Forge.fs
@@ -55,7 +55,7 @@ module Forge =
 
     let private quotePath (path : string) =
         if JS.isDefined path then
-            if path.Contains " " then "\"" + path + "\"" else path
+            if path = "" || path.Contains " " then "\"" + path + "\"" else path
         else
             path
     let moveFileUpPath path =


### PR DESCRIPTION
## Problem:

~~Providing empty string in vscode input results with using "--no-prompt" as project directory.~~
When provided with empty project directory string we should pass it to forge call as quoted empty string.

## My solution:

~~I have added empty string check and error message for project directory.~~
Added empty string case to `quotePath`.

## ~~Alternatives:~~

1. ~~Changing Forge behavior as atm Forge needs the project directory - if you don't supply it in args it will prompt for it (even with --no-prompt switch).~~
2. ~~Default, nonempty, project directory?~~


