### PR TITLE
Enable auto reveal

### DIFF
--- a/release/images/auto-reveal-dark.svg
+++ b/release/images/auto-reveal-dark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <g transform="matrix(1.02213,2.5035e-16,-2.44929e-16,1,6.82294,7)">
+        <path d="M5.065,1L3.108,1L5.065,3L-3.74,3L-3.74,5L5.065,5L3.108,7L5.065,7L8,4L5.065,1Z" style="fill:rgb(197,197,197);fill-rule:nonzero;"/>
+    </g>
+    <g transform="matrix(-1.02213,-3.75525e-16,3.67394e-16,-1,9.17706,10)">
+        <path d="M5.065,1L3.108,1L5.065,3L-3.74,3L-3.74,5L5.065,5L3.108,7L5.065,7L8,4L5.065,1Z" style="fill:rgb(197,197,197);fill-rule:nonzero;"/>
+    </g>
+</svg>

--- a/release/images/auto-reveal-light.svg
+++ b/release/images/auto-reveal-light.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <g transform="matrix(1.02213,2.5035e-16,-2.44929e-16,1,6.82294,7)">
+        <path d="M5.065,1L3.108,1L5.065,3L-3.74,3L-3.74,5L5.065,5L3.108,7L5.065,7L8,4L5.065,1Z" style="fill:rgb(66,66,66);fill-rule:nonzero;"/>
+    </g>
+    <g transform="matrix(-1.02213,-3.75525e-16,3.67394e-16,-1,9.17706,10)">
+        <path d="M5.065,1L3.108,1L5.065,3L-3.74,3L-3.74,5L5.065,5L3.108,7L5.065,7L8,4L5.065,1Z" style="fill:rgb(66,66,66);fill-rule:nonzero;"/>
+    </g>
+</svg>

--- a/release/package.json
+++ b/release/package.json
@@ -414,14 +414,14 @@
 			"explorer": [
 				{
 					"id": "ionide.projectExplorer",
-					"name": "F# Project Explorer",
+					"name": "F# Solution Explorer",
 					"when": "fsharp.project.any && fsharp.showProjectExplorerInExplorerActivity"
 				}
 			],
 			"ionide-fsharp": [
 				{
 					"id": "ionide.projectExplorerInActivity",
-					"name": "Project Explorer",
+					"name": "Solution Explorer",
 					"when": "fsharp.project.any && fsharp.showProjectExplorerInFsharpActivity"
 				}
 			]
@@ -1193,7 +1193,7 @@
 				"FSharp.enableTreeView": {
 					"type": "boolean",
 					"default": true,
-					"description": "Enables project explorer."
+					"description": "Enables solution explorer."
 				},
 				"FSharp.excludeProjectDirectories": {
 					"type": "array",
@@ -1286,6 +1286,17 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enables TouchBar integration"
+				},
+				"FSharp.autoRevealInExplorer": {
+					"type": "string",
+					"description": "Controls whether the solution explorer should automatically reveal and select files when opening them.",
+					"enum": [
+						"sameAsFileExplorer",
+						"enabled",
+						"disabled"
+					],
+					"default": "sameAsFileExplorer",
+					"scope": "window"
 				}
 			}
 		},

--- a/release/package.json
+++ b/release/package.json
@@ -398,6 +398,15 @@
 				"title": "Convert html to Elmish",
 				"description": "Converts your selection to Elmish by assuming that your selection is HTML code",
 				"category": "F#"
