### PR TITLE
convert project file paths to uri-style file paths

### DIFF
--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -307,11 +307,15 @@ module LanguageService =
             )
 
     let workspaceLoad (projects: string list)  =
+        let toFileUri (s: string) = "file://" + s
         match client with
         | None -> Promise.empty
         | Some cl ->
             let req : Types.WorkspaceLoadParms= {
-                TextDocuments = projects |> List.map (fun s -> {Types.Uri = s}) |> List.toArray
+                TextDocuments =
+                    projects
+                        |> List.map (fun s -> {Types.Uri = toFileUri s})
+                        |> List.toArray
             }
             cl.sendRequest("fsharp/workspaceLoad", req)
             |> Promise.map (fun (res: Types.PlainNotification) ->


### PR DESCRIPTION
this matches the contract of the  property and allows for better precision.

This should be lossless: the data we get back from workspacepeek right now is raw file paths, so simple concatenation is fine.