### PR TITLE
Add node_modules to default excludeProjectDirs

### DIFF
--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -52,7 +52,7 @@ module Project =
 
     let workspaceLoaded = EventEmitter<unit>()
 
-    let excluded = "FSharp.excludeProjectDirectories" |> Configuration.get [| ".git"; "paket-files"; ".fable" |]
+    let excluded = "FSharp.excludeProjectDirectories" |> Configuration.get [| ".git"; "paket-files"; ".fable"; "node_modules" |]
 
     let deepLevel = "FSharp.workspaceModePeekDeepLevel" |> Configuration.get 2 |> max 0
 


### PR DESCRIPTION
We may start pushing some Fable libraries via npm and I noticed that Ionide is trying to load the projects when it finds an .fsrpoj in one package within node_modules. Hopefully this PR disables that behaviour.