### PR TITLE
fix run command

### DIFF
--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -527,7 +527,6 @@ module Project =
             let! dotnet = Environment.dotnet
             match dotnet with
             | Some dotnet ->
-                let dotnet = if Environment.isWin then (sprintf "\"%s\"" dotnet) else dotnet
                 return Process.spawnWithShell dotnet "" cmd
             | None -> return! Promise.reject "dotnet binary not found"
         }


### PR DESCRIPTION
the `Process.spawnWithShell` already does the quoting of args as needed

Removed the quoting, otherwise get double quotes before exec