### PR TITLE
fix file watchers doesnt consider FSharp.excludeProjectDirectories

### DIFF
--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -308,22 +308,22 @@ module MSBuild =
 
 
     let activate (context : ExtensionContext) =
-        let unlessIgnored (n: Uri) f =
-            if Project.isIgnored n.fsPath then
+        let unlessIgnored (path: string) f =
+            if Project.isIgnored path then
                 unbox ()
             else
-                f n
+                f path
 
         let initWorkspace _n = Project.initWorkspace (fun _ -> Promise.empty)
-        let loadProject (n: Uri) = Project.load false n.fsPath
+        let loadProject path = Project.load false path
 
         let solutionWatcher = vscode.workspace.createFileSystemWatcher("**/*.sln")
-        solutionWatcher.onDidCreate.Invoke(fun n -> unlessIgnored n initWorkspace |> unbox) |> ignore
-        solutionWatcher.onDidChange.Invoke(fun n -> unlessIgnored n initWorkspace |> unbox) |> ignore
+        solutionWatcher.onDidCreate.Invoke(fun n -> unlessIgnored n.fsPath initWorkspace |> unbox) |> ignore
+        solutionWatcher.onDidChange.Invoke(fun n -> unlessIgnored n.fsPath initWorkspace |> unbox) |> ignore
 
         let projectWatcher = vscode.workspace.createFileSystemWatcher("**/*.fsproj")
-        projectWatcher.onDidCreate.Invoke(fun n -> unlessIgnored n initWorkspace |> unbox) |> ignore
-        projectWatcher.onDidChange.Invoke(fun n -> unlessIgnored n loadProject |> unbox) |> ignore
+        projectWatcher.onDidCreate.Invoke(fun n -> unlessIgnored n.fsPath initWorkspace |> unbox) |> ignore
+        projectWatcher.onDidChange.Invoke(fun n -> unlessIgnored n.fsPath loadProject |> unbox) |> ignore
 
         let assetWatcher = vscode.workspace.createFileSystemWatcher("**/project.assets.json")
 
@@ -331,7 +331,18 @@ module MSBuild =
             let objDir = node.path.dirname n.fsPath
             let fsprojDir = node.path.join(objDir, "..")
             let files = node.fs.readdirSync (U2.Case1 fsprojDir)
-            files |> Seq.tryFind(fun n -> n.EndsWith ".fsproj"), fsprojDir
+            let fsprojOpt = files |> Seq.tryFind(fun n -> n.EndsWith ".fsproj")
+            let fsprojOptNotIgnored =
+                match fsprojOpt with
+                | Some fsproj ->
+                    let p = node.path.join(fsprojDir, fsproj)
+                    if Project.isIgnored p then
+                        None
+                    else
+                        Some fsproj
+                | None ->
+                    None
+            fsprojOptNotIgnored, fsprojDir
 
         assetWatcher.onDidDelete.Invoke(fun n ->
             let (fsprojOpt, fsprojDir) = getFsProjFromAssets n

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -62,6 +62,17 @@ module Project =
     let updateInWorkspace (path : string) state =
         loadedProjects <- loadedProjects |> Map.add (path.ToUpperInvariant ()) state
 
+    let isIgnored (path: string) =
+        let relativePath = node.path.relative (workspace.rootPath, path)
+
+        let isSubDir p =
+            let relativeToDir = node.path.relative(p, relativePath)
+            let isSubdir = not (relativeToDir.StartsWith(".."))
+            isSubdir
+
+        excluded
+        |> Array.exists isSubDir
+
     let private guessFor p =
         let rec findFsProj dir =
             if node.fs.lstatSync(U2.Case1 dir).isDirectory() then


### PR DESCRIPTION
the setting `FSharp.excludeProjectDirectories` configure the ignored dirs
This was not considered by file watchers for changed/creation/deletion, so updating in these dir will trigger a reload/init workspace

- do not load created/changed projects/sln from ignored dirs
- do not reload project.assets.json of ignored fsproj