### PR TITLE
fix FSI spawning logic when the user is .net sdk but lacks .net framework

### DIFF
--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -62,13 +62,15 @@ module Fsi =
         promise {
             if isSdk
             then
-                match! LanguageService.dotnet() with
+                let! dotnet = LanguageService.dotnet ()
+                match dotnet with
                 | Some dotnet ->
                     return dotnet, [|yield "fsi"; yield! parms |]
                 | None ->
                     return failwith "dotnet fsi requested but no dotnet SDK was found."
             else
-                match! LanguageService.fsi () with
+                let! fsi = LanguageService.fsi ()
+                match fsi with
                 | Some fsi ->
                     return fsi, parms
                 | None ->
@@ -227,7 +229,6 @@ module Fsi =
                 return ()
         }
 
-
     let sendReferencesForProject project =
         project.References  |> List.filter (fun n -> n.EndsWith "FSharp.Core.dll" |> not && n.EndsWith "mscorlib.dll" |> not )  |> referenceAssemblies |> Promise.suppress |> ignore
 
@@ -246,7 +247,6 @@ module Fsi =
                 let ctn = ctn |> String.concat "\n"
                 e.insert(p,ctn))
             return () }
-
 
     let activate (context : ExtensionContext) =
         window.onDidCloseTerminal $ (handleCloseTerminal, (), context.subscriptions) |> ignore

--- a/src/Components/Gitignore.fs
+++ b/src/Components/Gitignore.fs
@@ -45,7 +45,8 @@ module Gitignore =
         match checkGitignore patternsToIgnore |> Set.toList with
         | [] -> ()
         | missingPatterns ->
-            match! window.showInformationMessage("You are missing entries in your .gitignore for Ionide-specific data files. Would you like to add them?", [|"Add entries"; "Ignore"; "Don't show again"|]) with
+            let! choice = window.showInformationMessage("You are missing entries in your .gitignore for Ionide-specific data files. Would you like to add them?", [|"Add entries"; "Ignore"; "Don't show again"|])
+            match choice with
             | "Add entries" ->
                 writePatternsToGitignore missingPatterns
             | "Ignore" ->

--- a/src/Components/ScriptRunner.fs
+++ b/src/Components/ScriptRunner.fs
@@ -13,17 +13,21 @@ module ScriptRunner =
         let scriptDir = node.path.dirname(scriptFile)
 
         promise {
-            let! (fsiBinary, _fsiParameters) = Fsi.fsiBinaryAndParameters ()
+            let! (fsiBinary, fsiParameters) = Fsi.fsiBinaryAndParameters ()
+            let flatArgs  =
+                fsiParameters
+                |> Array.map (sprintf "\"%s\"")
+                |> String.concat " "
             let (shellCmd, shellArgs, textToSend) =
                 match node.os.``type``() with
                 | "Windows_NT" ->
                     ("cmd.exe",
                      [| "/Q"; "/K" |],
-                     sprintf "cd \"%s\" && cls && \"%s\" \"%s\" && pause && exit" scriptDir fsiBinary scriptFile)
+                     sprintf "cd \"%s\" && cls && \"%s\" \"%s\" \"%s\" && pause && exit" scriptDir fsiBinary flatArgs scriptFile)
                 | _ ->
                     ("sh",
                      [||],
-                     sprintf "cd \"%s\" && clear && \"%s\" \"%s\" && echo \"Press enter to close script...\" && read && exit" scriptDir fsiBinary scriptFile)
+                     sprintf "cd \"%s\" && clear && \"%s\" \"%s\" \"%s\" && echo \"Press enter to close script...\" && read && exit" scriptDir fsiBinary flatArgs scriptFile)
 
             let title = node.path.basename scriptFile
             let terminal = window.createTerminal(title, shellCmd, shellArgs)

--- a/src/Components/ScriptRunner.fs
+++ b/src/Components/ScriptRunner.fs
@@ -13,6 +13,7 @@ module ScriptRunner =
         let scriptDir = node.path.dirname(scriptFile)
 
         promise {
+            // TODO: this doesn't work for .net core, is this component used?
             let! fsi =
                 LanguageService.fsi ()
                 |> Promise.bind (fun p ->

--- a/src/Components/ScriptRunner.fs
+++ b/src/Components/ScriptRunner.fs
@@ -13,24 +13,17 @@ module ScriptRunner =
         let scriptDir = node.path.dirname(scriptFile)
 
         promise {
-            // TODO: this doesn't work for .net core, is this component used?
-            let! fsi =
-                LanguageService.fsi ()
-                |> Promise.bind (fun p ->
-                    match p with
-                    | Some fsi -> Promise.lift fsi
-                    | None -> Promise.reject "FSI not found"
-                )
+            let! (fsiBinary, _fsiParameters) = Fsi.fsiBinaryAndParameters ()
             let (shellCmd, shellArgs, textToSend) =
                 match node.os.``type``() with
                 | "Windows_NT" ->
                     ("cmd.exe",
                      [| "/Q"; "/K" |],
-                     sprintf "cd \"%s\" && cls && \"%s\" \"%s\" && pause && exit" scriptDir fsi scriptFile)
+                     sprintf "cd \"%s\" && cls && \"%s\" \"%s\" && pause && exit" scriptDir fsiBinary scriptFile)
                 | _ ->
                     ("sh",
                      [||],
-                     sprintf "cd \"%s\" && clear && \"%s\" \"%s\" && echo \"Press enter to close script...\" && read && exit" scriptDir fsi scriptFile)
+                     sprintf "cd \"%s\" && clear && \"%s\" \"%s\" && echo \"Press enter to close script...\" && read && exit" scriptDir fsiBinary scriptFile)
 
             let title = node.path.basename scriptFile
             let terminal = window.createTerminal(title, shellCmd, shellArgs)


### PR DESCRIPTION
When users are on windows and using .Net Core, but _do not_ have .Net Framework installed, any attempt to launch an FSI shell will crash.

This is because in this situation:
* FSAC returns null for FSI path (because it is looking in the older framework paths)
* Ionide probes in framework paths for it (and is not found)
* and we unconditionally look for FSI regardless of the .Net Core opt-in a user may have done.

So instead this PR breaks out the 'support matrix' into four cases:
* .net core, 'dotnet' binary found -> invoke `dotnet fsi`
* .net core, 'dotnet' binary not found -> fail with message
* .net framework, 'fsi' path found -> invoke (mono) 'fsi'
* .net framework, 'fsi' path not found -> fail with message

This should fix #1247.

