### PR TITLE
show  project loading error notifications only for fsproj

### DIFF
--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -667,7 +667,7 @@ module Project =
                     projectNotRestoredLoaded.fire d.Project
                     Some (true, d.Project, ProjectLoadingState.NotRestored (d.Project, msg) )
                 | ErrorData.ProjectParsingFailed d ->
-                    if not disableShowNotification then
+                    if not disableShowNotification && d.Project.EndsWith(".fsproj") then
                         let msg = "Project parsing failed: " + path.basename(d.Project)
                         vscode.window.showErrorMessage(msg, "Disable notification", "Show status")
                         |> Promise.map(fun res ->


### PR DESCRIPTION
the others like csproj show the error in solution explorer, but not as
notification

fix https://github.com/ionide/ionide-vscode-fsharp/issues/1065