### PR TITLE
Don't modify markdown strings

### DIFF
--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -241,10 +241,6 @@ module Markdown =
     let createCommentBlock (comment: string) : MarkdownString =
         comment
         |> replaceXml
-        |> String.split [|'\n'|]
-        |> Array.filter (not << String.IsNullOrWhiteSpace)
-        |> Array.map String.trim
-        |> String.concat "\n\n"
         |> (fun v -> MarkdownString v)
 
 module Promise =


### PR DESCRIPTION
Fix #852


Markdown is space and whitespace sensitive. It will by itself remove undesirable blank lines, whitespaces, etc.

By triming the lines, the user can't format it's text correctly.

------------

Code:

```fs
/// A type describing a unit in terms of its dimensions, base coefficient and offset, and recognized names
/// A unit of measure is uniquely defined by its dimensionality and its base coefficient and offset. Most units only
/// have a base coefficient, which defines the multiplicative conversion factor to scale the unit's value to the base
/// unit's equivalent. Absolute temperature units also have an additive base offset that scales the unit's value to the
/// base unit's zero-point. The `Names` property contains the list of strings that can be used to refer to the unit,
/// usually a combination of full names and abbrevations.
/// * Maxime
///     * Maxime
///
/// ```fsharp
/// let maxime = ""
/// ```
type Unit = {
    Dimensions: obj
    BaseCoefficient: float
    Names: string list
}

```
Before:
![img_1534](https://user-images.githubusercontent.com/4760796/42996703-a596a4c6-8c14-11e8-8615-8c71dd699558.JPG)

After:
![img_4654](https://user-images.githubusercontent.com/4760796/42996722-ad2d7c3c-8c14-11e8-850f-d625f0ae5cb6.JPG)

Now the output result is what user would expected when writing markdown. Indented list, etc.