### PR TITLE
add `experimental-fsharp` extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,4 @@ release/package-lock\.json
 /release/bin_netcore/
 /.ionide
 /vendor/.paket/Paket.Restore.targets
-/release-vnext/
+/release-exp/

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ release/package-lock\.json
 *.vsix
 /release/bin_netcore/
 /.ionide
+/vendor/.paket/Paket.Restore.targets
+/release-vnext/

--- a/README_EXPERIMENTAL.md
+++ b/README_EXPERIMENTAL.md
@@ -1,10 +1,10 @@
-# [Ionide-VSCode: FSharp - Experimental](https://marketplace.visualstudio.com/items/Ionide.Ionide-fsharp-experimental)
+# [Ionide: Experimental FSharp](https://marketplace.visualstudio.com/items/Ionide.experimental-fsharp)
 **Enhanced F# Language Features for Visual Studio Code (EXPERIMENTAL VERSION)**
 
 _Part of the [Ionide](http://ionide.io) plugin suite._ Read detailed documentation at [Ionide docs page](http://ionide.io/docs).
 
-[![Version](https://vsmarketplacebadge.apphb.com/version/Ionide.Ionide-fsharp-experimental.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp-experimental) [![Installs](https://vsmarketplacebadge.apphb.com/downloads-short/Ionide.Ionide-fsharp-experimental.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp-experimental)
-[![Rating](https://vsmarketplacebadge.apphb.com/rating-star/Ionide.Ionide-fsharp-experimental.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp-experimental)
+[![Version](https://vsmarketplacebadge.apphb.com/version/Ionide.experimental-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.experimental-fsharp) [![Installs](https://vsmarketplacebadge.apphb.com/downloads-short/Ionide.experimental-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.experimental-fsharp)
+[![Rating](https://vsmarketplacebadge.apphb.com/rating-star/Ionide.experimental-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.experimental-fsharp)
 [![open collective backers](https://img.shields.io/opencollective/backers/ionide.svg?color=blue)](https://opencollective.com/ionide)
 [![open collective sponsors](https://img.shields.io/opencollective/sponsors/ionide.svg?color=blue)](https://opencollective.com/ionide)
 
@@ -14,7 +14,7 @@ You can support Ionide development on [Open Collective](https://opencollective.c
 
 # Notes
 
-This is the experimental version, used to test new features, so can be unstable.
+This is the experimental version of Ionide plugin, used to test new features. Can be unstable.
 
 For normal usage, please use the stable [Ionide-VSCode: FSharp](https://marketplace.visualstudio.com/items/Ionide.Ionide-fsharp) extension instead.
 

--- a/README_EXPERIMENTAL.md
+++ b/README_EXPERIMENTAL.md
@@ -1,0 +1,114 @@
+# [Ionide-VSCode: FSharp - Experimental](https://marketplace.visualstudio.com/items/Ionide.Ionide-fsharp-experimental)
+**Enhanced F# Language Features for Visual Studio Code (EXPERIMENTAL VERSION)**
+
+_Part of the [Ionide](http://ionide.io) plugin suite._ Read detailed documentation at [Ionide docs page](http://ionide.io/docs).
+
+[![Version](https://vsmarketplacebadge.apphb.com/version/Ionide.Ionide-fsharp-experimental.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp-experimental) [![Installs](https://vsmarketplacebadge.apphb.com/downloads-short/Ionide.Ionide-fsharp-experimental.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp-experimental)
+[![Rating](https://vsmarketplacebadge.apphb.com/rating-star/Ionide.Ionide-fsharp-experimental.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp-experimental)
+[![open collective backers](https://img.shields.io/opencollective/backers/ionide.svg?color=blue)](https://opencollective.com/ionide)
+[![open collective sponsors](https://img.shields.io/opencollective/sponsors/ionide.svg?color=blue)](https://opencollective.com/ionide)
+
+You can support Ionide development on [Open Collective](https://opencollective.com/ionide).
+
+[![Open Collective](https://opencollective.com/ionide/donate/button.png?color=blue)](https://opencollective.com/ionide)
+
+# Notes
+
+This is the experimental version, used to test new features, so can be unstable.
+
+For normal usage, please use the stable [Ionide-VSCode: FSharp](https://marketplace.visualstudio.com/items/Ionide.Ionide-fsharp) extension instead.
+
+# Requirements
+
+* F# (Windows) - Easiest way to install latest versions of F# on Windows is using [VS Build Tools 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017#build-tools-for-visual-studio-2017). If you use VS 2017, make sure that you've installed workload adding F# support.
+
+* F# (Linux/MacOS) - F# on non-Windows platform is distributed as part of the `mono`. Installation guide and recent version of `mono` can be found on the [project webpage](https://www.mono-project.com/download/stable/) and on the F# Software Foundation ["Use on Linux" page](https://fsharp.org/use/linux/)
+
+* .NET Core SDK - .NET Core is modern, cross-platform implementation of .NET Framework. Ionide is requiring it for set of features such as project modifications or debugging. The core part of SDK is `dotnet` CLI tool that provides easy way to create, build and run F# projects. What's important - the `dotnet` tool can be used also to create applications targeting also Full Framework (like `net461`). For detailed instructions on installing .NET Core, visit [official step-by-step installation guide](https://www.microsoft.com/net/core).
+
+* VS Code C# plugin (optional) - Ionide's debugging capabilities relies on the debugger provided by Omnisharp team. To get it install [C# extension from VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+
+* MSBuild 2015 (Windows only, optional) - For old, verbose `.fsproj` files on Windows MSBuild 2015 (14.0) needs to be additionally installed. You can download it [here](https://www.microsoft.com/en-us/download/details.aspx?id=48159). However, we highly recommend using new, SDK-based project files.
+
+## Features
+
+- Syntax highlighting
+- Auto completions
+- Error highlighting, error list, and quick fixes based on errors
+- Tooltips
+- Method parameter hints
+- Go to Definition
+- Peek Definition
+- Find all references
+- Highlighting usages
+- Rename
+- Show symbols in file
+- Find symbol in workspace
+- Show signature in status bar
+- Show signature as CodeLens / LineLens
+- Go to MSDN help
+- Add `open NAMESPACE` for symbol
+- Match case generator
+- Go to #load reference
+- Generate comment for the symbol
+- Integration with F# Interactive
+- Integration with Forge (Project scaffolding and modification)
+- Integration with FSharpLint (additional hints and quick fixes)
+- Integration with MSBuild (Build, Rebuild, Clean project)
+- Solution / project explorer
+
+## How to get logs for debugging / issue reporting
+
+1. Enable Logging in User settings with
+  ```json
+// FSharp configuration
+    // Set the verbosity for F# Language Service Output Channel
+    "FSharp.logLanguageServiceRequestsOutputWindowLevel": "DEBUG",
+
+    // Enable logging language service requests (FSAC)  to an output channel, the developer tools console, or both
+    "FSharp.logLanguageServiceRequests": "both"
+  ```
+2. Open the Output Panel and switch to the `F# Language Service` Channel
+3. Or Toggle Developer Tools (`Help |> Toggle Developer Tools`) and open the console tab
+
+## How to contribute
+
+See https://github.com/ionide/ionide-vscode-fsharp/blob/master/CONTRIBUTING.md
+
+## Contributing and copyright
+
+The project is hosted on [GitHub](https://github.com/ionide/ionide-vscode-fsharp) where you can [report issues](https://github.com/ionide/ionide-vscode-fsharp/issues), fork
+the project and submit pull requests.
+
+The library is available under [MIT license](https://github.com/ionide/ionide-vscode-fsharp/blob/master/LICENSE.md), which allows modification and redistribution for both commercial and non-commercial purposes.
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## Sponsors
+
+Ionide couldn't be created without support of [Lambda Factory](https://lambdafactory.io). If your company would be interested in supporting development of Ionide, or acquiring commercial support sent us email - lambda_factory@outlook.com
+
+You can also support Ionide development on [Open Collective](https://opencollective.com/ionide).
+
+[![Open Collective](https://opencollective.com/ionide/donate/button.png?color=blue)](https://opencollective.com/ionide)
+
+### Partners
+
+<div align="center">
+
+<a href="https://lambdafactory.io"><img src="https://cdn-images-1.medium.com/max/332/1*la7_YvDFvrtA720P5bYWBQ@2x.png" alt="drawing" width="100"/></a>
+
+</div>
+
+### Sponsors
+
+[Become a sponsor](https://opencollective.com/ionide) and get your logo on our README on Github, description in VSCode marketplace and on [ionide.io](http://ionide.io) with a link to your site.
+
+<div align="center">
+<a href="https://opencollective.com/ionide/sponsor/0/website?requireActive=false" target="_blank"><img src="https://opencollective.com/ionide/sponsor/0/avatar.svg?requireActive=false" height="50px"></a>
+<a href="https://opencollective.com/ionide/sponsor/1/website?requireActive=false" target="_blank"><img src="https://opencollective.com/ionide/sponsor/1/avatar.svg?requireActive=false" height="50px"></a>
+ <a href="https://opencollective.com/ionide/sponsor/2/website?requireActive=false" target="_blank"><img src="https://opencollective.com/ionide/sponsor/2/avatar.svg?requireActive=false" height="50px"></a>
+ <a href="http://www.miltonsecurity.com/" target="_blank"><img src="https://opencollective-production.s3-us-west-1.amazonaws.com/dec96cf0-3fd4-11e9-85d3-d3af44ed2d45.jpg" height="50px"></a>
+ <a href="https://opencollective.com/ionide/sponsor/3/website?requireActive=false" target="_blank"><img src="https://opencollective.com/ionide/sponsor/3/avatar.svg?requireActive=false" height="50px"></a>
+
+</div>

--- a/RELEASE_NOTES_EXPERIMENTAL.md
+++ b/RELEASE_NOTES_EXPERIMENTAL.md
@@ -1,4 +1,3 @@
-### 0.1.0 
+### 0.1.0
 
-* New experimental extension `Ionide-fsharp-experimental`
-
+* New experimental extension `experimental-fsharp`

--- a/RELEASE_NOTES_EXPERIMENTAL.md
+++ b/RELEASE_NOTES_EXPERIMENTAL.md
@@ -1,0 +1,4 @@
+### 0.1.0 
+
+* New experimental extension `Ionide-fsharp-experimental`
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,11 +23,42 @@ jobs:
       versionSpec: "1.10.1"
   - script: .\build.cmd InstallVSCE
     displayName: Install VSCE
-  - script: .\build.cmd BuildPackages
-    displayName: BuildPackages
+  - script: .\build.cmd BuildPackage
+    displayName: BuildPackage
     env:
       VersionSuffix: '$(VersionSuffix)'
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: 'temp'
       artifactName: 'ionide-fsharp-vscode-ext'
+- job: Windows
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - powershell: |
+      $buildId = $env:BUILD_BUILDNUMBER.PadLeft(7, '0');
+      $versionSuffixPR = "-PR$($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)-$buildId";
+      $branchName = "$env:BUILD_SOURCEBRANCHNAME".Replace("_","");
+      $versionSuffixBRANCH = "-$branchName-$buildId";
+      $isTag = "$env:BUILD_SOURCEBRANCH".StartsWith('refs/tags/');
+      $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne ""
+      $versionSuffix = if ($isTag) { "" } else { if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH } };
+      Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
+  - task: NodeTool@0
+    displayName: Install Node
+    inputs:
+      versionSpec: "10.15.1"
+  - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+    displayName: Install Yarn
+    inputs:
+      versionSpec: "1.10.1"
+  - script: .\build.cmd InstallVSCE
+    displayName: Install VSCE
+  - script: .\build.cmd BuildPackageExp
+    displayName: BuildPackageExp
+    env:
+      VersionSuffix: '$(VersionSuffix)'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: 'temp'
+      artifactName: 'experimental-fsharp-vscode-ext'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 name: $(Rev:r)
 jobs:
-- job: Windows
+- job: ionide-fsharp
   pool:
     vmImage: 'vs2017-win2016'
   steps:
@@ -31,7 +31,7 @@ jobs:
     inputs:
       pathtoPublish: 'temp'
       artifactName: 'ionide-fsharp-vscode-ext'
-- job: Windows
+- job: experimental-fsharp
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,6 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - powershell: |
-      $buildId = $env:BUILD_BUILDNUMBER.PadLeft(7, '0');
-      $versionSuffixPR = "-PR$($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)-$buildId";
-      $branchName = "$env:BUILD_SOURCEBRANCHNAME".Replace("_","");
-      $versionSuffixBRANCH = "-$branchName-$buildId";
-      $isTag = "$env:BUILD_SOURCEBRANCH".StartsWith('refs/tags/');
-      $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne ""
-      $versionSuffix = if ($isTag) { "" } else { if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH } };
-      Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
   - task: NodeTool@0
     displayName: Install Node
     inputs:
@@ -25,8 +16,6 @@ jobs:
     displayName: Install VSCE
   - script: .\build.cmd BuildPackage
     displayName: BuildPackage
-    env:
-      VersionSuffix: '$(VersionSuffix)'
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: 'temp'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 name: $(Rev:r)
 jobs:
-- job: ionide-fsharp
+- job: IonideFsharp
   pool:
     vmImage: 'vs2017-win2016'
   steps:
@@ -31,7 +31,7 @@ jobs:
     inputs:
       pathtoPublish: 'temp'
       artifactName: 'ionide-fsharp-vscode-ext'
-- job: experimental-fsharp
+- job: ExperimentalFsharp
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,13 +25,12 @@ jobs:
     vmImage: 'vs2017-win2016'
   steps:
   - powershell: |
-      $buildId = $env:BUILD_BUILDNUMBER.PadLeft(7, '0');
-      $versionSuffixPR = "-PR$($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)-$buildId";
+      $buildId = $env:BUILD_BUILDNUMBER;
+      $versionSuffixPR = "PR$($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER).$buildId";
       $branchName = "$env:BUILD_SOURCEBRANCHNAME".Replace("_","");
-      $versionSuffixBRANCH = "-$branchName-$buildId";
-      $isTag = "$env:BUILD_SOURCEBRANCH".StartsWith('refs/tags/');
-      $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne ""
-      $versionSuffix = if ($isTag) { "" } else { if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH } };
+      $versionSuffixBRANCH = "$branchName.$buildId";
+      $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne "";
+      $versionSuffix = if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH };
       Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
   - task: NodeTool@0
     displayName: Install Node
@@ -43,10 +42,10 @@ jobs:
       versionSpec: "1.10.1"
   - script: .\build.cmd InstallVSCE
     displayName: Install VSCE
-  - script: .\build.cmd BuildPackageExp
+  - script: .\build.cmd BuildPackageExp extVersionSuffix=%ExtVersionSuffix%
     displayName: BuildPackageExp
     env:
-      VersionSuffix: '$(VersionSuffix)'
+      ExtVersionSuffix: '$(VersionSuffix)'
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: 'temp'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,14 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
+  - powershell: |
+      $buildId = $env:BUILD_BUILDNUMBER;
+      $versionSuffixPR = "PR$($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER).$buildId";
+      $branchName = "$env:BUILD_SOURCEBRANCHNAME".Replace("_","");
+      $versionSuffixBRANCH = "$branchName.$buildId";
+      $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne "";
+      $versionSuffix = if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH };
+      Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
   - task: NodeTool@0
     displayName: Install Node
     inputs:
@@ -14,8 +22,10 @@ jobs:
       versionSpec: "1.10.1"
   - script: .\build.cmd InstallVSCE
     displayName: Install VSCE
-  - script: .\build.cmd BuildPackage
+  - script: .\build.cmd BuildPackage extVersionSuffix=%ExtVersionSuffix%
     displayName: BuildPackage
+    env:
+      ExtVersionSuffix: '$(VersionSuffix)'
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: 'temp'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,8 +23,8 @@ jobs:
       versionSpec: "1.10.1"
   - script: .\build.cmd InstallVSCE
     displayName: Install VSCE
-  - script: .\build.cmd BuildPackage
-    displayName: BuildPackage
+  - script: .\build.cmd BuildPackages
+    displayName: BuildPackages
     env:
       VersionSuffix: '$(VersionSuffix)'
   - task: PublishBuildArtifacts@1

--- a/build.fsx
+++ b/build.fsx
@@ -455,7 +455,4 @@ Target "BuildPackages" DoNothing
 ==> "ExpPublishToGallery"
 ==> "ReleaseExp"
 
-"BuildPackage" ==> "BuildPackages"
-"BuildPackageExp" ==> "BuildPackages"
-
 RunTargetOrDefault "Default"

--- a/build.fsx
+++ b/build.fsx
@@ -301,6 +301,7 @@ module ExperimentalExtension =
         fileName
         |> File.ReadAllText
         |> fun text -> text.Replace("Ionide-fsharp", "Ionide-fsharp-experimental") // case sensitive is the only occurrence
+        |> fun text -> text.Replace("ionide-fsharp", "ionide-fsharp-experimental") // case sensitive is the only two occurrence
         |> fun text -> File.WriteAllText(fileName, text)
     )
 

--- a/build.fsx
+++ b/build.fsx
@@ -188,6 +188,11 @@ let releaseGithub (release: ReleaseNotes) =
     |> releaseDraft
     |> Async.RunSynchronously
 
+Target "InstallVSCE" ( fun _ ->
+    killProcess "npm"
+    run npmTool "install -g vsce" ""
+)
+
 module StableExtension =
 
     Target "CopyDocs" (fun _ ->
@@ -261,11 +266,6 @@ module StableExtension =
     Target "ReleaseGitHub" (fun _ ->
         releaseGithub release
     )
-
-Target "InstallVSCE" ( fun _ ->
-    killProcess "npm"
-    run npmTool "install -g vsce" ""
-)
 
 module ExperimentalExtension =
 

--- a/build.fsx
+++ b/build.fsx
@@ -269,7 +269,7 @@ module StableExtension =
 
 module ExperimentalExtension =
 
-    let releaseExp = "release-exp"
+    let releaseExpDir = "release-exp"
 
     Target "ExpRunScript" (fun _ ->
         // Ideally we would want a production (minized) build but UglifyJS fail on PerMessageDeflate.js as it contains non-ES6 javascript.
@@ -277,17 +277,17 @@ module ExperimentalExtension =
     )
 
     Target "ExpCopyAssets" (fun _ ->
-        ensureDirectory releaseExp
+        ensureDirectory releaseExpDir
 
         [ "release/package.json"
           "release/language-configuration.json" ]
-        |> CopyFiles releaseExp
+        |> CopyFiles releaseExpDir
 
-        CopyDir (sprintf "%s/images" releaseExp) "release/images" (fun _ -> true)
+        CopyDir (sprintf "%s/images" releaseExpDir) "release/images" (fun _ -> true)
     )
 
     Target "ExpUpdatePackageId" (fun _ ->
-        let dir = releaseExp
+        let dir = releaseExpDir
 
         // replace "name": "Ionide-fsharp" with "Ionide-fsharp-experimental"
         let fileName = Path.Combine(dir, "package.json")
@@ -318,10 +318,10 @@ module ExperimentalExtension =
 
         let fsacDir = "vendor/paket-files/github.com/fsharp/FsAutoComplete"
 
-        let releaseBin = sprintf "%s/bin" releaseExp
+        let releaseBin = sprintf "%s/bin" releaseExpDir
         let fsacBin = sprintf "%s/bin/release" fsacDir
 
-        let releaseBinNetcore = sprintf "%s/bin_netcore" releaseExp
+        let releaseBinNetcore = sprintf "%s/bin_netcore" releaseExpDir
         let fsacBinNetcore = sprintf "%s/bin/release" fsacDir
 
         ensureDirectory releaseBin
@@ -335,27 +335,27 @@ module ExperimentalExtension =
 
     Target "ExpCopyForge" (fun _ ->
         let forgeDir = "paket-files/github.com/fsharp-editing/Forge"
-        let releaseForge = sprintf "%s/bin_forge" releaseExp
+        let releaseForge = sprintf "%s/bin_forge" releaseExpDir
 
         copyForge forgeDir releaseForge
     )
 
     Target "ExpCopyGrammar" (fun _ ->
         let fsgrammarDir = "paket-files/github.com/ionide/ionide-fsgrammar/grammar"
-        let fsgrammarRelease = sprintf "%s/syntaxes" releaseExp
+        let fsgrammarRelease = sprintf "%s/syntaxes" releaseExpDir
 
         copyGrammar fsgrammarDir fsgrammarRelease
     )
 
     Target "ExpCopySchemas" (fun _ ->
         let fsschemaDir = "schemas"
-        let fsschemaRelease = sprintf "%s/schemas" releaseExp
+        let fsschemaRelease = sprintf "%s/schemas" releaseExpDir
 
         copySchemas fsschemaDir fsschemaRelease
     )
 
     Target "BuildPackageExp" ( fun _ ->
-        buildPackage releaseExp
+        buildPackage releaseExpDir
     )
 
     // Read additional information from the release notes document
@@ -369,11 +369,11 @@ module ExperimentalExtension =
     let releaseMsg = (sprintf "Release %s\n" release.NugetVersion) + msg
 
     Target "ExpSetVersion" (fun _ ->
-        setVersion release releaseExp
+        setVersion release releaseExpDir
     )
 
     Target "ExpPublishToGallery" ( fun _ ->
-        publishToGallery releaseExp
+        publishToGallery releaseExpDir
     )
 
     Target "ExpReleaseGitHub" (fun _ ->

--- a/build.fsx
+++ b/build.fsx
@@ -397,10 +397,6 @@ module ExperimentalExtension =
         publishToGallery releaseExpDir
     )
 
-    Target "ExpReleaseGitHub" (fun _ ->
-        releaseGithub releaseExp
-    )
-
 
 // --------------------------------------------------------------------------------------
 // Run generator by default. Invoke 'build <Target>' to override
@@ -456,7 +452,6 @@ Target "BuildPackages" DoNothing
 ==> "Release"
 
 "BuildPackageExp"
-==> "ExpReleaseGitHub"
 ==> "ExpPublishToGallery"
 ==> "ReleaseExp"
 

--- a/build.fsx
+++ b/build.fsx
@@ -1,3 +1,4 @@
+open Fake.IO
 // --------------------------------------------------------------------------------------
 // FAKE build script
 // --------------------------------------------------------------------------------------
@@ -70,6 +71,8 @@ Target "Clean" (fun _ ->
     CleanDir "./temp"
     CopyFiles "release" ["README.md"; "LICENSE.md"]
     CopyFile "release/CHANGELOG.md" "RELEASE_NOTES.md"
+
+    CleanDir "./release-exp"
 )
 
 Target "YarnInstall" <| fun () ->
@@ -241,6 +244,8 @@ module ExperimentalExtension =
         [ "release/package.json"
           "release/language-configuration.json" ]
         |> CopyFiles releaseExp
+
+        CopyDir (sprintf "%s/images" releaseExp) "release/images" (fun _ -> true)
     )
 
     Target "ExpUpdatePackageId" (fun _ ->
@@ -251,7 +256,7 @@ module ExperimentalExtension =
 
         fileName
         |> File.ReadAllText
-        |> fun text -> text.Replace("Ionide-fsharp", "Ionide-fsharp-vNext") // case sensitive is the only occurrence
+        |> fun text -> text.Replace("Ionide-fsharp", "Ionide-fsharp-experimental") // case sensitive is the only occurrence
         |> fun text -> File.WriteAllText(fileName, text)
     )
 
@@ -375,10 +380,11 @@ Target "BuildPackages" DoNothing
 ==> "SetVersion"
 // ==> "InstallVSCE"
 ==> "BuildPackage"
-==> "BuildPackageExp"
-==> "BuildPackages"
 ==> "ReleaseGitHub"
 ==> "PublishToGallery"
 ==> "Release"
+
+"BuildPackage" ==> "BuildPackages"
+"BuildPackageExp" ==> "BuildPackages"
 
 RunTargetOrDefault "Default"

--- a/build.fsx
+++ b/build.fsx
@@ -17,6 +17,13 @@ open Fake.ZipHelper
 
 #nowarn "44"
 
+let extVersionSuffix =
+    match getBuildParamOrDefault "extVersionSuffix" "" with
+    | "" -> None
+    | v -> Some v
+
+printfn "extension version suffix: %A" extVersionSuffix
+
 // Git configuration (used for publishing documentation in gh-pages branch)
 // The profile where the project is posted
 let gitOwner = "ionide"
@@ -146,7 +153,11 @@ let setPackageJsonField name value releaseDir =
     File.WriteAllLines(fileName,lines)
 
 let setVersion (release: ReleaseNotes) releaseDir =
-    setPackageJsonField "version" (sprintf "\"%O\"" release.NugetVersion) releaseDir
+    let versionString =
+        match extVersionSuffix with
+        | None -> sprintf "\"%O\"" release.NugetVersion
+        | Some prerelease -> sprintf "\"%O-%s\"" release.NugetVersion prerelease
+    setPackageJsonField "version" versionString releaseDir
 
 let publishToGallery releaseDir =
     let token =

--- a/build.fsx
+++ b/build.fsx
@@ -195,6 +195,8 @@ Target "InstallVSCE" ( fun _ ->
 
 module StableExtension =
 
+    let ionideExtensionGuid = "0ea05e3f-5a38-419d-8305-f6c3f6d409d2"
+
     Target "CopyDocs" (fun _ ->
         CopyFiles "release" ["README.md"; "LICENSE.md"]
         CopyFile "release/CHANGELOG.md" "RELEASE_NOTES.md"
@@ -271,6 +273,7 @@ module ExperimentalExtension =
 
     let releaseExpDir = "release-exp"
     let experimentalExtensionId = "experimental-fsharp"
+    let experimentalExtensionGuid = "e55f9a16-11f8-4e9c-854c-5fb440534340"
 
     Target "ExpRunScript" (fun _ ->
         // Ideally we would want a production (minized) build but UglifyJS fail on PerMessageDeflate.js as it contains non-ES6 javascript.
@@ -296,7 +299,7 @@ module ExperimentalExtension =
     Target "ExpUpdatePackageId" (fun _ ->
         let dir = releaseExpDir
 
-        // replace "name": "Ionide-fsharp" with "Ionide-fsharp-experimental"
+        // replace "name": "Ionide-fsharp" with "experimental-fsharp"
         let fileName = Path.Combine(dir, "package.json")
 
         let capitalize (s: string) = sprintf "%c%s" (s.[0] |> Char.ToUpper) (s.Substring(1))
@@ -305,6 +308,7 @@ module ExperimentalExtension =
         |> File.ReadAllText
         |> fun text -> text.Replace(capitalize "ionide-fsharp", experimentalExtensionId) // case sensitive is the only occurrence
         |> fun text -> text.Replace("ionide-fsharp", experimentalExtensionId) // case sensitive is the only two occurrence
+        |> fun text -> text.Replace(StableExtension.ionideExtensionGuid, experimentalExtensionGuid) // replace guid of extension
         |> fun text -> File.WriteAllText(fileName, text)
     )
 

--- a/build.fsx
+++ b/build.fsx
@@ -270,7 +270,7 @@ module StableExtension =
 module ExperimentalExtension =
 
     let releaseExpDir = "release-exp"
-    let experimentalExtensionId = "ionide-fsharp-experimental"
+    let experimentalExtensionId = "experimental-fsharp"
 
     Target "ExpRunScript" (fun _ ->
         // Ideally we would want a production (minized) build but UglifyJS fail on PerMessageDeflate.js as it contains non-ES6 javascript.
@@ -303,7 +303,7 @@ module ExperimentalExtension =
 
         fileName
         |> File.ReadAllText
-        |> fun text -> text.Replace(capitalize "ionide-fsharp", capitalize experimentalExtensionId) // case sensitive is the only occurrence
+        |> fun text -> text.Replace(capitalize "ionide-fsharp", experimentalExtensionId) // case sensitive is the only occurrence
         |> fun text -> text.Replace("ionide-fsharp", experimentalExtensionId) // case sensitive is the only two occurrence
         |> fun text -> File.WriteAllText(fileName, text)
     )

--- a/build.fsx
+++ b/build.fsx
@@ -235,7 +235,7 @@ module ExperimentalExtension =
 
     Target "ExpRunScript" (fun _ ->
         // Ideally we would want a production (minized) build but UglifyJS fail on PerMessageDeflate.js as it contains non-ES6 javascript.
-        runFable (sprintf "--env.outputPath=%s" releaseExp) false
+        runFable "--env.ionideExperimental" false
     )
 
     Target "ExpCopyAssets" (fun _ ->
@@ -251,7 +251,7 @@ module ExperimentalExtension =
     Target "ExpUpdatePackageId" (fun _ ->
         let dir = releaseExp
 
-        // replace "name": "Ionide-fsharp" with "Ionide-fsharp-vNext"
+        // replace "name": "Ionide-fsharp" with "Ionide-fsharp-experimental"
         let fileName = Path.Combine(dir, "package.json")
 
         fileName

--- a/build.fsx
+++ b/build.fsx
@@ -295,6 +295,27 @@ module ExperimentalExtension =
         copyFSACNetcore releaseBinNetcore fsacBinNetcore
     )
 
+    Target "ExpCopyForge" (fun _ ->
+        let forgeDir = "paket-files/github.com/fsharp-editing/Forge"
+        let releaseForge = sprintf "%s/bin_forge" releaseExp
+
+        copyForge forgeDir releaseForge
+    )
+
+    Target "ExpCopyGrammar" (fun _ ->
+        let fsgrammarDir = "paket-files/github.com/ionide/ionide-fsgrammar/grammar"
+        let fsgrammarRelease = sprintf "%s/syntaxes" releaseExp
+
+        copyGrammar fsgrammarDir fsgrammarRelease
+    )
+
+    Target "ExpCopySchemas" (fun _ ->
+        let fsschemaDir = "schemas"
+        let fsschemaRelease = sprintf "%s/schemas" releaseExp
+
+        copySchemas fsschemaDir fsschemaRelease
+    )
+
     Target "BuildPackageExp" ( fun _ ->
         buildPackage releaseExp
     )
@@ -374,6 +395,9 @@ Target "BuildPackages" DoNothing
 ==> "ExpCopyAssets"
 ==> "ExpUpdatePackageId"
 ==> "ExpCopyFSAC"
+==> "ExpCopyForge"
+==> "ExpCopyGrammar"
+==> "ExpCopySchemas"
 ==> "BuildPackageExp"
 
 "Build"

--- a/build.fsx
+++ b/build.fsx
@@ -363,13 +363,14 @@ module ExperimentalExtension =
         File.ReadAllLines "RELEASE_NOTES_EXPERIMENTAL.md"
         |> parseAllReleaseNotes
 
-    let release = List.head releaseNotesExpData
+    let releaseExp = List.head releaseNotesExpData
 
-    let msg =  release.Notes |> List.fold (fun r s -> r + s + "\n") ""
-    let releaseMsg = (sprintf "Release %s\n" release.NugetVersion) + msg
+    let msg =  releaseExp.Notes |> List.fold (fun r s -> r + s + "\n") ""
+    let releaseExpMsg = (sprintf "Release %s\n" releaseExp.NugetVersion) + msg
 
     Target "ExpSetVersion" (fun _ ->
-        setVersion release releaseExpDir
+        printfn "Setting %s" releaseExpMsg
+        setVersion releaseExp releaseExpDir
     )
 
     Target "ExpPublishToGallery" ( fun _ ->
@@ -377,7 +378,7 @@ module ExperimentalExtension =
     )
 
     Target "ExpReleaseGitHub" (fun _ ->
-        releaseGithub release
+        releaseGithub releaseExp
     )
 
 

--- a/build.fsx
+++ b/build.fsx
@@ -270,6 +270,7 @@ module StableExtension =
 module ExperimentalExtension =
 
     let releaseExpDir = "release-exp"
+    let experimentalExtensionId = "ionide-fsharp-experimental"
 
     Target "ExpRunScript" (fun _ ->
         // Ideally we would want a production (minized) build but UglifyJS fail on PerMessageDeflate.js as it contains non-ES6 javascript.
@@ -298,10 +299,12 @@ module ExperimentalExtension =
         // replace "name": "Ionide-fsharp" with "Ionide-fsharp-experimental"
         let fileName = Path.Combine(dir, "package.json")
 
+        let capitalize (s: string) = sprintf "%c%s" (s.[0] |> Char.ToUpper) (s.Substring(1))
+
         fileName
         |> File.ReadAllText
-        |> fun text -> text.Replace("Ionide-fsharp", "Ionide-fsharp-experimental") // case sensitive is the only occurrence
-        |> fun text -> text.Replace("ionide-fsharp", "ionide-fsharp-experimental") // case sensitive is the only two occurrence
+        |> fun text -> text.Replace(capitalize "ionide-fsharp", capitalize experimentalExtensionId) // case sensitive is the only occurrence
+        |> fun text -> text.Replace("ionide-fsharp", experimentalExtensionId) // case sensitive is the only two occurrence
         |> fun text -> File.WriteAllText(fileName, text)
     )
 

--- a/build.fsx
+++ b/build.fsx
@@ -286,6 +286,12 @@ module ExperimentalExtension =
         CopyDir (sprintf "%s/images" releaseExpDir) "release/images" (fun _ -> true)
     )
 
+    Target "ExpCopyDocs" (fun _ ->
+        CopyFiles releaseExpDir ["LICENSE.md"]
+        CopyFile (sprintf "%s/README.md" releaseExpDir) "README_EXPERIMENTAL.md"
+        CopyFile (sprintf "%s/CHANGELOG.md" releaseExpDir) "RELEASE_NOTES_EXPERIMENTAL.md"
+    )
+
     Target "ExpUpdatePackageId" (fun _ ->
         let dir = releaseExpDir
 
@@ -418,6 +424,7 @@ Target "BuildPackages" DoNothing
 "Clean"
 ==> "ExpRunScript"
 ==> "ExpCopyAssets"
+==> "ExpCopyDocs"
 ==> "ExpUpdatePackageId"
 ==> "ExpCopyFSAC"
 ==> "ExpCopyForge"

--- a/release/package.json
+++ b/release/package.json
@@ -9,6 +9,7 @@
 		}
 	],
 	"description": "F# Language Support",
+	"preview": false,
 	"categories": [
 		"Linters",
 		"Programming Languages",

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -414,19 +414,24 @@ type ShowStatus private (panel : WebviewPanel, body : string) as this =
 [<RequireQualifiedAccess>]
 module VSCodeExtension =
 
-    let private addSuffix s =
+    let private extensionName =
 #if IONIDE_EXPERIMENTAL
-        s + "-experimental"
+        "ionide-fsharp-experimental"
 #else
-        s
+        "ionide-fsharp"
 #endif
 
     let ionidePluginPath () =
 
+        let capitalize (s: string) =
+            sprintf "%c%s" (s.[0] |> Char.ToUpper) (s.Substring(1))
+
+        let oldExtensionName = capitalize extensionName
+
         try
-            (VSCode.getPluginPath (addSuffix "Ionide.ionide-fsharp"))
+            (VSCode.getPluginPath (sprintf "Ionide.%s" extensionName))
         with
-        | _ -> (VSCode.getPluginPath (addSuffix "Ionide.Ionide-fsharp"))
+        | _ -> (VSCode.getPluginPath (sprintf "Ionide.%s" oldExtensionName))
 
     let workbeachViewId () =
-        addSuffix "workbench.view.extension.ionide-fsharp"
+        sprintf "workbench.view.extension.%s" extensionName

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -416,7 +416,7 @@ module VSCodeExtension =
 
     let private extensionName =
 #if IONIDE_EXPERIMENTAL
-        "ionide-fsharp-experimental"
+        "experimental-fsharp"
 #else
         "ionide-fsharp"
 #endif

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -415,7 +415,14 @@ type ShowStatus private (panel : WebviewPanel, body : string) as this =
 module VSCodeExtension =
 
     let ionidePluginPath () =
+        let addSuffix s =
+#if IONIDE_EXPERIMENTAL
+            s + "-experimental"
+#else
+            s
+#endif
+
         try
-            (VSCode.getPluginPath "Ionide.ionide-fsharp")
+            (VSCode.getPluginPath (addSuffix "Ionide.ionide-fsharp"))
         with
-        | _ -> (VSCode.getPluginPath "Ionide.Ionide-fsharp")
+        | _ -> (VSCode.getPluginPath (addSuffix "Ionide.Ionide-fsharp"))

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -414,15 +414,19 @@ type ShowStatus private (panel : WebviewPanel, body : string) as this =
 [<RequireQualifiedAccess>]
 module VSCodeExtension =
 
-    let ionidePluginPath () =
-        let addSuffix s =
+    let private addSuffix s =
 #if IONIDE_EXPERIMENTAL
-            s + "-experimental"
+        s + "-experimental"
 #else
-            s
+        s
 #endif
+
+    let ionidePluginPath () =
 
         try
             (VSCode.getPluginPath (addSuffix "Ionide.ionide-fsharp"))
         with
         | _ -> (VSCode.getPluginPath (addSuffix "Ionide.Ionide-fsharp"))
+
+    let workbeachViewId () =
+        addSuffix "workbench.view.extension.ionide-fsharp"

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -60,7 +60,7 @@ let activate (context : ExtensionContext) : Api =
         ))
         |> Promise.onSuccess (fun _ ->
             if showExplorer then
-                commands.executeCommand("workbench.view.extension.ionide-fsharp")
+                commands.executeCommand(VSCodeExtension.workbeachViewId ())
                 |> ignore
         )
         |> Promise.onSuccess (fun _ ->

--- a/vendor/paket.dependencies
+++ b/vendor/paket.dependencies
@@ -1,0 +1,3 @@
+version 5.169.0
+
+git https://github.com/fsharp/FsAutoComplete.git

--- a/vendor/paket.lock
+++ b/vendor/paket.lock
@@ -1,0 +1,4 @@
+
+GIT
+  remote: https://github.com/fsharp/FsAutoComplete.git
+     (5a217a4a1e08a8f1c27e30a0b5c4cdab7abab586)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,8 +18,14 @@ console.log("Bundling for " + (isProduction ? "production" : "development") + ".
 
 module.exports = function(env) {
 
-  var outputPath = (env && env.outputPath) || "release";
+  var ionideExperimental = (env && env.ionideExperimental);
+  var outputPath = ionideExperimental? "release-exp" : "release";
   console.log("Output path: " + outputPath);
+
+  var compilerDefines = isProduction ? [] : ["DEBUG"];
+  if (ionideExperimental) {
+    compilerDefines.push("IONIDE_EXPERIMENTAL");
+  }
 
   return {
   target: 'node',
@@ -51,7 +57,7 @@ module.exports = function(env) {
           loader: "fable-loader",
           options: {
             babel: babelOptions,
-            define: isProduction ? [] : ["DEBUG"]
+            define: compilerDefines
           }
         }
       },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,13 +16,18 @@ var babelOptions = fableUtils.resolveBabelOptions({
 var isProduction = process.argv.indexOf("-p") >= 0;
 console.log("Bundling for " + (isProduction ? "production" : "development") + "...");
 
-module.exports = {
+module.exports = function(env) {
+
+  var outputPath = (env && env.outputPath) || "release";
+  console.log("Output path: " + outputPath);
+
+  return {
   target: 'node',
   devtool: "source-map",
   entry: resolve('./src/Ionide.FSharp.fsproj'),
   output: {
     filename: 'fsharp.js',
-    path: resolve('./release'),
+    path: resolve('./' + outputPath),
     //library: 'IONIDEFSHARP',
     libraryTarget: 'commonjs'
   },
@@ -61,3 +66,4 @@ module.exports = {
     ]
   }
 };
+}


### PR DESCRIPTION
Add build of a new `experimental-fsharp` extension, who can be used to test new features or changes.

- the `experimental-fsharp` extension is built in `release-exp` directory
- add a compiler define `IONIDE_EXPERIMENTAL` when built in experimental extension
- add vendor lib with another copy of fsac, currectly built from tag `vnext` instead of `master`
- use assets (package.json, images, etc) of `ionide-fsharp`, but replace identifiers (done in code under `IONIDE_EXPERIMENTAL` define)
- add `RELEASE_NOTES_EXPERIMENTAL.md` and `README_EXPERIMENTAL.md`
- set experimental extension as preview

## Build infra
- add `BuildPackageExp` to build just the experimental package, and related `ReleaseExp` target to release it
- internal fake targets have `Exp` prefix
- azure pipeline build both extensions in parallel on different jobs
- both stable and experiemental have prerelease numbers in PR/branch from azure devops ci, like `PR{PR_NUMBER}-{UNIQUE_BUILD_NUMBER}` => `Ionide-fsharp-3.35.0-PR1054.47.vsix`. Users can download from build job summary and install as vsix


