### PR TITLE
Update plugin initialization 

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1141,25 +1141,6 @@
 						"netcore"
 					]
 				},
-				"FSharp.workspaceMode": {
-					"type": "string",
-					"default": "sln",
-					"description": "Choose the workspace mode",
-					"enum": [
-						"sln",
-						"directory",
-						"ionideSearch"
-					]
-				},
-				"FSharp.workspaceLoader": {
-					"type": "string",
-					"default": "workspaceLoad",
-					"description": "Choose the FSAC workspace loader",
-					"enum": [
-						"projects",
-						"workspaceLoad"
-					]
-				},
 				"FSharp.workspaceModePeekDeepLevel": {
 					"type": "integer",
 					"default": 2,


### PR DESCRIPTION
1. Adds support for both .Net Core and .Net runties of FSAC - using .Net Core as default
2. Removes multiple project loading strategies - `workspaceLoad` will be always used. 