### PR TITLE
Only use log levels that exists

### DIFF
--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -29,7 +29,7 @@ module Logging =
         let browserLogTemplate = String.Format("[{0}] {1}", source.ToString(), template.Replace("%j", "%O"))
         let nameOnConsoleObject =
             match level with
-            | DEBUG -> "debug"
+            | DEBUG -> "log"
             | INFO -> "info"
             | WARN -> "warn"
             | ERROR -> "error"

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -20,7 +20,7 @@ module Logging =
 
     let getIonideLogs () = ionideLogsMemory |> String.concat "\n"
 
-    [<Emit("console[$0]($1...)")>]
+    [<Emit("console[$0] ? console[$0]($1...) : void 0")>]
     let private consoleLog (_level: string, [<ParamListAttribute>] _args: obj list): unit = failwith "JS only"
 
     let getConsoleLogArgs (level: Level) (source: string option) (template: string) (args: obj[]) =
@@ -29,7 +29,7 @@ module Logging =
         let browserLogTemplate = String.Format("[{0}] {1}", source.ToString(), template.Replace("%j", "%O"))
         let nameOnConsoleObject =
             match level with
-            | DEBUG -> "log"
+            | DEBUG -> "debug"
             | INFO -> "info"
             | WARN -> "warn"
             | ERROR -> "error"


### PR DESCRIPTION
It seem that the way vscode exposes console.debug is special and only accessible when vscode itself is being debugged.

As it works when debugging vscode itself I didn't see it before the final version was released.

This PR check if a log level exists before using it.