### PR TITLE
Remove .sln from activation event

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1629,7 +1629,6 @@
 		"workspaceContains:**/*.fs",
 		"workspaceContains:**/*.fsx",
 		"workspaceContains:**/*.fsproj",
-		"workspaceContains:**/*.sln",
 		"onLanguage:fsharp",
 		"onCommand:fsi.Start",
 		"onCommand:fsharp.NewProject"


### PR DESCRIPTION
Removing `.sln` from list of activation events, this is primarily due to this related issue:
https://github.com/fsharp/FsAutoComplete/issues/620

Thinking about it the combination of other events should be sufficient. What are your thoughts?