### PR TITLE
Improve SignatureData generation + auto comment in doc comment section

### DIFF
--- a/src/Components/LanguageConfiguration.fs
+++ b/src/Components/LanguageConfiguration.fs
@@ -1,0 +1,31 @@
+namespace Ionide.VSCode.FSharp
+
+open Fable.Core.JsInterop
+open Fable.Import
+open Fable.Import.vscode
+open Ionide.VSCode.Helpers
+
+module LanguageConfiguration =
+
+    let activate (context: ExtensionContext) =
+        let config =
+            jsOptions<LanguageConfiguration> (fun o ->
+                o.onEnterRules <- Some <| ResizeArray<OnEnterRule>(
+                    [|
+                        // Doc single-line comment
+                        // Example: ///
+                        jsOptions<OnEnterRule> (fun rule ->
+                            rule.action <- jsOptions<EnterAction>(fun action ->
+                                action.indentAction <- IndentAction.Indent
+                                action.appendText <- Some "/// "
+                            )
+                            rule.beforeText <- JS.RegExp.Create("^\s*\/{3}.*$")
+                        )
+
+                    |]
+                )
+            )
+
+        JS.console.log config.onEnterRules.Value.[0].beforeText
+
+        context.subscriptions.Add(vscode.languages.setLanguageConfiguration("fsharp", config))

--- a/src/Components/SignatureData.fs
+++ b/src/Components/SignatureData.fs
@@ -1,12 +1,7 @@
 namespace Ionide.VSCode.FSharp
 
 open System
-open Fable.Core
-open Fable.Core.JsInterop
-open Fable.Import
 open Fable.Import.vscode
-open Fable.Import.Node
-open System.Text.RegularExpressions
 open DTO
 open Ionide.VSCode.Helpers
 
@@ -23,10 +18,10 @@ module SignatureData =
                     p.Data.Parameters
                     |> Seq.collect id
                     |> Seq.where (fun prm -> String.IsNullOrWhiteSpace prm.Name |> not )
-                    |> Seq.map (fun prm -> sprintf "///  * `%s` - parameter of type `%s`" prm.Name prm.Type)
+                    |> Seq.map (fun prm -> sprintf "///   * `%s` - parameter of type `%s`" prm.Name prm.Type)
                     |> String.concat "\n"
                 let pms = if pms = "" then "///" else pms
-                let comment = sprintf "\n///**Description**\n///\n///**Parameters**\n%s\n///\n///**Output Type**\n///  * `%s`\n///\n///**Exceptions**\n///" pms p.Data.OutputType
+                let comment = sprintf "\n/// **Description**\n///\n/// **Parameters**\n%s\n///\n/// **Output Type**\n///   * `%s`\n///\n/// **Exceptions**\n///" pms p.Data.OutputType
                 let x = window.activeTextEditor.selection.active.line
                 let t = window.activeTextEditor.document.getText(Range(x, 0., x, 1000.))
                 let t' = t.TrimStart(' ')

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="Components/Tooltip.fs" />
     <Compile Include="Components/Autocomplete.fs" />
     <Compile Include="Components/ParameterHints.fs" />
+    <Compile Include="Components/LanguageConfiguration.fs" />
     <Compile Include="Components/Definition.fs" />
     <Compile Include="Components/TypeDefinition.fs" />
     <Compile Include="Components/References.fs" />

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -87,6 +87,7 @@ let activate (context: ExtensionContext) : Api =
     Forge.activate context
     Fsi.activate context
     ScriptRunner.activate context
+    LanguageConfiguration.activate context
 
     let buildProject project = promise {
         let! exit = MSBuild.buildProjectPath "Build" project


### PR DESCRIPTION
**Auto comment demo**

![2018-05-17 14 00 27](https://user-images.githubusercontent.com/4760796/40176229-fabd47d2-59da-11e8-9db2-087c58f9dcf0.gif)

Because in general, we write `/// Mytext` (note the space after `///`), I also modified the `SignatureData` generation to add an extra space. I looked at some code and also at F# Formmating. We can of course revert my proposition :)

**Old generation**
```fs
///**Description**
///
///**Parameters**
///  * `context` - parameter of type `ExtensionContext`
///
///**Output Type**
///  * `unit`
///
///**Exceptions**
///

```

**New generation**

```fs
/// **Description**
/// 
/// **Parameters**
///   * `context` - parameter of type `ExtensionContext`
/// 
/// **Output Type**
///   * `unit`
/// 
/// **Exceptions**
/// 
```

*Notes*

Should we tried to provide auto completion for: 

```
///   *
```

```
///      >
```

Doc comment:
```fs
/// **Description**
/// 
/// **Parameters**
///   * `context` - parameter of type `ExtensionContext`
///      > I am describing my parameter usage here
///
/// **Output Type**
///   * `unit`
/// 
/// **Exceptions**
/// 
```

Display result:
<img width="354" alt="capture d ecran 2018-05-17 a 14 10 20" src="https://user-images.githubusercontent.com/4760796/40176570-162b701a-59dc-11e8-9e5f-e873b9b0543b.png">

