### PR TITLE
Fix #921: Add smart indent support

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1317,7 +1317,12 @@
 					],
 					"default": "sameAsFileExplorer",
 					"scope": "window"
-				}
+                },
+                "FSharp.smartIndent": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enables smart indent feature"
+                }
 			}
 		},
 		"jsonValidation": [

--- a/src/Components/LanguageConfiguration.fs
+++ b/src/Components/LanguageConfiguration.fs
@@ -7,7 +7,17 @@ open Ionide.VSCode.Helpers
 
 module LanguageConfiguration =
 
-    let activate (context : ExtensionContext) =
+    let mutable private reference : Disposable option = None
+
+    let indentationRules =
+        jsOptions<IndentationRule> (fun o ->
+            o.increaseIndentPattern <- JS.RegExp.Create("""^(\s*(module|type|let|static member|member)\b.*=\s*)$|^(\s*(with get|and set)\b.*=.*)$|^(\s*(if|elif|then|else|static member|member)).*$""")
+
+            o.decreaseIndentPattern <- JS.RegExp.Create("""^(\s*(else|elif|and)).*$""")
+        )
+
+    let setLanguageConfiguration (context : ExtensionContext) =
+        // Config always setted
         let config =
             jsOptions<LanguageConfiguration> (fun o ->
                 o.onEnterRules <- Some <| ResizeArray<OnEnterRule>(
@@ -26,6 +36,36 @@ module LanguageConfiguration =
                 )
             )
 
-        JS.console.log config.onEnterRules.Value.[0].beforeText
+        let activateSmartIndent = "FSharp.smartIndent" |> Configuration.get false
 
-        context.subscriptions.Add(vscode.languages.setLanguageConfiguration("fsharp", config))
+        if activateSmartIndent then
+            config.indentationRules <- Some indentationRules
+
+        let triggerNotification =
+            match reference with
+            | Some oldReference ->
+                // Disable previous language configuration if there was one
+                oldReference.dispose() |> ignore
+                true
+            | None ->
+                false
+
+        reference <- Some <| vscode.languages.setLanguageConfiguration("fsharp", config)
+
+        // Notify the user if needed
+        if triggerNotification then
+            let msg =
+                if activateSmartIndent then
+                    "Smart indent has been activated for F#"
+                else
+                    "Smart indent has been deactivated for F#"
+
+            vscode.window.showInformationMessage(msg) |> ignore
+
+        context.subscriptions.Add(reference)
+
+    let activate (context : ExtensionContext) =
+        // We listen for config change so we can update on the fly the language configuration
+        workspace.onDidChangeConfiguration $ (setLanguageConfiguration, context, context.subscriptions) |> ignore
+
+        setLanguageConfiguration context


### PR DESCRIPTION
Update the language configuration on the fly and notify the user:

![2019-01-25 16 36 48](https://user-images.githubusercontent.com/4760796/51756017-53029a80-20c0-11e9-8791-558965c00953.gif)

Code wrote with smart indent enabled:
![2019-01-25 16 37 18](https://user-images.githubusercontent.com/4760796/51756076-762d4a00-20c0-11e9-9b96-5a40e95df53a.gif)

Code wrote with smart indent disabled:
![2019-01-25 16 39 12](https://user-images.githubusercontent.com/4760796/51756106-90672800-20c0-11e9-8163-36a66a377da2.gif)
