### PR TITLE
Recognize .gitignore paths that contain slashes at the start or the end.

### DIFF
--- a/src/Components/Gitignore.fs
+++ b/src/Components/Gitignore.fs
@@ -24,7 +24,7 @@ module Gitignore =
 
             (patterns, lines)
             ||> Array.fold (fun notFoundPats line ->
-                let line = line.Trim()
+                let line = line.Trim('\t', ' ', '/', '\\')
                 if notFoundPats |> Set.contains line
                 then notFoundPats |> Set.remove line
                 else notFoundPats


### PR DESCRIPTION
Some might ignore the directory `.ionide/`, but the extension would still recommend `.ionide` to be ignored.