### PR TITLE
Ensure "Not in project" warning show when it should

### DIFF
--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -384,7 +384,7 @@ module MSBuild =
             | None -> undefined
         ) |> context.subscriptions.Add
 
-        Project.projectNotRestoredLoaded.event.Invoke(fun n -> restoreProjectWithoutParseData n |> unbox)
+        Project.projectNotRestoredLoaded.Invoke(fun n -> restoreProjectWithoutParseData n |> unbox)
         |> context.subscriptions.Add
 
         let registerCommand com (action : unit -> _) = vscode.commands.registerCommand(com, unbox<Func<obj, obj>> action) |> context.subscriptions.Add

--- a/src/Components/QuickInfoProject.fs
+++ b/src/Components/QuickInfoProject.fs
@@ -58,3 +58,18 @@ module QuickInfoProject =
             handler window.activeTextEditor
             undefined)
         |> context.subscriptions.Add
+
+        Project.projectNotRestoredLoaded.Invoke(fun _project ->
+            handler window.activeTextEditor
+            undefined)
+        |> context.subscriptions.Add
+
+        Project.workspaceChanged.Invoke(fun _workspacePeek ->
+            handler window.activeTextEditor
+            undefined)
+        |> context.subscriptions.Add
+
+        Project.workspaceLoaded.Invoke(fun () ->
+            handler window.activeTextEditor
+            undefined)
+        |> context.subscriptions.Add

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -491,7 +491,7 @@ module SolutionExplorer =
 
         let treeViewId = ShowInActivity.initializeAndGetId ()
 
-        Project.workspaceChanged.event.Invoke(fun _ ->
+        Project.workspaceChanged.Invoke(fun _ ->
             emiter.fire (undefined) |> unbox)
         |> context.subscriptions.Add
 


### PR DESCRIPTION
There were cases where the warning was showing only due to a transient status immediately resolved but the status bar wasn't updating.

The code now subscribe to more project and workspace events to ensure that the status bar is up-to-date

Follow-up to https://github.com/ionide/ionide-vscode-fsharp/pull/1093

(It will also fix cases where the project indicator was previously absent and would show when changing files and going back, the problem was already present before #1093 just a lot less visible as it didn't result in a yellow item in the status bar)