### PR TITLE
Fix lines split for Windows system

### DIFF
--- a/src/Components/Gitignore.fs
+++ b/src/Components/Gitignore.fs
@@ -20,7 +20,7 @@ module Gitignore =
             logger.Debug("gitignore path:", (gitignorePath ()))
             let lines =
                 fs.readFileSync(gitignorePath (), "utf8")
-                |> String.split [| '\n' |]
+                |> String.split [| '\n'; '\r' |]
 
             (patterns, lines)
             ||> Array.fold (fun notFoundPats line ->


### PR DESCRIPTION
Hello!

Every times when I open F# project, I recieve Ionide message.

![image](https://user-images.githubusercontent.com/6348792/80923539-1c203780-8d8d-11ea-9020-aefd0a539aee.png)

I think this fix may be helpful.