### PR TITLE
Remove net FSAC target

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -62,13 +62,8 @@ let npmTool =
 let vsceTool = lazy (platformTool "vsce" "vsce.cmd")
 
 let runFable additionalArgs =
-    let cmd = "webpack " + additionalArgs 
+    let cmd = "webpack " + additionalArgs
     Yarn.exec cmd id
-
-let copyFSAC releaseBin fsacBin =
-    Directory.ensure releaseBin
-    Shell.cleanDir releaseBin
-    Shell.copyDir releaseBin fsacBin (fun _ -> true)
 
 let copyFSACNetcore releaseBinNetcore fsacBinNetcore =
     Directory.ensure releaseBinNetcore
@@ -217,15 +212,10 @@ Target.create "RunDevScript" (fun _ ->
     runFable "--mode development"
 )
 
-Target.create "CopyFSAC" (fun _ ->
-    let fsacBin = sprintf "%s/bin/release" fsacDir
-    let releaseBin = "release/bin"
-    copyFSAC releaseBin fsacBin
-)
 
 Target.create "CopyFSACNetcore" (fun _ ->
     let fsacBinNetcore = sprintf "%s/bin/release_netcore" fsacDir
-    let releaseBinNetcore = "release/bin_netcore"
+    let releaseBinNetcore = "release/bin"
 
     copyFSACNetcore releaseBinNetcore fsacBinNetcore
 )
@@ -296,7 +286,6 @@ Target.create "BuildPackages" ignore
 "Clean"
 ==> "RunScript"
 ==> "CopyDocs"
-==> "CopyFSAC"
 ==> "CopyFSACNetcore"
 ==> "CopyForge"
 ==> "CopyGrammar"

--- a/release/package.json
+++ b/release/package.json
@@ -1235,25 +1235,10 @@
 					"description": "The path to the 'fsautocomplete.dll', useful for debugging a self-built fsac.",
 					"scope": "machine-overridable"
 				},
-				"FSharp.fsac.netExePath": {
-					"type": "string",
-					"default": "",
-					"description": "The path to the 'fsautocomplete.exe', useful for debugging a self-built fsac.",
-					"scope": "machine-overridable"
-				},
 				"FSharp.fsac.attachDebugger": {
 					"type": "boolean",
 					"default": false,
 					"description": "Appends the '--attachdebugger' argument to fsac, this will allow you to attach the debugger."
-				},
-				"FSharp.fsacRuntime": {
-					"type": "string",
-					"description": "Choose the runtime of FsAutocomplete (FSAC). Requires restart.",
-					"enum": [
-						"net",
-						"netcore"
-					],
-					"default": "netcore"
 				},
 				"FSharp.workspaceModePeekDeepLevel": {
 					"type": "integer",

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -20,9 +20,7 @@ module Fsi =
 
         let shouldNotifyAboutSdkScripts () =
             let k = Configuration.get false useKey
-            match LanguageService.clientType with
-            | LanguageService.Types.FSACTargetRuntime.NetcoreFdd -> not k
-            | _ -> false
+            not k
 
 
         let disablePromptGlobally () =

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -572,7 +572,7 @@ Consider:
 
         let spawnNetCore dotnet =
             let fsautocompletePath =
-                if String.IsNullOrEmpty fsacNetcorePath then VSCodeExtension.ionidePluginPath () + "/bin_netcore/fsautocomplete.dll"
+                if String.IsNullOrEmpty fsacNetcorePath then VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.dll"
                 else fsacNetcorePath
             printfn "FSAC (NETCORE): '%s'" fsautocompletePath
             let args =


### PR DESCRIPTION
This removes an option to choose runtime on which FSAC is run - with Ionide 5.0 we will only use .NET Core runtime for running FSAC. 