### PR TITLE
Fixed rename refactoring for type parameters (#819)

### DIFF
--- a/src/Components/Rename.fs
+++ b/src/Components/Rename.fs
@@ -16,7 +16,7 @@ module Rename =
             let res = WorkspaceEdit ()
             if isNotNull o then
                 o.Data.Uses |> Array.iter (fun s ->
-                    let range = Range(float s.StartLine - 1., (float s.EndColumn) - (float o.Data.Name.Length) - 1., float s.EndLine - 1., float s.EndColumn - 1.)
+                    let range = CodeRange.fromSymbolUse s
                     let te = TextEdit.replace(range, newName)
                     let uri = Uri.file s.FileName
                     res.replace(uri,range, newName))


### PR DESCRIPTION
Hi. I changed the way of getting a range for symbol use.
As in References we now use `CodeRange.fromSymbolUse` which fixes the renaming of `<'Type>` (avoids duplication of `'`)