### PR TITLE
Use a shorter name for Configuration title

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1229,7 +1229,7 @@
 		},
 		"configuration": {
 			"type": "object",
-			"title": "FSharp configuration",
+			"title": "F#",
 			"properties": {
 				"FSharp.fsac.netCoreDllPath": {
 					"type": "string",


### PR DESCRIPTION
'FSharp Configuration' is long and repeating the fact that it's a
configuration while the user see that inside a configuration editor is
redundant. 'F#' is short and recognizable.

Before:
![image](https://user-images.githubusercontent.com/131878/64479197-e43c0280-d1b3-11e9-8a58-31eb971097a8.png)

After:
![image](https://user-images.githubusercontent.com/131878/64479207-18172800-d1b4-11e9-8b7b-2b2f04829763.png)


