### PR TITLE
Fix/1130

### DIFF
--- a/src/Components/QuickInfoProject.fs
+++ b/src/Components/QuickInfoProject.fs
@@ -21,8 +21,9 @@ module QuickInfoProject =
             let proj = Project.tryFindLoadedProjectByFile fileName
             match proj with
             | None ->
-                match te.document with
-                | Document.FSharp when path.extname te.document.fileName <> ".fsx" && not (te.document.isUntitled) ->
+                let workspaceLoaded = Project.isLoadingWorkspaceComplete()
+                match workspaceLoaded, te.document with
+                | true, Document.FSharp when path.extname te.document.fileName <> ".fsx" && not (te.document.isUntitled) ->
                     let fileNameOnly = node.path.basename fileName
                     item.Value.text <- "$(circuit-board) Not in a F# project"
                     item.Value.tooltip <- sprintf "%s is not in any project known to Ionide" fileNameOnly


### PR DESCRIPTION
This should resolve #1130.

I just disabled showing "Not in a F# project" in status bar if the workspace is not fully loaded.
While the workspace is loading we do not know if the file is in project or not so we should probably just be quiet.
Is this OK?