### PR TITLE
tweak the configuration matrix to stop bugging users about their life choices

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1075,7 +1075,6 @@
 			"properties": {
 				"FSharp.fsacRuntime": {
 					"type": "string",
-					"default": "net",
 					"description": "Choose the runtime of FsAutocomplete (FSAC). Requires restart",
 					"enum": [
 						"net",

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -635,6 +635,8 @@ module LanguageService =
             | FSACTargetRuntime.NET -> "net"
             | FSACTargetRuntime.NetcoreFdd -> "netcore"
         Configuration.set runtimeSettingsKey value
+        |> Promise.bind (fun _ -> vscode.window.showInformationMessage("Please reload your VSCode instance for this change to take effect"))
+        |> Promise.map (fun _ -> ())
 
     let spawnFSACForRuntime (runtime: ConfigValue<FSACTargetRuntime>) rootPath =
         let spawnNetFSAC mono =

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -96,6 +96,9 @@ module Configuration =
     let getInContext context defaultValue key =
         workspace.getConfiguration(?resource = Some context).get(key, defaultValue)
 
+    let set key value =
+        workspace.getConfiguration().update(key, value, false)
+
 [<AutoOpen>]
 module Utils =
     open Fable.Core


### PR DESCRIPTION
Addresses a concern raised in #1026 about popups for target-runtime suggestions being raised even when the user has set an explicit value. Now we don't do that anymore.