### PR TITLE
Use fsac binary paths

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -602,10 +602,10 @@ NUGET
       FSharp.Core (>= 4.3.4) - restriction: >= netstandard2.0
 GIT
   remote: https://github.com/fsharp/FsAutoComplete.git
-     (a303a16b5cf31f429bea92caaadef4c2c83040aa)
+     (fb8bb1fb0636602b308093579659347ccb0a17b0)
       build: build.cmd LocalRelease
       os: windows
-     (a303a16b5cf31f429bea92caaadef4c2c83040aa)
+     (fb8bb1fb0636602b308093579659347ccb0a17b0)
       build: build.sh LocalRelease
       os: mono
   remote: https://github.com/fsharp-editing/Forge.git
@@ -1138,5 +1138,5 @@ NUGET
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
 GITHUB
   remote: fsharp/FAKE
-    modules/Octokit/Octokit.fsx (e12702e99e775460e77b116fada9568ae291a7c7)
+    modules/Octokit/Octokit.fsx (0e2a58d4065fc3dda72448c1a3d978ab433c170f)
       Octokit (>= 0.20)

--- a/src/Components/Diagnostics.fs
+++ b/src/Components/Diagnostics.fs
@@ -145,7 +145,7 @@ Error: %s
 
     let getMSBuildVersion () =
         promise {
-            let! msbuild = Environment.msbuild
+            let! msbuild = Binaries.msbuild ()
             let! version = execCommand msbuild [ "/version" ]
             return version.Trim()
         }

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -60,8 +60,8 @@ module Fsi =
                 else
                     fsiParams
                 |> Array.ofList
-
-            let terminal = window.createTerminal("F# Interactive", Environment.fsi, parms)
+            let! fsiPath = Binaries.fsi ()
+            let terminal = window.createTerminal("F# Interactive", fsiPath, parms)
             terminal.processId |> Promise.onSuccess (fun pId -> fsiOutputPID <- Some pId) |> ignore
             lastCd <- None
             lastCurrentFile <- None
@@ -69,8 +69,7 @@ module Fsi =
             sendCd window.activeTextEditor
             terminal.show(true)
             return terminal
-
-            }
+        }
         |> Promise.onFail (fun _ ->
             window.showErrorMessage "Failed to spawn FSI, please ensure it's in PATH" |> ignore)
 

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -37,7 +37,7 @@ module MSBuild =
 
     let pickMSbuildHostType () =
         promise {
-            let! envMsbuild = Environment.msbuild
+            let! envMsbuild = Binaries.msbuild ()
             let! envDotnet = Environment.dotnet
 
             let hosts =
@@ -128,7 +128,7 @@ module MSBuild =
 
                 let! msbuildPath =
                     match host' with
-                    | MSbuildHost.MSBuildExe -> Environment.msbuild
+                    | MSbuildHost.MSBuildExe -> Binaries.msbuild ()
                     | MSbuildHost.DotnetCli -> Environment.dotnet
                     | MSbuildHost.Auto -> Promise.lift ""
                 let cmd =
@@ -361,7 +361,7 @@ module MSBuild =
             f p h
 
         let envMsbuild =
-            Environment.msbuild
+            Binaries.msbuild ()
             |> Promise.map (fun p ->
                 logger.Info("MSBuild (.NET) found at %s", p)
                 p)

--- a/src/Core/Binaries.fs
+++ b/src/Core/Binaries.fs
@@ -1,0 +1,24 @@
+namespace Ionide.VSCode.FSharp
+
+open Ionide.VSCode.Helpers
+
+/// This module encapsulates finding fsharpc/fsharpi/masbuild binaries for the current session.
+/// It defers to local configuration (via VSCode settings files), but if those are not present uses 
+/// FSAC to provide the locations.
+module Binaries = 
+
+    let private fsacConfig () = 
+        LanguageService.compilerLocation () 
+        |> Promise.map (fun c -> c.Data)
+
+    let fsi () = 
+        Environment.configFSIPath |> Option.map Promise.lift
+        |> Option.defaultWith (fsacConfig >> Promise.map (fun paths -> paths.Fsi))
+
+    let fsc () = 
+        Environment.configFSCPath |> Option.map Promise.lift
+        |> Option.defaultWith (fsacConfig >> Promise.map (fun paths -> paths.Fsc))
+        
+    let msbuild () = 
+        Environment.configMSBuildPath |> Option.map Promise.lift
+        |> Option.defaultWith (fsacConfig >> Promise.map (fun paths -> paths.MSBuild))

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -122,7 +122,7 @@ module DTO =
     }
 
     type CompilerLocation = {
-        Fcs : string
+        Fsc : string
         Fsi : string
         MSBuild : string
     }

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -317,7 +317,7 @@ module LanguageService =
         {PositionRequest.Line = line; FileName = handleUntitled fn; Column = col; Filter = ""}
         |> request "signatureData" 0 (makeRequestId())
 
