### PR TITLE
Normalize leading space for docs tooltips

### DIFF
--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -268,9 +268,22 @@ module Markdown =
             res.Replace(oldValue, newValue)
         ) res
 
+    let private normalizeLeadingSpace (content : string) =
+        content
+            .Replace("\r\n", "\n")
+            .Split('\n')
+        |> Array.map(fun line ->
+            if line.Length > 1 && line.[0] = ' ' then
+                line.[1..]
+            else
+                line
+        )
+        |> String.concat "\n"
+
     let createCommentBlock (comment: string) : MarkdownString =
         comment
         |> replaceXml
+        |> normalizeLeadingSpace
         |> (fun v -> MarkdownString v)
 
 module Promise =


### PR DESCRIPTION
Fix #885

Before:
![2018-08-22 12 50 47](https://user-images.githubusercontent.com/4760796/44459868-67230700-a60b-11e8-825d-42f7b0241562.gif)

Now:
![2018-08-22 12 48 46](https://user-images.githubusercontent.com/4760796/44459872-69856100-a60b-11e8-8376-3fbdfb544e81.gif)
