### PR TITLE
Use a different ID for views in the fsharp activity container

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -423,12 +423,12 @@
 			],
 			"ionide-fsharp": [
 				{
-					"id": "ionide.projectExplorer",
+					"id": "ionide.projectExplorerInActivity",
 					"name": "Project Explorer",
 					"when": "fsharp.project.any && fsharp.showProjectExplorerInFsharpActivity"
 				},
 				{
-					"id": "ionide.codeOutline",
+					"id": "ionide.codeOutlineInActivity",
 					"name": "Code Outline",
 					"when": "fsharp.showCodeOutline && fsharp.showCodeOutlineInFsharpActivity"
 				}
@@ -633,10 +633,22 @@
 					"when": "view == ionide.projectExplorer"
 				},
 				{
+					"command": "fsharp.NewProject",
+					"group": "navigation@1",
+					"alt": "fsharp.NewProjectNoFake",
+					"when": "view == ionide.projectExplorerInActivity"
+				},
+				{
 					"command": "fsharp.debugDefaultProject",
 					"group": "navigation@2",
 					"alt": "fsharp.runDefaultProject",
 					"when": "view == ionide.projectExplorer"
+				},
+				{
+					"command": "fsharp.debugDefaultProject",
+					"group": "navigation@2",
+					"alt": "fsharp.runDefaultProject",
+					"when": "view == ionide.projectExplorerInActivity"
 				},
 				{
 					"command": "fsharp.changeWorkspace",
@@ -644,9 +656,19 @@
 					"when": "view == ionide.projectExplorer"
 				},
 				{
+					"command": "fsharp.changeWorkspace",
+					"group": "modification@1",
+					"when": "view == ionide.projectExplorerInActivity"
+				},
+				{
 					"command": "fsharp.explorer.msbuild.pickHost",
 					"group": "modification@2",
 					"when": "view == ionide.projectExplorer"
+				},
+				{
+					"command": "fsharp.explorer.msbuild.pickHost",
+					"group": "modification@2",
+					"when": "view == ionide.projectExplorerInActivity"
 				},
 				{
 					"command": "fsharp.chooseDefaultProject",
@@ -654,9 +676,19 @@
 					"when": "view == ionide.projectExplorer"
 				},
 				{
+					"command": "fsharp.chooseDefaultProject",
+					"group": "modification@3",
+					"when": "view == ionide.projectExplorerInActivity"
+				},
+				{
 					"command": "fsharp.explorer.refresh",
 					"group": "modification@4",
 					"when": "view == ionide.projectExplorer"
+				},
+				{
+					"command": "fsharp.explorer.refresh",
+					"group": "modification@4",
+					"when": "view == ionide.projectExplorerInActivity"
 				},
 				{
 					"command": "fsharp.explorer.clearCache",
@@ -664,222 +696,238 @@
 					"when": "view == ionide.projectExplorer"
 				},
 				{
+					"command": "fsharp.explorer.clearCache",
+					"group": "modification@5",
+					"when": "view == ionide.projectExplorerInActivity"
+				},
+				{
 					"command": "ionide.codeOutline.collapseDefault",
 					"group": "navigation@1",
 					"when": "view == ionide.codeOutline"
+				},
+				{
+					"command": "ionide.codeOutline.collapseDefault",
+					"group": "navigation@1",
+					"when": "view == ionide.codeOutlineInActivity"
 				},
 				{
 					"command": "ionide.codeOutline.collapseAll",
 					"alt": "ionide.codeOutline.expandAll",
 					"group": "navigation@2",
 					"when": "view == ionide.codeOutline"
+				},
+				{
+					"command": "ionide.codeOutline.collapseAll",
+					"alt": "ionide.codeOutline.expandAll",
+					"group": "navigation@2",
+					"when": "view == ionide.codeOutlineInActivity"
 				}
 			],
 			"view/item/context": [
 				{
 					"command": "fsharp.explorer.moveUp",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.file",
+					"when": "viewItem ==ionide.projectExplorer.file",
 					"group": "1_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.moveDown",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.file",
+					"when": "viewItem ==ionide.projectExplorer.file",
 					"group": "1_navigation@2"
 				},
 				{
 					"command": "fsharp.explorer.moveToFolder",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.file",
+					"when": "viewItem ==ionide.projectExplorer.file",
 					"group": "1_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.removeFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.file",
+					"when": "viewItem ==ionide.projectExplorer.file",
 					"group": "1_navigation@4"
 				},
 				{
 					"command": "fsharp.explorer.renameFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.file",
+					"when": "viewItem ==ionide.projectExplorer.file",
 					"group": "2_modification@1"
 				},
 				{
 					"command": "fsharp.explorer.addAbove",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.file",
+					"when": "viewItem ==ionide.projectExplorer.file",
 					"group": "3_add@1"
 				},
 				{
 					"command": "fsharp.explorer.addBelow",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.file",
+					"when": "viewItem ==ionide.projectExplorer.file",
 					"group": "3_add@2"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectNotLoaded"
+					"when": "viewItem ==ionide.projectExplorer.projectNotLoaded"
 				},
 				{
 					"command": "fsharp.explorer.showProjectLoadFailedInfo",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectLoadFailed"
+					"when": "viewItem ==ionide.projectExplorer.projectLoadFailed"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectLoadFailed"
+					"when": "viewItem ==ionide.projectExplorer.projectLoadFailed"
 				},
 				{
 					"command": "fsharp.explorer.showProjectStatus",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectLoading"
+					"when": "viewItem ==ionide.projectExplorer.projectLoading"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectLoading"
+					"when": "viewItem ==ionide.projectExplorer.projectLoading"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectNotRestored"
+					"when": "viewItem ==ionide.projectExplorer.projectNotRestored"
 				},
 				{
 					"command": "fsharp.explorer.showProjectStatus",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectNotRestored"
+					"when": "viewItem ==ionide.projectExplorer.projectNotRestored"
 				},
 				{
 					"command": "fsharp.explorer.addProjecRef",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectRefList"
+					"when": "viewItem ==ionide.projectExplorer.projectRefList"
 				},
 				{
 					"command": "fsharp.explorer.removeProjecRef",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projRef"
+					"when": "viewItem ==ionide.projectExplorer.projRef"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+					"when": "viewItem ==ionide.projectExplorer.project",
 					"group": "4_derails@1"
 				},
 				{
 					"command": "fsharp.explorer.showProjectStatus",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+					"when": "viewItem ==ionide.projectExplorer.project",
 					"group": "4_details@2"
 				},
 				{
 					"command": "fsharp.explorer.addFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+					"when": "viewItem ==ionide.projectExplorer.project",
 					"group": "2_modifications@2"
 				},
 				{
 					"command": "fsharp.explorer.project.generateFSI",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+					"when": "viewItem ==ionide.projectExplorer.project",
 					"group": "3_fsi@1"
 				},
 				{
 					"command": "fsharp.explorer.project.sendFSI",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+					"when": "viewItem ==ionide.projectExplorer.project",
 					"group": "3_fsi@2"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.build",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+					"when": "viewItem ==ionide.projectExplorer.project",
 					"group": "1_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.rebuild",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+					"when": "viewItem ==ionide.projectExplorer.project",
 					"group": "1_navigation@2"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.clean",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+					"when": "viewItem ==ionide.projectExplorer.project",
 					"group": "1_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.restore",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.project",
+					"when": "viewItem ==ionide.projectExplorer.project",
 					"group": "1_navigation@4"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.restore",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectNotRestored",
+					"when": "viewItem ==ionide.projectExplorer.projectNotRestored",
 					"group": "1_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.solution.build",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.solution",
+					"when": "viewItem ==ionide.projectExplorer.solution",
 					"group": "1_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.solution.rebuild",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.solution",
+					"when": "viewItem ==ionide.projectExplorer.solution",
 					"group": "1_navigation@2"
 				},
 				{
 					"command": "fsharp.explorer.solution.clean",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.solution",
+					"when": "viewItem ==ionide.projectExplorer.solution",
 					"group": "1_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.solution.restore",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.solution",
+					"when": "viewItem ==ionide.projectExplorer.solution",
 					"group": "1_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.solution.addProject",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.solution",
+					"when": "viewItem ==ionide.projectExplorer.solution",
 					"group": "2_modification@1"
 				},
 				{
 					"command": "fsharp.explorer.addFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "3_modifications@2"
 				},
 				{
 					"command": "fsharp.explorer.project.generateFSI",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "4_fsi@1"
 				},
 				{
 					"command": "fsharp.explorer.project.sendFSI",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "4_fsi@2"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "5_detail@1"
 				},
 				{
 					"command": "fsharp.explorer.showProjectStatus",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "5_detail@2"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.build",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "2_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.rebuild",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "2_navigation@2"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.clean",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "2_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.restore",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "2_navigation@4"
 				},
 				{
 					"command": "fsharp.explorer.project.run",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "1_run@1"
 				},
 				{
 					"command": "fsharp.explorer.project.debug",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "1_run@2"
 				},
 				{
 					"command": "fsharp.explorer.project.setDefault",
-					"when": "view == ionide.projectExplorer && viewItem == ionide.projectExplorer.projectExe",
+					"when": "viewItem ==ionide.projectExplorer.projectExe",
 					"group": "1_run@3"
 				}
 			],

