### PR TITLE
enhance solution explorer for projects

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -613,10 +613,10 @@ NUGET
       FSharp.Core (>= 4.3.4) - restriction: >= netstandard2.0
 GIT
   remote: https://github.com/fsharp/FsAutoComplete.git
-     (158baaec8bb95b171422cc94723cf71b9ef92a00)
+     (49056f4ca916f7ab9d8c40a77f1e515c86ae3a8e)
       build: build.cmd LocalRelease
       os: windows
-     (158baaec8bb95b171422cc94723cf71b9ef92a00)
+     (49056f4ca916f7ab9d8c40a77f1e515c86ae3a8e)
       build: build.sh LocalRelease
       os: mono
   remote: https://github.com/ionide/Forge.git

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -226,6 +226,14 @@ module DTO =
         { Command : string
           Arguments : string }
 
+    type ProjectResponseItem =
+        {
+          Name: string
+          FilePath: string
+          VirtualPath: string
+          Metadata: Map<string, string>
+        }
+
     type Project =
         { Project : ProjectFilePath
           Files : SourceFilePath list
@@ -234,6 +242,7 @@ module DTO =
           Logs : Map<string, string>
           OutputType : string
           Info : ProjectResponseInfo
+          Items: ProjectResponseItem list
           AdditionalInfo : Map<string, string> }
 
     type FsdnRequest =


### PR DESCRIPTION
use new FsAutocomplete support for project visual items (ref https://github.com/fsharp/FsAutoComplete/pull/424)

- same VS behaviour for compile file outside fsproj directory (not in subdirectory). The visual path will show only the file name. No more trees with lot of nested `..`
- support `Link` metadata for `Compile` items, to change the visual tree path

![image](https://user-images.githubusercontent.com/147243/61258100-48be8080-a774-11e9-932b-db62b38d684d.png)


cleanup project tree management:
- the visual path is generated backend side
- the visual path use always `/` as dir separators