### PR TITLE
Improve the error message if the error is about SDK version

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -8,7 +8,7 @@ _Part of the [Ionide](http://ionide.io) plugin suite._ Read detailed documentati
 
 You can support Ionide development on [Open Collective](https://opencollective.com/ionide).
 
-[![Open Collective](https://opencollective.com/webpack/donate/button.png?color=blue)](https://opencollective.com/ionide)
+[![Open Collective](https://opencollective.com/ionide/donate/button.png?color=blue)](https://opencollective.com/ionide)
 
 # Requirements
 
@@ -89,12 +89,24 @@ The library is available under [MIT license](https://github.com/ionide/ionide-vs
 
 ## Sponsors
 
-<a href="https://lambdafactory.io"><img src="https://cdn-images-1.medium.com/max/332/1*la7_YvDFvrtA720P5bYWBQ@2x.png" alt="drawing" width="100"/></a>
-
-Ionide couldn't be created without support of [Lambda Factory](https://lambdafactory.io). If you'd be interested in rich F# test integration check out our VSCode plugin - [Neptune](https://github.com/LambdaFactory/Neptune-public).
-
-If your company would be interested in supporting development of Ionide, or acquiring commercial support sent us email - lambda_factory@outlook.com
+Ionide couldn't be created without support of [Lambda Factory](https://lambdafactory.io). If your company would be interested in supporting development of Ionide, or acquiring commercial support sent us email - lambda_factory@outlook.com
 
 You can also support Ionide development on [Open Collective](https://opencollective.com/ionide).
 
-[![Open Collective](https://opencollective.com/webpack/donate/button.png?color=blue)](https://opencollective.com/ionide)
+[![Open Collective](https://opencollective.com/ionide/donate/button.png?color=blue)](https://opencollective.com/ionide)
+
+### Partners
+
+<div align="center">
+
+<a href="https://lambdafactory.io"><img src="https://cdn-images-1.medium.com/max/332/1*la7_YvDFvrtA720P5bYWBQ@2x.png" alt="drawing" width="100"/></a>
+
+</div>
+
+### Sponsors
+
+[Become a sponsor](https://opencollective.com/ionide) and get your logo on our README on Github, description in VSCode marketplace and on [ionide.io](http://ionide.io) with a link to your site.
+
+<div align="center">
+<a href="https://opencollective.com/ionide/sponsor/0/website?requireActive=false" target="_blank"><img src="https://opencollective.com/ionide/sponsor/0/avatar.svg?requireActive=false"></a>
+</div>

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -8,6 +8,7 @@ open Fable.Import.vscode
 open Fable.Import.Node
 open Ionide.VSCode.Helpers
 open System.Collections.Generic
+open System.Text.RegularExpressions
 
 open DTO
 module node = Fable.Import.Node.Exports
@@ -698,9 +699,26 @@ module SolutionExplorer =
                 |> String.concat "<br />"
 
             let viewFailed path error =
-                [ "<b>Status:</b> failed to load"; ""
-                  "<b>Error:</b>"
-                  error ]
+                let sdkErrorRegex = Regex("A compatible SDK version for global\.json version: \[([\d.]+)\].*was not found.*", RegexOptions.IgnoreCase)
+
+                let errorMsg =
+                    match sdkErrorRegex.Match error with
+                    | m when m.Success ->
+                        let version = m.Groups.[1].Value
+                        [ sprintf "A compatible SDK version for global.json version: <b>%s</b> was not found." version
+                          ""
+                          "If you haven't installed a compatible version on your computer, you can go to: <a href=\"https://dotnet.microsoft.com/download/archives\">https://dotnet.microsoft.com/download/archives</a> to download it."
+                          ""
+                          "<hr/>"
+                          "<b>Original error:</b>"
+                          ""
+                          error ]
+                    | _ ->
+                        [ error ]
+
+                [ "<b>Status:</b> failed to load"
+                  ""
+                  "<b>Error:</b>" ] @ errorMsg
                 |> String.concat "<br />"
 
             { new TextDocumentContentProvider with
@@ -931,5 +949,3 @@ module SolutionExplorer =
         )) |> context.subscriptions.Add
 
         ()
-
-


### PR DESCRIPTION
Fix #918

Preview:

<img width="1414" alt="capture d ecran 2019-02-07 a 11 28 19" src="https://user-images.githubusercontent.com/4760796/52405563-ddd59300-2acb-11e9-8e19-ccc80a2c4ec6.png">

The provided link goes to [https://dotnet.microsoft.com/download/archives](https://dotnet.microsoft.com/download/archives). Like that the user have access to all the version of the SDK.