### PR TITLE
Clarify documentation for fsiFIlePath

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1264,7 +1264,7 @@
 				"FSharp.fsiFilePath": {
 					"type": "string",
 					"default": "",
-					"description": "The path to the F# Interactive tool used by Ionide-FSharp",
+					"description": "The path to the F# Interactive tool used by Ionide-FSharp (.NET Framework only, on .NET Core `dotnet fsi` is run)",
 					"scope": "machine-overridable"
 				},
 				"FSharp.keywordsAutocomplete": {


### PR DESCRIPTION
`fsiFilePath` is only taken into account properly when running .NET Framework F# Interactive

Specifically if `isSdk` is true on [this code path](https://github.com/ionide/ionide-vscode-fsharp/blob/17dd55a2b0280ccadc07eaba4939eaca9a6cb46d/src/Components/Fsi.fs#L271) then `LanguageService.fsi` is never called.

For now just clarifying the documentation. I'll send a separate PR to respect a new setting `fsiFilePathForDotnetSdk` ?  