### PR TITLE
Fix #1264

### DIFF
--- a/src/Components/ScriptRunner.fs
+++ b/src/Components/ScriptRunner.fs
@@ -23,11 +23,11 @@ module ScriptRunner =
                 | "Windows_NT" ->
                     ("cmd.exe",
                      [| "/Q"; "/K" |],
-                     sprintf "cd \"%s\" && cls && \"%s\" \"%s\" \"%s\" && pause && exit" scriptDir fsiBinary flatArgs scriptFile)
+                     sprintf "cd \"%s\" && cls && \"%s\" %s \"%s\" && pause && exit" scriptDir fsiBinary flatArgs scriptFile)
                 | _ ->
                     ("sh",
                      [||],
-                     sprintf "cd \"%s\" && clear && \"%s\" \"%s\" \"%s\" && echo \"Press enter to close script...\" && read && exit" scriptDir fsiBinary flatArgs scriptFile)
+                     sprintf "cd \"%s\" && clear && \"%s\" %s \"%s\" && echo \"Press enter to close script...\" && read && exit" scriptDir fsiBinary flatArgs scriptFile)
 
             let title = node.path.basename scriptFile
             let terminal = window.createTerminal(title, shellCmd, shellArgs)


### PR DESCRIPTION
for #1264

Currently "Run script" command executes as described below when `FSharp.useSdkScripts` is `true`;

- Windows  
   `cd "(scriptDir)" && cls && "dotnet" ""fsi" "--fsi-server-input-codepage:65001"" "(scriptFile)" && pause && exit`
- Others  
   `cd "(scriptDir)" && clear && "dotnet" ""fsi"" "(scriptFile)" && echo "Press enter to close script..." && read && exit`

`""fsi""` just works but `""fsi" "--fsi-server-input-codepage:65001""` does not.
