### PR TITLE
Fix #730: Clear diagnostics when file is deleted

### DIFF
--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -15,7 +15,6 @@ module Errors =
     let mutable private currentDiagnostic = languages.createDiagnosticCollection ()
 
     let private mapResult (ev : ParseResult) =
-        printfn "======= MAP RESULT ======="
         let errors =
             ev.Data.Errors
             |> Seq.distinctBy (fun error -> error.Severity, error.StartLine, error.StartColumn)

--- a/src/Components/Linter.fs
+++ b/src/Components/Linter.fs
@@ -17,6 +17,8 @@ module Linter =
 
     let private isLinterEnabled () = "FSharp.linter" |> Configuration.get true
 
+    let deleteDiagnostic uri = currentDiagnostic.delete uri
+
     let private diagnosticFromLintWarning file (warning : Lint) =
         let range = CodeRange.fromDTO warning.Range
         let loc = Location (Uri.file file, range |> U2.Case1)

--- a/src/Components/SimplifyName.fs
+++ b/src/Components/SimplifyName.fs
@@ -15,6 +15,8 @@ module SimplifyName =
     let refresh = EventEmitter<string>()
     let private isAnalyzerEnabled () = "FSharp.simplifyNameAnalyzer" |> Configuration.get true
 
+    let deleteDiagnostic uri = currentDiagnostic.delete uri
+
     let private diagnosticFromRange file (data : SimplifiedNameData) =
         let range = CodeRange.fromSimplifiedNameRange data.UnnecessaryRange
         Diagnostic(range, "This qualifier is redundant", DiagnosticSeverity.Information), file

--- a/src/Components/UnusedDeclarations.fs
+++ b/src/Components/UnusedDeclarations.fs
@@ -15,6 +15,8 @@ module UnusedDeclarations =
     let refresh = EventEmitter<string>()
     let private isAnalyzerEnabled () = "FSharp.unusedDeclarationsAnalyzer" |> Configuration.get true
 
+    let deleteDiagnostic uri = currentDiagnostic.delete uri
+
     let private diagnosticFromRange file (warning : UnusedDeclaration) =
         let range = CodeRange.fromDTO warning.Range
         let loc = Location (Uri.file file, range |> U2.Case1)

--- a/src/Components/UnusedOpens.fs
+++ b/src/Components/UnusedOpens.fs
@@ -16,6 +16,9 @@ module UnusedOpens =
 
     let private isAnalyzerEnabled () = "FSharp.unusedOpensAnalyzer" |> Configuration.get true
 
+    let deleteDiagnostic uri =
+        currentDiagnostic.delete uri
+
     let private diagnosticFromRange file (warning : Range) =
         let range = CodeRange.fromDTO warning
         Diagnostic(range, "Unused open statement", DiagnosticSeverity.Information), file


### PR DESCRIPTION
Feature tested when **deleting** or **renaming** it, both are supported.