### PR TITLE
no longer chunk messages because underlying node lib is better

### DIFF
--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -97,13 +97,9 @@ module Fsi =
         | Some fo -> Promise.lift fo
         |> Promise.onSuccess (fun fp ->
             fp.show true
-
-            //send in chunks of 256, terminal has a character limit
-            msgWithNewline
-            |> chunkStringBySize 256
-            |> List.iter (fun x -> fp.sendText(x,false))
-
-            lastSelectionSent <- Some msg)
+            fp.sendText(msgWithNewline, false)
+            lastSelectionSent <- Some msg
+        )
         |> Promise.onFail (fun _ ->
             window.showErrorMessage "Failed to send text to FSI" |> ignore)
 


### PR DESCRIPTION
Per https://github.com/ionide/ionide-vscode-fsharp/issues/1242#issuecomment-541135786 the underlying node library is better so we may not need to chunk the message anymore.