--- a/release/package.json
+++ b/release/package.json
@@ -726,208 +726,208 @@
 			"view/item/context": [
 				{
 					"command": "fsharp.explorer.moveUp",
-					"when": "viewItem ==ionide.projectExplorer.file",
+					"when": "viewItem == ionide.projectExplorer.file",
 					"group": "1_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.moveDown",
-					"when": "viewItem ==ionide.projectExplorer.file",
+					"when": "viewItem == ionide.projectExplorer.file",
 					"group": "1_navigation@2"
 				},
 				{
 					"command": "fsharp.explorer.moveToFolder",
-					"when": "viewItem ==ionide.projectExplorer.file",
+					"when": "viewItem == ionide.projectExplorer.file",
 					"group": "1_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.removeFile",
-					"when": "viewItem ==ionide.projectExplorer.file",
+					"when": "viewItem == ionide.projectExplorer.file",
 					"group": "1_navigation@4"
 				},
 				{
 					"command": "fsharp.explorer.renameFile",
-					"when": "viewItem ==ionide.projectExplorer.file",
+					"when": "viewItem == ionide.projectExplorer.file",
 					"group": "2_modification@1"
 				},
 				{
 					"command": "fsharp.explorer.addAbove",
-					"when": "viewItem ==ionide.projectExplorer.file",
+					"when": "viewItem == ionide.projectExplorer.file",
 					"group": "3_add@1"
 				},
 				{
 					"command": "fsharp.explorer.addBelow",
-					"when": "viewItem ==ionide.projectExplorer.file",
+					"when": "viewItem == ionide.projectExplorer.file",
 					"group": "3_add@2"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "viewItem ==ionide.projectExplorer.projectNotLoaded"
+					"when": "viewItem == ionide.projectExplorer.projectNotLoaded"
 				},
 				{
 					"command": "fsharp.explorer.showProjectLoadFailedInfo",
-					"when": "viewItem ==ionide.projectExplorer.projectLoadFailed"
+					"when": "viewItem == ionide.projectExplorer.projectLoadFailed"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "viewItem ==ionide.projectExplorer.projectLoadFailed"
+					"when": "viewItem == ionide.projectExplorer.projectLoadFailed"
 				},
 				{
 					"command": "fsharp.explorer.showProjectStatus",
-					"when": "viewItem ==ionide.projectExplorer.projectLoading"
+					"when": "viewItem == ionide.projectExplorer.projectLoading"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "viewItem ==ionide.projectExplorer.projectLoading"
+					"when": "viewItem == ionide.projectExplorer.projectLoading"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "viewItem ==ionide.projectExplorer.projectNotRestored"
+					"when": "viewItem == ionide.projectExplorer.projectNotRestored"
 				},
 				{
 					"command": "fsharp.explorer.showProjectStatus",
-					"when": "viewItem ==ionide.projectExplorer.projectNotRestored"
+					"when": "viewItem == ionide.projectExplorer.projectNotRestored"
 				},
 				{
 					"command": "fsharp.explorer.addProjecRef",
-					"when": "viewItem ==ionide.projectExplorer.projectRefList"
+					"when": "viewItem == ionide.projectExplorer.projectRefList"
 				},
 				{
 					"command": "fsharp.explorer.removeProjecRef",
-					"when": "viewItem ==ionide.projectExplorer.projRef"
+					"when": "viewItem == ionide.projectExplorer.projRef"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "viewItem ==ionide.projectExplorer.project",
+					"when": "viewItem == ionide.projectExplorer.project",
 					"group": "4_derails@1"
 				},
 				{
 					"command": "fsharp.explorer.showProjectStatus",
-					"when": "viewItem ==ionide.projectExplorer.project",
+					"when": "viewItem == ionide.projectExplorer.project",
 					"group": "4_details@2"
 				},
 				{
 					"command": "fsharp.explorer.addFile",
-					"when": "viewItem ==ionide.projectExplorer.project",
+					"when": "viewItem == ionide.projectExplorer.project",
 					"group": "2_modifications@2"
 				},
 				{
 					"command": "fsharp.explorer.project.generateFSI",
-					"when": "viewItem ==ionide.projectExplorer.project",
+					"when": "viewItem == ionide.projectExplorer.project",
 					"group": "3_fsi@1"
 				},
 				{
 					"command": "fsharp.explorer.project.sendFSI",
-					"when": "viewItem ==ionide.projectExplorer.project",
+					"when": "viewItem == ionide.projectExplorer.project",
 					"group": "3_fsi@2"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.build",
-					"when": "viewItem ==ionide.projectExplorer.project",
+					"when": "viewItem == ionide.projectExplorer.project",
 					"group": "1_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.rebuild",
-					"when": "viewItem ==ionide.projectExplorer.project",
+					"when": "viewItem == ionide.projectExplorer.project",
 					"group": "1_navigation@2"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.clean",
-					"when": "viewItem ==ionide.projectExplorer.project",
+					"when": "viewItem == ionide.projectExplorer.project",
 					"group": "1_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.restore",
-					"when": "viewItem ==ionide.projectExplorer.project",
+					"when": "viewItem == ionide.projectExplorer.project",
 					"group": "1_navigation@4"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.restore",
-					"when": "viewItem ==ionide.projectExplorer.projectNotRestored",
+					"when": "viewItem == ionide.projectExplorer.projectNotRestored",
 					"group": "1_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.solution.build",
-					"when": "viewItem ==ionide.projectExplorer.solution",
+					"when": "viewItem == ionide.projectExplorer.solution",
 					"group": "1_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.solution.rebuild",
-					"when": "viewItem ==ionide.projectExplorer.solution",
+					"when": "viewItem == ionide.projectExplorer.solution",
 					"group": "1_navigation@2"
 				},
 				{
 					"command": "fsharp.explorer.solution.clean",
-					"when": "viewItem ==ionide.projectExplorer.solution",
+					"when": "viewItem == ionide.projectExplorer.solution",
 					"group": "1_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.solution.restore",
-					"when": "viewItem ==ionide.projectExplorer.solution",
+					"when": "viewItem == ionide.projectExplorer.solution",
 					"group": "1_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.solution.addProject",
-					"when": "viewItem ==ionide.projectExplorer.solution",
+					"when": "viewItem == ionide.projectExplorer.solution",
 					"group": "2_modification@1"
 				},
 				{
 					"command": "fsharp.explorer.addFile",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "3_modifications@2"
 				},
 				{
 					"command": "fsharp.explorer.project.generateFSI",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "4_fsi@1"
 				},
 				{
 					"command": "fsharp.explorer.project.sendFSI",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "4_fsi@2"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "5_detail@1"
 				},
 				{
 					"command": "fsharp.explorer.showProjectStatus",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "5_detail@2"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.build",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "2_navigation@1"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.rebuild",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "2_navigation@2"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.clean",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "2_navigation@3"
 				},
 				{
 					"command": "fsharp.explorer.msbuild.restore",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "2_navigation@4"
 				},
 				{
 					"command": "fsharp.explorer.project.run",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "1_run@1"
 				},
 				{
 					"command": "fsharp.explorer.project.debug",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "1_run@2"
 				},
 				{
 					"command": "fsharp.explorer.project.setDefault",
-					"when": "viewItem ==ionide.projectExplorer.projectExe",
+					"when": "viewItem == ionide.projectExplorer.projectExe",
 					"group": "1_run@3"
 				}
 			],

