### PR TITLE
add missing config for FSharp.notifyFsNotInFsproj

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1269,6 +1269,11 @@
 					"default": false,
 					"description": "Disables popup notifications for failed project loading"
 				},
+				"FSharp.notifyFsNotInFsproj": {
+					"type": "boolean",
+					"default": true,
+					"description": "Disables popup notifications for .fs files outside of project"
+				},
 				"FSharp.enableBackgroundSymbolCache": {
 					"type": "boolean",
 					"default": false,


### PR DESCRIPTION
without the config setting the UI disable doesnt work because cannot store the preference

fix https://github.com/ionide/ionide-vscode-fsharp/issues/1066