### PR TITLE
remove workarounds

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -110,19 +110,6 @@ Target "CopyFSACNetcore" (fun _ ->
     CleanDir releaseBinNetcore
 
     CopyDir releaseBinNetcore fsacBinNetcore (fun _ -> true)
-    let mainfestFile = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
-  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
-    <security>
-      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
-        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
-      </requestedPrivileges>
-    </security>
-  </trustInfo>
-</assembly>"""
-
-    System.IO.File.WriteAllText(releaseBinNetcore </> "default.win32manifest", mainfestFile)
 )
 
 let releaseForge = "release/bin_forge"

--- a/build.fsx
+++ b/build.fsx
@@ -110,8 +110,6 @@ Target "CopyFSACNetcore" (fun _ ->
     CleanDir releaseBinNetcore
 
     CopyDir releaseBinNetcore fsacBinNetcore (fun _ -> true)
-    CopyFiles releaseBinNetcore !!"paket-files/github.com/fsharp/FsAutoComplete/src/FsAutoComplete.SymbolCache/bin/Release/netcoreapp2.1/*.json"
-
     let mainfestFile = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>


### PR DESCRIPTION
remove add default manifest workaround.
fixed by https://github.com/fsharp/FsAutoComplete/commit/9a35503f78382059b0efbfe3a53ea44c73a9629b

remove copy `.deps.json` and `.runtime.config.json` workaround
the `.dev.json` is not added, because is used only for development not in production (contains local paths from build machine)
fixed by https://github.com/fsharp/FsAutoComplete/commit/bd5ad65b939dac93c4bb39aa2ccb4d526b32d7e2