### PR TITLE
allow to build stable version of experimental

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ jobs:
       $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne "";
       $versionSuffix = if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH };
       Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
+    condition: eq(variables['ionide.isExperimentalRelease'], 'false')
   - task: NodeTool@0
     displayName: Install Node
     inputs:
@@ -42,6 +43,7 @@ jobs:
       $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne "";
       $versionSuffix = if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH };
       Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
+    condition: eq(variables['ionide.isExperimentalRelease'], 'false')
   - task: NodeTool@0
     displayName: Install Node
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,6 @@ jobs:
       $versionSuffix = if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH };
       Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
     displayName: Set Prerelease Version
-    condition: eq(variables['ionide.isExperimentalRelease'], 'false')
   - task: NodeTool@0
     displayName: Install Node
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ jobs:
       $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne "";
       $versionSuffix = if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH };
       Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
+    displayName: Set Prerelease Version
     condition: eq(variables['ionide.isExperimentalRelease'], 'false')
   - task: NodeTool@0
     displayName: Install Node
@@ -43,6 +44,7 @@ jobs:
       $isPR = "$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" -ne "";
       $versionSuffix = if ($isPR) { $versionSuffixPR } else { $versionSuffixBRANCH };
       Write-Host "##vso[task.setvariable variable=VersionSuffix]$versionSuffix";
+    displayName: Set Prerelease Version
     condition: eq(variables['ionide.isExperimentalRelease'], 'false')
   - task: NodeTool@0
     displayName: Install Node


### PR DESCRIPTION
disable prerelease tag if `ionide.isExperimentalRelease` var is set in azure devops build