### PR TITLE
allow users to set a configurable FSAC url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,13 +140,15 @@ The new extension window will appear with window title `Extension development ho
 
 ### Working with FSAC
 
-1. Run `build.cmd Build` \ `build.sh Build`
-2. Open Ionide-vscode-fsharp in VSCode.
-3. Run FSAC:
-    - or from sources in your favorite editor: open the `FsAutoComplete.sln`, start debugging with  `.NET Core mode http (debug)` configuration
+1. Run FSAC:
+    - or from sources in your favorite editor: open the `FsAutoComplete.sln`, start debugging with  `.NET Core mode http (debug)` configuration (default to port `8088`)
     - or run it with `--mode http --port 8088` arguments
-4. Press F5 in VSCode to build Ionide and start experimental instance
-5. In the new instance, set the `FSharp.fsacUrl` setting to `http://127.0.0.1:8088` and reload the experimental instance. Note that if you have changed the standard FSAC configuration to use a different port you will need to update that port number in the `FSharp.fsacUrl` setting.
+2. In vscode, set the `FSharp.fsacUrl` setting to `http://localhost:8088`
+3. Reload the instance with `> Developer: Reload Window`.
+
+The port number can be changed as needed.
+
+Remove that setting to go back to FSAC bundled in Ionide extension.
 
 ### Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,14 +137,15 @@ Once the initial build on the command line is completed, you should use vscode i
 These two options can be reached in VsCode in the bottom bar (look for triangle), or by typing `control-P Debug <space> ` and then selecting either `Build and Launch` or `Watch`
 
 The new extension window will appear with window title `Extension development host`
+
 ### Working with FSAC
 
 1. Run `build.cmd Build` \ `build.sh Build`
-1. Open Ionide-vscode-fsharp in VSCode.
-2. Set `devMode` to `true` in `src/Core/LanguageService.fs`
+2. Open Ionide-vscode-fsharp in VSCode.
 3. Open FSAC in VS
 4. Start FSAC.Suave in VS
 5. Press F5 in VSCode to build Ionide and start experimental instance
+6. In the new instance, set the `FSharp.fsacUrl` setting to `http://127.0.0.1:8088` and reload the experimental instance. Note that if you have changed the standard FSAC configuration to use a different port you will need to update that port number in the `FSharp.fsacUrl` setting.
 
 ### Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,10 +142,11 @@ The new extension window will appear with window title `Extension development ho
 
 1. Run `build.cmd Build` \ `build.sh Build`
 2. Open Ionide-vscode-fsharp in VSCode.
-3. Open FSAC in VS
-4. Start FSAC.Suave in VS
-5. Press F5 in VSCode to build Ionide and start experimental instance
-6. In the new instance, set the `FSharp.fsacUrl` setting to `http://127.0.0.1:8088` and reload the experimental instance. Note that if you have changed the standard FSAC configuration to use a different port you will need to update that port number in the `FSharp.fsacUrl` setting.
+3. Run FSAC:
+    - or from sources in your favorite editor: open the `FsAutoComplete.sln`, start debugging with  `.NET Core mode http (debug)` configuration
+    - or run it with `--mode http --port 8088` arguments
+4. Press F5 in VSCode to build Ionide and start experimental instance
+5. In the new instance, set the `FSharp.fsacUrl` setting to `http://127.0.0.1:8088` and reload the experimental instance. Note that if you have changed the standard FSAC configuration to use a different port you will need to update that port number in the `FSharp.fsacUrl` setting.
 
 ### Dependencies
 