+			},
+			{
+				"command": "fsharp.revealInSolutionExplorer",
+				"title": "F#: Reveal in solution explorer",
+				"category": "F#",
+				"icon": {
+					"light": "./images/auto-reveal-light.svg",
+					"dark": "./images/auto-reveal-dark.svg"
+				}
 			}
 		],
 		"viewsContainers": {
@@ -628,6 +637,16 @@
 					"command": "fsharp.debugDefaultProject",
 					"group": "navigation@2",
 					"alt": "fsharp.runDefaultProject",
+					"when": "view == ionide.projectExplorerInActivity"
+				},
+				{
+					"command": "fsharp.revealInSolutionExplorer",
+					"group": "navigation@3",
+					"when": "view == ionide.projectExplorer"
+				},
+				{
+					"command": "fsharp.revealInSolutionExplorer",
+					"group": "navigation@3",
 					"when": "view == ionide.projectExplorerInActivity"
 				},
 				{

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -459,8 +459,8 @@ module SolutionExplorer =
 
         let private onDidChangeTreeVisibility (tree : TreeView<Model>) (state : State option ref) (change: TreeViewVisibilityChangeEvent) =
             if change.visible && RevealConfiguration.getAutoReveal () then
-                // Done on a small timeout to avoid VSCode double-selecting due to a race-condition
-                JS.setTimeout (fun () -> revealTextEditor tree state window.activeTextEditor true) 10
+                // Done out of the event call to avoid VSCode double-selecting due to a race-condition
+                JS.setTimeout (fun () -> revealTextEditor tree state window.activeTextEditor true) 0
                 |> ignore
 
         let activate (context : ExtensionContext) (rootChanged : Event<Model>) (treeView : TreeView<Model>) =

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -259,10 +259,8 @@ module SolutionExplorer =
           with
             member __.getParent =
                 Some (fun node ->
-                    printfn "GET PARENT %A" (getLabel node)
                     if JS.isDefined node then
                         let parentRef = getParentRef node
-                        printfn "PARENT = %A" (!parentRef |> Option.map getLabel)
                         !parentRef
                     else
                         None)
@@ -415,7 +413,6 @@ module SolutionExplorer =
         let private revealUri (tree : TreeView<Model>) (state : State option ref) (uri : Uri) =
             if tree.visible then
                 let model = findModelFromUri state uri
-                printfn "FOUND %A for %s" model uri.fsPath
                 match model with
                 | Some model ->
                     let options = createEmpty<TreeViewRevealOptions>
@@ -457,9 +454,6 @@ module SolutionExplorer =
 
         let private onModelChanged (state : State option ref) (newValue : Model) =
             let modelPerFile = getModelPerFile newValue |> Map.ofList
-            printfn "------------------------------"
-            printfn "UPDATED STATE = %A" modelPerFile
-            printfn "------------------------------"
             let newState = Some { RootModel = newValue; ModelPerFile = modelPerFile }
             state := newState
 

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -452,10 +452,13 @@ module SolutionExplorer =
             | ProjectReferencesList _->
                 []
 
-        let private onModelChanged (state : State option ref) (newValue : Model) =
+        let private onModelChanged (tree : TreeView<Model>) (state : State option ref) (newValue : Model) =
             let modelPerFile = getModelPerFile newValue |> Map.ofList
             let newState = Some { RootModel = newValue; ModelPerFile = modelPerFile }
             state := newState
+
+            if RevealConfiguration.getAutoReveal () then
+                revealTextEditor tree state window.activeTextEditor false
 
         let private onDidChangeTreeVisibility (tree : TreeView<Model>) (state : State option ref) (change: TreeViewVisibilityChangeEvent) =
             if change.visible && RevealConfiguration.getAutoReveal () then
@@ -470,7 +473,7 @@ module SolutionExplorer =
             window.onDidChangeActiveTextEditor.Invoke(unbox onDidChangeActiveTextEditor')
                 |> context.subscriptions.Add
 
-            let onModelChanged' = onModelChanged state
+            let onModelChanged' = onModelChanged treeView state
             rootChanged.Invoke(unbox onModelChanged')
                 |> context.subscriptions.Add
 

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -459,7 +459,9 @@ module SolutionExplorer =
 
         let private onDidChangeTreeVisibility (tree : TreeView<Model>) (state : State option ref) (change: TreeViewVisibilityChangeEvent) =
             if change.visible && RevealConfiguration.getAutoReveal () then
-                revealTextEditor tree state window.activeTextEditor true
+                // Done on a small timeout to avoid VSCode double-selecting due to a race-condition
+                JS.setTimeout (fun () -> revealTextEditor tree state window.activeTextEditor true) 10
+                |> ignore
 
         let activate (context : ExtensionContext) (rootChanged : Event<Model>) (treeView : TreeView<Model>) =
             let state: State option ref = ref None


### PR DESCRIPTION
Enable auto-reveal (select the current file in solution explorer)

* Doesn't show the Fsharp view when not visible as it did before (They added `.visible` on `TreeView`)
* Can be enabled/disabled in settings (By default it follow the setting for auto-reveal in the file view)
* A manual sync is possible from a new button at the top of the view)

*PS: Need a new version of **Fable.Import.VSCode.fs** with https://github.com/ionide/ionide-vscode-helpers/pull/26*

![auto-reveal2](https://user-images.githubusercontent.com/131878/49341552-3c573e80-f64f-11e8-90ac-0ed998a8b6e3.gif)
