### PR TITLE
Docs link is broken, ionide.io is fine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Ionide-VSCode: FSharp](https://marketplace.visualstudio.com/items/Ionide.Ionide-fsharp)
 **Enhanced F# Language Features for Visual Studio Code**
 
-_Part of the [Ionide](https://ionide.io) plugin suite._ Read detailed documentation at [Ionide docs page](https://ionide.io/docs).
+_Part of the [Ionide](https://ionide.io) plugin suite._ Read detailed documentation at [Ionide docs page](https://ionide.io).
 
 [![Version](https://vsmarketplacebadge.apphb.com/version/Ionide.Ionide-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp) [![Installs](https://vsmarketplacebadge.apphb.com/downloads-short/Ionide.Ionide-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp)
 [![Rating](https://vsmarketplacebadge.apphb.com/rating-star/Ionide.Ionide-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp)

--- a/README_EXPERIMENTAL.md
+++ b/README_EXPERIMENTAL.md
@@ -1,7 +1,7 @@
 # [Ionide: Experimental FSharp](https://marketplace.visualstudio.com/items/Ionide.experimental-fsharp)
 **Enhanced F# Language Features for Visual Studio Code (EXPERIMENTAL VERSION)**
 
-_Part of the [Ionide](http://ionide.io) plugin suite._ Read detailed documentation at [Ionide docs page](http://ionide.io/docs).
+_Part of the [Ionide](http://ionide.io) plugin suite._ Read detailed documentation at [Ionide docs page](http://ionide.io).
 
 [![Version](https://vsmarketplacebadge.apphb.com/version/Ionide.experimental-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.experimental-fsharp) [![Installs](https://vsmarketplacebadge.apphb.com/downloads-short/Ionide.experimental-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.experimental-fsharp)
 [![Rating](https://vsmarketplacebadge.apphb.com/rating-star/Ionide.experimental-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.experimental-fsharp)


### PR DESCRIPTION
ionide.io/docs doesn't point anywhere and ionide.io appears to point to the docs. While it's a bit redundant, I think it reduces the risk of someone searching the readme over and over for the docs instead of just clicking the site link. 