### PR TITLE
Project picker 2

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1355,6 +1355,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "EXPERIMENTAL. Enables disabling in-memory project references. It means that cross-project changes will be picked up only after building project. It can be useful for big solutions (like F# compiler). Requires workspace loading mode. Requires restart"
+				},
+				"FSharp.workspacePath": {
+					"type": "string",
+					"description": "Path to the directory or solution file that should be loaded as a workspace.",
+					"scope": "window"
 				}
 			}
 		},

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -401,12 +401,20 @@ module Project =
 
         let text (x : WorkspacePeekFound) =
             let check = if isDefault x then "✔ " else ""
+
             match x with
             | WorkspacePeekFound.Directory dir ->
-                sprintf "%s[DIR] %s     (%i projects)" check dir.Directory dir.Fsprojs.Length
+                let item = createEmpty<QuickPickItem>
+                item.label <- sprintf "%s%s" check dir.Directory
+                item.description <- sprintf "Directory with %i projects" dir.Fsprojs.Length
+                item
             | WorkspacePeekFound.Solution sln ->
-                let relativeSln = node.path.relative (workspace.rootPath, sln.Path)
-                sprintf "%s[SLN] %s     (%i projects)" check relativeSln (countProjectsInSln sln)
+                let relative = path.relative (workspace.rootPath, sln.Path)
+                let item = createEmpty<QuickPickItem>
+                item.label <- sprintf "%s%s" check relative
+                item.description <- sprintf "Solution with %i projects" (countProjectsInSln sln)
+                item
+
         match ws |> List.map (fun x -> (text x), x) with
         | [] ->
             None |> Promise.lift

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -421,7 +421,7 @@ module Project =
         | projects ->
             promise {
                 let opts = createEmpty<QuickPickOptions>
-                opts.placeHolder <- Some "Place"
+                opts.placeHolder <- Some "Workspace or Solution"
                 let chooseFrom = projects |> List.map fst |> ResizeArray
                 let! chosen = window.showQuickPick(chooseFrom |> U2.Case1, opts)
                 if JS.isDefined chosen then

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -400,12 +400,13 @@ module Project =
             | None -> false
 
         let text (x : WorkspacePeekFound) =
+            let check = if isDefault x then "✔ " else ""
             match x with
             | WorkspacePeekFound.Directory dir ->
-                sprintf "[DIR] %s     (%i projects)" dir.Directory dir.Fsprojs.Length
+                sprintf "%s[DIR] %s     (%i projects)" check dir.Directory dir.Fsprojs.Length
             | WorkspacePeekFound.Solution sln ->
                 let relativeSln = node.path.relative (workspace.rootPath, sln.Path)
-                sprintf "[SLN] %s     (%i projects)" relativeSln (countProjectsInSln sln)
+                sprintf "%s[SLN] %s     (%i projects)" check relativeSln (countProjectsInSln sln)
         match ws |> List.map (fun x -> (text x), x) with
         | [] ->
             None |> Promise.lift


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/131878/48381311-a0838400-e6db-11e8-9eae-8339667cb042.png)


* Save the current F# workspace in the vscode workspace and don't ask again each start
* Add a `FSharp.workspacePath` setting in vscode workspace settings to optionally commit the default workspace with the repository
* Update the solution picker to be a little nicer