-    let declarations fn (text : string) version=
+    let declarations fn (text : string) version =
         let lines = text.Replace("\uFEFF", "").Split('\n')
         {DeclarationsRequest.FileName = handleUntitled fn; Lines = lines; Version = version}
         |> request<_, Result<Symbols[]>> "declarations" 0 (makeRequestId())
@@ -327,7 +327,7 @@ module LanguageService =
         "" |> request "declarationsProjects" 0 (makeRequestId())
 
     let compilerLocation () =
-        "" |> request "compilerlocation" 0 (makeRequestId())
+        "" |> request<string, CompilerLocationResult> "compilerlocation" 0 (makeRequestId())
 
     let lint s =
         {ProjectRequest.FileName = s}
@@ -520,19 +520,19 @@ module LanguageService =
 
     type [<RequireQualifiedAccess>] FSACTargetRuntime = NET | NetcoreFdd
 
-    let startFSAC () =
-         let fsacTargetRuntime =
-            match "FSharp.fsacRuntime" |> Configuration.get "net" with
-            | "netcore" -> FSACTargetRuntime.NetcoreFdd
-            | "net" | _ -> FSACTargetRuntime.NET
+    let targetRuntime =
+        match "FSharp.fsacRuntime" |> Configuration.get "net" with
+        | "netcore" -> FSACTargetRuntime.NetcoreFdd
+        | "net" | _ -> FSACTargetRuntime.NET
 
+    let startFSAC () =
          let ionidePluginPath =
             try
                 (VSCode.getPluginPath "Ionide.ionide-fsharp")
             with
             | _ -> (VSCode.getPluginPath "Ionide.Ionide-fsharp")
 
-         match fsacTargetRuntime with
+         match targetRuntime with
          | FSACTargetRuntime.NET ->
              let path = ionidePluginPath + "/bin/fsautocomplete.exe"
              let fsacExe, fsacArgs =

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -337,7 +337,7 @@ module Project =
 
     let buildWithMsbuild outputChannel (project:Project) =
         promise {
-            let! msbuild = Environment.msbuild
+            let! msbuild = Binaries.msbuild ()
             return! Process.spawnWithNotification msbuild "" (String.quote project.Project) outputChannel
             |> Process.toPromise
         }

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -79,6 +79,10 @@ module Document =
 
 [<RequireQualifiedAccess>]
 module Configuration =
+    let tryGet key =
+        let configuredValue = workspace.getConfiguration().get(key)
+        if configuredValue = "" then None else Some configuredValue
+
     let get defaultValue key =
         workspace.getConfiguration().get(key, defaultValue)
 

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="Core/Environment.fs" />
     <Compile Include="Core/Logging.fs" />
     <Compile Include="Core/LanguageService.fs" />
+    <Compile Include="Core/Binaries.fs" />
     <Compile Include="Core/Project.fs" />
     <Compile Include="Components/Tooltip.fs" />
     <Compile Include="Components/Autocomplete.fs" />


### PR DESCRIPTION
Use the paths reported by FSAC's `compilerlocation` command instead of doing probing ourselves, this way we can centralize as much as possible the probing logic.

We still defer to the configuration settings, so for example these settings:
```
{
    "FSharp.logLanguageServiceRequests": "both",
    "FSharp.logLanguageServiceRequestsOutputWindowLevel": "DEBUG",
    "FSharp.fsiFilePath": "butts",
    "FSharp.msbuildLocation": "lolol"
}
```

result in UI like this:

MSBuild:
![image](https://user-images.githubusercontent.com/573979/44290768-e39a9c00-a23f-11e8-9698-4b8ec1951bff.png)

FSI:
![image](https://user-images.githubusercontent.com/573979/44290776-eb5a4080-a23f-11e8-976f-368abe8e9ace.png)
