### PR TITLE
Enable LineLens by default when CodeLens is disabled

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1280,7 +1280,7 @@
 						"replaceCodeLens",
 						"always"
 					],
-					"default": "never"
+					"default": "replaceCodeLens"
 				},
 				"FSharp.lineLens.prefix": {
 					"type": "string",
@@ -1419,8 +1419,8 @@
 				"id": "fsharp.linelens",
 				"description": "Foreground color for F# LineLenses",
 				"defaults": {
-					"dark": "#525252",
-					"light": "#C2C2C2",
+					"dark": "#696969",
+					"light": "#919191",
 					"highContrast": "#A2E2A2"
 				}
 			}


### PR DESCRIPTION
Hopefully it will make more people notice the feature.

I also changed the default colors, I like ones that aren't very contrasted with the background but depending on screen calibration it's hard to read and some people made the remark to me.

The new colors have been choosen to have a ~3.0 contrast ratio with the default VSCode theme (WCAG AA minimum for large text)