--- a/src/Components/CodeOutline.fs
+++ b/src/Components/CodeOutline.fs
@@ -219,10 +219,12 @@ module CodeOutline =
             let showIn = "FSharp.showCodeOutlineIn" |> Configuration.get "fsharp"
             showIn = "fsharp"
 
-        let set () =
+        let initializeAndGetId () =
             let inFsharpActivity = showInFsharpActivity ()
             setInFsharpActivity inFsharpActivity
             setInExplorerActivity (not inFsharpActivity)
+
+            if inFsharpActivity then "ionide.codeOutlineInActivity" else "ionide.codeOutline"
 
     let setShowCodeOutline = Context.cachedSetter<bool> "fsharp.showCodeOutline"
 
@@ -255,7 +257,9 @@ module CodeOutline =
 
     let activate (context: ExtensionContext) =
         setShowCodeOutlineForEditor window.activeTextEditor
-        ShowInActivity.set()
+
+        let treeViewId = ShowInActivity.initializeAndGetId ()
+
         window.onDidChangeActiveTextEditor.Invoke(unbox onDidChangeActiveTextEditor)
             |> context.subscriptions.Add
 
@@ -299,5 +303,5 @@ module CodeOutline =
             refresh.fire undefined |> unbox
         )) |> context.subscriptions.Add
 
