### PR TITLE
Fix - add content security policy to info panel web view

### DIFF
--- a/src/Components/InfoPanel.fs
+++ b/src/Components/InfoPanel.fs
@@ -39,6 +39,7 @@ module InfoPanel =
                     sprintf """
                     <html>
                     <head>
+                    <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
                     <style>
                     pre {color: var(--textCodeBlock.background)}
                     </style>


### PR DESCRIPTION
Attempting to resolve #1199.

Currently unsure if `content="default-src 'none'` is the correct security policy to use.

https://code.visualstudio.com/api/extension-guides/webview#security