### PR TITLE
Use `dotnet fsi` as default

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1534,7 +1534,7 @@
 				},
 				"FSharp.useSdkScripts": {
 					"type": "boolean",
-					"default": false,
+					"default": true,
 					"description": "Use 'dotnet fsi' instead of 'fsi.exe'/'fsharpi'"
 				},
 				"FSharp.dotNetRoot": {

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -19,7 +19,7 @@ module Fsi =
         let useKey = "FSharp.useSdkScripts"
 
         let shouldNotifyAboutSdkScripts () =
-            let k = Configuration.get false useKey
+            let k = Configuration.get true useKey
             not k
 
 


### PR DESCRIPTION
Use `dotnet fsi` as default rather than `fsi.exe`