-        window.registerTreeDataProvider("ionide.codeOutline", createProvider () )
+        window.registerTreeDataProvider(treeViewId, createProvider () )
         |> context.subscriptions.Add

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -221,11 +221,9 @@ module SolutionExplorer =
             member this.getChildren(node) =
                 if JS.isDefined node then
                     let r = getSubmodel node |> ResizeArray
-                    printfn "[TREE VIEW]: %A" r
                     r
                 else
                     let r = getRoot () |> getSubmodel |> ResizeArray
-                    printfn "[TREE VIEW]: %A" r
                     r
 
             member this.getTreeItem(node) =
@@ -327,18 +325,20 @@ module SolutionExplorer =
         let private setInFsharpActivity = Context.cachedSetter<bool> "fsharp.showProjectExplorerInFsharpActivity"
         let private setInExplorerActivity = Context.cachedSetter<bool> "fsharp.showProjectExplorerInExplorerActivity"
 
-        let set () =
+        let initializeAndGetId (): string =
             let showIn = "FSharp.showProjectExplorerIn" |> Configuration.get "fsharp"
             let inFsharpActivity = (showIn = "fsharp")
             setInFsharpActivity inFsharpActivity
             setInExplorerActivity (not inFsharpActivity)
+
+            if inFsharpActivity then "ionide.projectExplorerInActivity" else "ionide.projectExplorer"
 
     let activate (context: ExtensionContext) =
         let emiter = EventEmitter<Model option>()
 
         let provider = createProvider emiter
 
-        ShowInActivity.set ()
+        let treeViewId = ShowInActivity.initializeAndGetId ()
 
         Project.workspaceChanged.event.Invoke(fun _ ->
             emiter.fire (undefined) |> unbox)
@@ -478,7 +478,7 @@ module SolutionExplorer =
             | _ -> undefined
         )) |> context.subscriptions.Add
 
-        window.registerTreeDataProvider("ionide.projectExplorer", provider )
+        window.registerTreeDataProvider(treeViewId, provider )
         |> context.subscriptions.Add
 
         let wsProvider =


### PR DESCRIPTION
We need some duplication but it's far less hackish.

While trying to implement an `autoReveal` feature I noticed that the hack can make vscode stackoverflow so it's better to take the price of duplication in the `project.json`.