### PR TITLE
Fix build vsix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,33 @@
+name: $(Rev:r)
+jobs:
+- job: Windows
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - powershell: |
+      $buildId = $env:BUILD_BUILDNUMBER.PadLeft(7, '0');
+      $versionSuffixPR = "-PR$($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)-$buildId";
+      $branchName = "$env:BUILD_SOURCEBRANCHNAME".Replace("_","");
+      $versionSuffixBRANCH = "-$branchName-$buildId";
+      $isTag = "$env:BUILD_SOURCEBRANCH".StartsWith('refs/tags/');
+      $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne ""
+      $versionSuffix = if ($isTag) { "" } else { if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH } };
+      Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
+  - task: NodeTool@0
+    displayName: Install Node
+    inputs:
+      versionSpec: "10.15.1"
+  - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+    displayName: Install Yarn
+    inputs:
+      versionSpec: "1.10.1"
+  - script: .\build.cmd InstallVSCE
+    displayName: Install VSCE
+  - script: .\build.cmd BuildPackage
+    displayName: BuildPackage
+    env:
+      VersionSuffix: '$(VersionSuffix)'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: 'temp'
+      artifactName: 'ionide-fsharp-vscode-ext'

--- a/build.fsx
+++ b/build.fsx
@@ -278,7 +278,7 @@ Target "Release" DoNothing
 "YarnInstall" ==> "Build"
 "DotNetRestore" ==> "Build"
 
-"Default"
+"Build"
 ==> "SetVersion"
 // ==> "InstallVSCE"
 ==> "BuildPackage"


### PR DESCRIPTION
fix `BuildPackage` to run `Build` first, so contains fsac/forge etc.

require rebase after #1050 is merged ( ci green https://dev.azure.com/enricosada/ionide-vscode-fsharp/_build/results?buildId=67&view=results , with package in Summary tab )