### PR TITLE
Fix a bug I introduced in code outline

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -430,7 +430,7 @@
 				{
 					"id": "ionide.codeOutline",
 					"name": "Code Outline",
-					"when": "fsharp.project.any && fsharp.showCodeOutlineInFsharpActivity"
+					"when": "fsharp.showCodeOutline && fsharp.showCodeOutlineInFsharpActivity"
 				}
 			]
 		},
@@ -1156,7 +1156,8 @@
 				"FSharp.codeOutline": {
 					"type": "boolean",
 					"default": true,
-					"description": "Enables Code Outline tree view."
+					"description": "Enables Code Outline tree view.",
+					"scope": "resource"
 				},
 				"FSharp.minimizeBackgroundParsing": {
 					"type": "boolean",


### PR DESCRIPTION
Mainly it was always there (but empty) when the new activity mode was enabled and  it was disabled.

(I always disable it 😉)