### PR TITLE
Remove not in project warning

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1480,6 +1480,15 @@
 					"light": "#919191",
 					"highContrast": "#A2E2A2"
 				}
+			},
+			{
+				"id": "fsharp.statusBarWarnings",
+				"description": "Text colors for warnings shown in the status bar",
+				"defaults": {
+					"dark": "#FFCC00",
+					"light": "#FFCC00",
+					"highContrast": "#FFFF00"
+				}
 			}
 		]
 	},

--- a/release/package.json
+++ b/release/package.json
@@ -1328,11 +1328,6 @@
 					"default": false,
 					"description": "Disables popup notifications for failed project loading"
 				},
-				"FSharp.notifyFsNotInFsproj": {
-					"type": "boolean",
-					"default": true,
-					"description": "Disables popup notifications for .fs files outside of project"
-				},
 				"FSharp.enableBackgroundSymbolCache": {
 					"type": "boolean",
 					"default": false,

--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -105,29 +105,6 @@ module Errors =
             match event.document with
             | Document.FSharp ->
                 promise {
-                    let fileInProj =
-                        if path.extname event.document.fileName = ".fsx" then
-                            true
-                        else
-                            Project.getLoaded ()
-                            |> List.exists (fun n ->
-                                n.Files |> List.exists (fun p -> path.normalize p = path.normalize event.document.fileName ))
-
-                    let notifyFsNotInProject = "FSharp.notifyFsNotInFsproj" |> Configuration.get true
-                    let! _ =
-                        if (not fileInProj) && notifyFsNotInProject then
-                            promise {
-                                let! res = window.showWarningMessage(sprintf "File %s can't be found in any parsed project. Usually .fs files should be included in .fsproj file" (path.basename event.document.fileName), "Disable notification", "OK"  )
-                                let! _ =
-                                    if res = "Disable notification" then
-                                        Configuration.set "FSharp.notifyFsNotInFsproj" false
-                                    else
-                                        Promise.empty
-                                return ()
-                            }
-                        else
-                            Promise.empty
-
                     let! parseResult = parseFile event.document
 
                     if allowBackgroundParsing then

--- a/src/Components/Errors.fs
+++ b/src/Components/Errors.fs
@@ -191,7 +191,7 @@ module Errors =
         let d = ("FSharp.customTypecheckingDelay" |> Configuration.get -1.)
         customDelay <- d
         let allowBackgroundParsing = not ("FSharp.minimizeBackgroundParsing" |> Configuration.get false)
-        Project.projectLoaded.event $ (parseVisibleFileInProject, (), context.subscriptions) |> ignore
+        Project.projectLoaded $ (parseVisibleFileInProject, (), context.subscriptions) |> ignore
 
 
         deleteWatcher.onDidDelete $ (fun (uri : Uri) ->

--- a/src/Components/QuickInfoProject.fs
+++ b/src/Components/QuickInfoProject.fs
@@ -1,5 +1,6 @@
 namespace Ionide.VSCode.FSharp
 
+open Fable.Core
 open Fable.Import.vscode
 open Fable.Import.Node
 
@@ -26,7 +27,7 @@ module QuickInfoProject =
                     item.Value.text <- "$(circuit-board) Not in a F# project"
                     item.Value.tooltip <- sprintf "%s is not in any project known to Ionide" fileNameOnly
                     item.Value.command <- "fsharp.AddFileToProject"
-                    item.Value.color <- "#FFCC00"
+                    item.Value.color <- ThemeColor "fsharp.statusBarWarnings" |> U2.Case2
                     item.Value.show()
                 | _ -> ()
             | Some p ->

--- a/src/Components/QuickInfoProject.fs
+++ b/src/Components/QuickInfoProject.fs
@@ -21,10 +21,10 @@ module QuickInfoProject =
             match proj with
             | None ->
                 match te.document with
-                | Document.FSharp when path.extname te.document.fileName <> ".fsx" ->
-                    item.Value.text <- "$(circuit-board) Not in a project"
+                | Document.FSharp when path.extname te.document.fileName <> ".fsx" && not (te.document.isUntitled) ->
+                    item.Value.text <- "$(circuit-board) Not in a F# project"
                     item.Value.tooltip <- "This F# file is not in any project known to Ionide"
-                    item.Value.command <- undefined
+                    item.Value.command <- "fsharp.AddFileToProject"
                     item.Value.color <- "#FFCC00"
                     item.Value.show()
                 | _ -> ()

--- a/src/Components/QuickInfoProject.fs
+++ b/src/Components/QuickInfoProject.fs
@@ -22,8 +22,9 @@ module QuickInfoProject =
             | None ->
                 match te.document with
                 | Document.FSharp when path.extname te.document.fileName <> ".fsx" && not (te.document.isUntitled) ->
+                    let fileNameOnly = node.path.basename fileName
                     item.Value.text <- "$(circuit-board) Not in a F# project"
-                    item.Value.tooltip <- "This F# file is not in any project known to Ionide"
+                    item.Value.tooltip <- sprintf "%s is not in any project known to Ionide" fileNameOnly
                     item.Value.command <- "fsharp.AddFileToProject"
                     item.Value.color <- "#FFCC00"
                     item.Value.show()

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -48,7 +48,9 @@ module Project =
 
     let projectNotRestoredLoaded = EventEmitter<string>()
 
-    let projectLoaded = EventEmitter<Project>()
+    let private projectLoadedEmitter = EventEmitter<Project>()
+
+    let projectLoaded = projectLoadedEmitter.event
 
     let workspaceLoaded = EventEmitter<unit>()
 
@@ -220,7 +222,7 @@ module Project =
 
         let loaded (pr : ProjectResult) =
             if isNotNull pr then
-                projectLoaded.fire (pr.Data)
+                projectLoadedEmitter.fire (pr.Data)
                 Some (pr.Data.Project, (ProjectLoadingState.Loaded pr.Data))
             else
                 None
@@ -656,7 +658,7 @@ module Project =
         let projStatus =
             match res with
             | Choice1Of4 (pr: ProjectResult) ->
-                projectLoaded.fire (pr.Data)
+                projectLoadedEmitter.fire (pr.Data)
                 Some (true, pr.Data.Project, (ProjectLoadingState.Loaded pr.Data))
             | Choice2Of4 (pr: ProjectLoadingResult) ->
                 Some (false, pr.Data.Project, (ProjectLoadingState.Loading pr.Data.Project))

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -76,7 +76,6 @@ module Option =
 
 [<RequireQualifiedAccess>]
 module Document =
-
     let (|FSharp|CSharp|VB|Other|) (document : TextDocument) =
         if document.languageId = "fsharp" then FSharp
         else if document.languageId = "csharp" then CSharp

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -130,7 +130,7 @@ let activate (context : ExtensionContext) : Api =
     }
 
     let event = Fable.Import.vscode.EventEmitter<DTO.Project>()
-    Project.projectLoaded.event.Invoke(fun n ->
+    Project.projectLoaded.Invoke(fun n ->
         !!(setTimeout (fun _ -> event.fire n) 500.)
     ) |> ignore
 


### PR DESCRIPTION
This change completly remove the "This file is not in any F# project" warning (See #1078)

It's a good warning but doesn't need to be a "in your face" one, so I replaced it with the already existing project indicator in the status bar. It now morph to a message instead of disappearing when the file is not in any project

![image](https://user-images.githubusercontent.com/131878/57335417-d2bded80-7122-11e9-9b2f-334cc8f23db3.png)

The message is actually also a button that trigger the Forge command to add the current file to the project (That I didn't manage to make work, but debugging or even understanding Forge is for another day)

In addition to the previous implementation the warning also detects untitled (unsaved) files and ignore them.

*PS: Require https://github.com/ionide/ionide-vscode-helpers/pull/28 to be merged / integrated*