### PR TITLE
add setting `FSharp.fsac.netExePath` for custom fsautocomplete.exe

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1236,6 +1236,11 @@
 					"default": "",
 					"description": "The path to the 'fsautocomplete.dll', useful for debugging a self-built fsac."
 				},
+				"FSharp.fsac.netExePath": {
+					"type": "string",
+					"default": "",
+					"description": "The path to the 'fsautocomplete.exe', useful for debugging a self-built fsac."
+				},
 				"FSharp.fsac.attachDebugger": {
 					"type": "boolean",
 					"default": false,

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -538,12 +538,13 @@ Consider:
         let verbose = "FSharp.verboseLogging" |> Configuration.get false
 
         let spawnNetCore dotnet =
-            let ionidePluginPath =
+            let fsautocompletePath =
                 if String.IsNullOrEmpty fsacPath then VSCodeExtension.ionidePluginPath () + "/bin_netcore/fsautocomplete.dll"
                 else fsacPath
+            printfn "FSAC (NETCORE): '%s'" fsautocompletePath
             let args =
                 [
-                    yield ionidePluginPath
+                    yield fsautocompletePath
                     yield"--mode"
                     yield "lsp"
                     if fsacAttachDebugger then yield "--attachdebugger"
@@ -558,7 +559,8 @@ Consider:
             ]
 
         let spawnNetWin () =
-            let ionidePluginPath = VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.exe"
+            let fsautocompletePath = VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.exe"
+            printfn "FSAC (NET): '%s'" fsautocompletePath
             let args =
                 [
                     yield "--mode"
@@ -568,16 +570,17 @@ Consider:
                 ] |> ResizeArray
 
             createObj [
-                "command" ==> ionidePluginPath
+                "command" ==> fsautocompletePath
                 "args" ==> args
                 "transport" ==> 0
             ]
 
         let spawnNetMono mono =
-            let ionidePluginPath = VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.exe"
+            let fsautocompletePath = VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.exe"
+            printfn "FSAC (MONO): '%s'" fsautocompletePath
             let args =
                 [
-                    yield ionidePluginPath
+                    yield fsautocompletePath
                     yield "--mode"
                     yield "lsp"
                     if backgroundSymbolCache then yield "--background-service-enabled"

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -535,6 +535,7 @@ Consider:
         let backgroundSymbolCache = "FSharp.enableBackgroundServices" |> Configuration.get true
         let fsacAttachDebugger = "FSharp.fsac.attachDebugger" |> Configuration.get false
         let fsacNetcorePath = "FSharp.fsac.netCoreDllPath" |> Configuration.get ""
+        let fsacNetPath = "FSharp.fsac.netExePath" |> Configuration.get ""
         let verbose = "FSharp.verboseLogging" |> Configuration.get false
 
         let spawnNetCore dotnet =
@@ -559,7 +560,9 @@ Consider:
             ]
 
         let spawnNetWin () =
-            let fsautocompletePath = VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.exe"
+            let fsautocompletePath =
+                if String.IsNullOrEmpty fsacNetPath then VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.exe"
+                else fsacNetPath
             printfn "FSAC (NET): '%s'" fsautocompletePath
             let args =
                 [
@@ -576,7 +579,9 @@ Consider:
             ]
 
         let spawnNetMono mono =
-            let fsautocompletePath = VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.exe"
+            let fsautocompletePath =
+                if String.IsNullOrEmpty fsacNetPath then VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.exe"
+                else fsacNetPath
             printfn "FSAC (MONO): '%s'" fsautocompletePath
             let args =
                 [

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -534,13 +534,13 @@ Consider:
 
         let backgroundSymbolCache = "FSharp.enableBackgroundServices" |> Configuration.get true
         let fsacAttachDebugger = "FSharp.fsac.attachDebugger" |> Configuration.get false
-        let fsacPath = "FSharp.fsac.netCoreDllPath" |> Configuration.get ""
+        let fsacNetcorePath = "FSharp.fsac.netCoreDllPath" |> Configuration.get ""
         let verbose = "FSharp.verboseLogging" |> Configuration.get false
 
         let spawnNetCore dotnet =
             let fsautocompletePath =
-                if String.IsNullOrEmpty fsacPath then VSCodeExtension.ionidePluginPath () + "/bin_netcore/fsautocomplete.dll"
-                else fsacPath
+                if String.IsNullOrEmpty fsacNetcorePath then VSCodeExtension.ionidePluginPath () + "/bin_netcore/fsautocomplete.dll"
+                else fsacNetcorePath
             printfn "FSAC (NETCORE): '%s'" fsautocompletePath
             let args =
                 [


### PR DESCRIPTION
add setting `FSharp.fsac.netExePath` to set path of custom fsautocomplete.exe (.NET)

log fsac path at startup