--- a/release/package.json
+++ b/release/package.json
@@ -1070,9 +1070,13 @@
 			"type": "object",
 			"title": "FSharp configuration",
 			"properties": {
+				"FSharp.fsacUrl": {
+					"type":"string",
+					"description": "The URL of an already-running instance of F# AutoComplete to use instead of the bundled version. Requires restart."
+				},
 				"FSharp.fsacRuntime": {
 					"type": "string",
-					"description": "Choose the runtime of FsAutocomplete (FSAC). Requires restart",
+					"description": "Choose the runtime of FsAutocomplete (FSAC). Requires restart.",
 					"enum": [
 						"net",
 						"netcore"
@@ -1238,7 +1242,7 @@
 						".fable",
 						"node_modules"
 					],
-					"description": "Directories in the array are excluded from project file search. Requires restart"
+					"description": "Directories in the array are excluded from project file search. Requires restart."
 				},
 				"FSharp.lineLens.enabled": {
 					"type": "string",
@@ -1296,12 +1300,12 @@
 						"packages/Analyzers",
 						"analyzers"
 					],
-					"description": "Directories in the array are used as a source of custom analyzers. Requires restart"
+					"description": "Directories in the array are used as a source of custom analyzers. Requires restart."
 				},
 				"FSharp.customTypecheckingDelay": {
 					"type": "number",
 					"default": -1,
-					"description": "Custom delay for error type checking. Use -1 for default behavior. Requires restart"
+					"description": "Custom delay for error type checking. Use -1 for default behavior. Requires restart."
 				},
 				"FSharp.disableInMemoryProjectReferences": {
 					"type": "boolean",

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -9,14 +9,22 @@ open Fable.Import.Node
 open Ionide.VSCode.Helpers
 open Fable.Import.ws
 
+
 open DTO
 open Fable.Import.Axios
+
+module URL =
+    /// Create a new URL from a url string
+    [<Emit("new URL($0)")>]
+    let create (urlString: string) : Fable.Import.Browser.URL = jsNative ""
+
+    /// Create a new URL with a relative path from some base URL
+    [<Emit("new URL($0, $1)")>]
+    let createFrom (relativeInput: string) (baseURL: Fable.Import.Browser.URL): Fable.Import.Browser.URL = jsNative ""
 
 module LanguageService =
 
     let ax =  Globals.require.Invoke "axios" |> unbox<Axios.AxiosStatic>
-
-    let devMode = false
 
     [<RequireQualifiedAccess>]
     type LogConfigSetting =
@@ -89,14 +97,29 @@ module LanguageService =
 
     let log, fsacStdoutWriter = createConfiguredLoggers "IONIDE-FSAC" "F# Language Service"
 
-    let genPort () =
+    let private genPort () =
         let r = JS.Math.random ()
         let r' = r * (8999. - 8100.) + 8100.
         r'.ToString().Substring(0,4)
 
-    let port = if devMode then "8088" else genPort ()
+    let private fsacUrlConfigured = Configuration.tryGet "FSharp.FSACUrl" |> Option.isSome
+    let private fsacUrl =
+        Configuration.tryGet "FSharp.fsacUrl"
+        |> Option.map URL.create
+        |> Option.map (fun url -> log.Info("FSAC Url was provided by configuration and is %s", url); url)
+        |> Option.defaultWith (fun _ ->
+            let port = genPort()
+            let url = URL.create (sprintf "http://127.0.0.1:%s" port)
+            log.Info ("No FSAC url provided, using %s", url)
+            url
+        )
 
-    let private url fsacAction requestId = (sprintf "http://127.0.0.1:%s/%s?requestId=%i" port fsacAction requestId)
+
+    let private url fsacAction requestId =
+        let baseUrl = URL.createFrom (sprintf "/%s" fsacAction) fsacUrl
+        baseUrl.search <- sprintf "requestId=%d" requestId
+        baseUrl.toString ()
+
     /// because node 7.x doesn't give us the signal used if a process dies, we have to set up our own signal to show if we died via our own `stop()` call.
     let mutable private exitRequested : bool = false
 
@@ -541,7 +564,9 @@ module LanguageService =
             true
 
     let private startSocket notificationEvent =
-        let address = sprintf "ws://localhost:%s/%s" port notificationEvent
+        let baseAddress = URL.createFrom (sprintf "/%s" notificationEvent) fsacUrl
+        baseAddress.protocol <- "ws"
+        let address = baseAddress.toString()
         try
             let sck = WebSocket address
             log.Info(sprintf "listening notification on /%s started" notificationEvent)
@@ -560,7 +585,7 @@ module LanguageService =
                 spawnLogged fsacExe
                   [ yield! fsacArgs
                     yield! ["--mode"; "http"]
-                    yield! ["--port"; port]
+                    yield! ["--port"; fsacUrl.port]
                     yield sprintf "--hostPID=%i" (int Globals.``process``.pid) ]
 
             let mutable isResolvedAsStarted = false
@@ -785,7 +810,7 @@ module LanguageService =
             )
 
         let startByDevMode =
-            if devMode
+            if fsacUrlConfigured
             then Promise.empty
             else doRetry startFSAC
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -813,6 +813,9 @@ module LanguageService =
             if shouldStartFSAC then
                 doRetry startFSAC
             else
+                let msg = sprintf "Using FSAC from url %O provided by configuration 'FSharp.fsacUrl'." fsacUrl
+                log.Debug(msg)
+                vscode.window.showInformationMessage(msg) |> ignore
                 Promise.empty
 
         startByDevMode


### PR DESCRIPTION
Fixes #1048 by adding a new configuration setting and flowing that through.  If the url is set we don't spawn an FSAC instance, but if it's not we use the same logic as before.