### PR TITLE
add gitignore component

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1511,6 +1511,11 @@
 						"fsharp"
 					],
 					"scope": "application"
+				},
+				"FSharp.suggestGitignore": {
+					"type": "boolean",
+					"default": true,
+					"description": "Allow Ionide to prompt whenever internal data files aren't included in your project's .gitignore"
 				}
 			}
 		},

--- a/src/Components/Gitignore.fs
+++ b/src/Components/Gitignore.fs
@@ -1,0 +1,58 @@
+/// Prompt users to add VSCode lines to their gitignore if the config is set
+namespace Ionide.VSCode.FSharp
+
+module Gitignore =
+
+    open Fable.Core
+    open Fable.Import.Node
+    open Fable.Import.vscode
+    open Ionide.VSCode.Helpers
+    open Ionide.VSCode.FSharp
+
+    let GITIGNORE_KEY = "FSharp.suggestGitignore"
+
+    let checkGitignore patterns =
+        let patterns = Set.ofSeq patterns
+        try
+            let lines =
+                fs.readFileSync(".gitignore", "utf8")
+                |> String.split [| '\n' |]
+
+            (patterns, lines)
+            ||> Array.fold (fun notFoundPats line ->
+                if notFoundPats |> Set.contains line
+                then notFoundPats |> Set.remove line
+                else notFoundPats
+            )
+        with e -> patterns
+
+    let writePatternsToGitignore patterns =
+        let data = patterns |> String.concat System.Environment.NewLine
+        fs.appendFileSync(".gitignore", data, "utf8")
+
+    let disablePrompt () =
+        Configuration.set GITIGNORE_KEY false
+
+    let patternsToIgnore = [
+        ".fake"
+        ".ionide"
+    ]
+
+    let checkForPatternsAndPromptUser () = promise {
+        match checkGitignore patternsToIgnore |> Set.toList with
+        | [] -> ()
+        | missingPatterns ->
+            match! window.showInformationMessage("You are missing entries in your .gitignore for Ionide-specific data files. Would you like to add them?", [|"Add entries"; "Ignore"|]) with
+            | "Add entries" ->
+                writePatternsToGitignore missingPatterns
+            | "Ignore" ->
+                do! disablePrompt ()
+            | _ -> ()
+    }
+
+    let activate _context =
+        if Configuration.get true GITIGNORE_KEY
+        then checkForPatternsAndPromptUser () |> ignore
+        else ()
+
+

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -95,8 +95,13 @@ module Configuration =
     let getInContext context defaultValue key =
         workspace.getConfiguration(?resource = Some context).get(key, defaultValue)
 
+    /// write the value to the given key in the workspace configuration
     let set key value =
         workspace.getConfiguration().update(key, value, false)
+
+    /// write the value to the given key in the global configuration
+    let setGlobal key value =
+        workspace.getConfiguration().update(key, value, true)
 
 [<AutoOpen>]
 module Utils =

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -44,6 +44,7 @@
     <Compile Include="Components/InfoPanel.fs" />
     <Compile Include="Components/CodeLensHelpers.fs" />
     <Compile Include="Components/FakeTargetsOutline.fs" />
+    <Compile Include="Components/Gitignore.fs" />
     <Compile Include="fsharp.fs" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="Core/Logging.fs" />
     <Compile Include="Core/LanguageService.fs" />
     <Compile Include="Core/Project.fs" />
+    <Compile Include="Components/Gitignore.fs" />
     <Compile Include="Components/LanguageConfiguration.fs" />
     <Compile Include="Components/SignatureData.fs" />
     <Compile Include="Components/Fsi.fs" />
@@ -44,7 +45,6 @@
     <Compile Include="Components/InfoPanel.fs" />
     <Compile Include="Components/CodeLensHelpers.fs" />
     <Compile Include="Components/FakeTargetsOutline.fs" />
-    <Compile Include="Components/Gitignore.fs" />
     <Compile Include="fsharp.fs" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -67,6 +67,7 @@ let activate (context : ExtensionContext) : Fable.Import.JS.Promise<Api> =
         InfoPanel.activate context
         CodeLensHelpers.activate context
         FakeTargetsOutline.activate context
+        Gitignore.activate context
 
         let buildProject project = promise {
             let! exit = MSBuild.buildProjectPath "Build" project


### PR DESCRIPTION
a simple implementation of #1159 that check gitignore content for two patterns and adds the ones it can't find, if the user prompts.  Also includes an 'ignore' button the user can click to silence the prompt.

I can't test this locally because the fable build doesn't seem to be picking up the new file, even though dotnet build definitely does.  Thoughts?