### PR TITLE
Remove MsBuild host

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -214,10 +214,6 @@
 				"title": "MSBuild: Restore project"
 			},
 			{
-				"command": "MSBuild.switchMSbuildHostType",
-				"title": "MSBuild: Switch host type"
-			},
-			{
 				"command": "MSBuild.buildCurrentSolution",
 				"title": "MSBuild: Build current solution"
 			},
@@ -378,10 +374,6 @@
 			{
 				"command": "fsharp.explorer.project.generateFSI",
 				"title": "Generate references for FSI"
-			},
-			{
-				"command": "fsharp.explorer.msbuild.pickHost",
-				"title": "F#: Pick MsBuild Host"
 			},
 			{
 				"command": "fsharp.runDefaultProject",
@@ -619,10 +611,6 @@
 					"when": "false"
 				},
 				{
-					"command": "fsharp.explorer.msbuild.pickHost",
-					"when": "false"
-				},
-				{
 					"command": "fsharp.explorer.project.run",
 					"when": "false"
 				},
@@ -776,16 +764,6 @@
 				{
 					"command": "fsharp.changeWorkspace",
 					"group": "modification@1",
-					"when": "view == ionide.projectExplorerInActivity"
-				},
-				{
-					"command": "fsharp.explorer.msbuild.pickHost",
-					"group": "modification@2",
-					"when": "view == ionide.projectExplorer"
-				},
-				{
-					"command": "fsharp.explorer.msbuild.pickHost",
-					"group": "modification@2",
 					"when": "view == ionide.projectExplorerInActivity"
 				},
 				{
@@ -1348,17 +1326,6 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Automatically shows MsBuild output panel"
-				},
-				"FSharp.msbuildHost": {
-					"type": "string",
-					"default": "auto",
-					"description": "MSBuild host",
-					"enum": [
-						".net",
-						".net core",
-						"ask at first use",
-						"auto"
-					]
 				},
 				"FSharp.resolveNamespaces": {
 					"type": "boolean",

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -16,135 +16,21 @@ module MSBuild =
     let outputChannel = window.createOutputChannel "msbuild"
     let private logger = ConsoleAndOutputChannelLogger(Some "msbuild", Level.DEBUG, Some outputChannel, Some Level.DEBUG)
 
-    type MSbuildHost =
-        | MSBuildExe // .net on win, mono on non win
-        | DotnetCli
-        | Auto
-
-    type private Host () =
-        let mutable currentMsbuildHostType : MSbuildHost option = None
-        let _onMSbuildHostTypeDidChange = vscode.EventEmitter<MSbuildHost option>()
-
-        member public this.onMSbuildHostTypeDidChange with get () = _onMSbuildHostTypeDidChange.event
-
-        member public this.value
-            with get () = currentMsbuildHostType
-             and set host =
-                currentMsbuildHostType <- host
-                _onMSbuildHostTypeDidChange.fire(currentMsbuildHostType)
-
-    let private host = Host ()
-
-    let pickMSbuildHostType () =
-        promise {
-            let! envMsbuild = LanguageService.msbuild ()
-            let! envDotnet = LanguageService.dotnet()
-
-            let hosts =
-                [ yield envMsbuild |> Option.map (fun msbuild -> sprintf ".NET (%s)" msbuild, MSbuildHost.MSBuildExe)
-                  yield envDotnet |> Option.map (fun dotnet -> sprintf ".NET Core (%s msbuild)" dotnet, MSbuildHost.DotnetCli) ]
-                |> List.choose id
-                |> Map.ofList
-
-            let hostsLabels = hosts |> Map.toList |> List.map fst |> ResizeArray
-            let opts = createEmpty<QuickPickOptions>
-            opts.placeHolder <- Some "The msbuild host to use"
-            let! chosen = window.showQuickPick(hostsLabels |> U2.Case1, opts)
-            return
-                if JS.isDefined chosen
-                then
-                    logger.Debug("user choose host %s", chosen)
-                    host.value <- hosts |> Map.tryFind chosen
-                    host.value
-                else
-                    logger.Debug("user cancelled host pick")
-                    None
-        }
-
-
-    let loadMSBuildHostCfg () =
-        promise {
-            let cfg = vscode.workspace.getConfiguration()
-            return
-                match cfg.get ("FSharp.msbuildHost", "auto") with
-                | ".net" -> Some MSbuildHost.MSBuildExe
-                | ".net core" -> Some MSbuildHost.DotnetCli
-                | "auto" -> Some MSbuildHost.Auto
-                | "ask at first use" -> None
-                | _ -> None
-        }
-
-    let switchMSbuildHostType () =
-        promise {
-            logger.Debug "switching msbuild host (msbuild <-> dotnet cli)"
-            let! h =
-                match host.value with
-                | Some MSbuildHost.MSBuildExe ->
-                    Some MSbuildHost.DotnetCli |> Promise.lift
-                | Some MSbuildHost.DotnetCli ->
-                    Some MSbuildHost.MSBuildExe |> Promise.lift
-                | Some MSbuildHost.Auto | None ->
-                    logger.Debug("not yet choosen, try pick one")
-                    pickMSbuildHostType ()
-
-            host.value <- h
-
-            return h
-        }
-
-    let getMSbuildHostType () =
-        match host.value with
-        | Some h -> Some h |> Promise.lift
-        | None ->
-            promise {
-                logger.Debug "No MSBuild host selected yet"
-                let! hostFromConfig = loadMSBuildHostCfg ()
-                let! ho =
-                    match hostFromConfig with
-                    | Some h -> Some h |> Promise.lift
-                    | None -> pickMSbuildHostType ()
-
-                ho |> Option.iter (fun h -> host.value <- Some h)
-
-                return ho
-            }
-
-    let tryGetRightHostType (project : string) =
-        match Project.isSDKProjectPath project with
-        | true -> MSbuildHost.DotnetCli
-        | false -> MSbuildHost.MSBuildExe
-
-    let invokeMSBuild project target hostPreference =
+    let invokeMSBuild project target =
         let autoshow =
             let cfg = vscode.workspace.getConfiguration()
             cfg.get ("FSharp.msbuildAutoshow", false)
 
         let safeproject = sprintf "\"%s\"" project
         let command = sprintf "%s /t:%s" safeproject target
-        let executeWithHost host =
+        let executeWithHost () =
             promise {
-                let host' =
-                    match host with
-                    | MSbuildHost.Auto -> tryGetRightHostType project
-                    | h -> h
-
                 let! msbuildPath =
-                    match host' with
-                    | MSbuildHost.MSBuildExe ->
-                        LanguageService.msbuild ()
-                        |> Promise.bind (function Some msbuild -> Promise.lift msbuild
-                                                | None -> Promise.reject "MSBuild binary not found. Please install it from the [Visual Studio Download Page](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15)")
-                    | MSbuildHost.DotnetCli ->
-                        LanguageService.dotnet ()
-                        |> Promise.bind (function Some msbuild -> Promise.lift msbuild
-                                                | None -> Promise.reject "dotnet SDK not found. Please install it from the [Dotnet SDK Download Page](https://www.microsoft.com/net/download)")
-                    | MSbuildHost.Auto -> Promise.lift ""
+                    LanguageService.dotnet ()
+                    |> Promise.bind (function Some msbuild -> Promise.lift msbuild
+                                            | None -> Promise.reject "dotnet SDK not found. Please install it from the [Dotnet SDK Download Page](https://www.microsoft.com/net/download)")
 
-                let cmd =
-                    match host' with
-                    | MSbuildHost.MSBuildExe -> command
-                    | MSbuildHost.DotnetCli -> sprintf "msbuild %s" command
-                    | MSbuildHost.Auto -> ""
+                let cmd = sprintf "msbuild %s" command
                 logger.Info("invoking msbuild from %s on %s for target %s", msbuildPath, safeproject, target)
                 let _ =
                     if autoshow then outputChannel.show()
@@ -152,23 +38,13 @@ module MSBuild =
                         |> Process.toPromise
             }
 
-        let theMSbuildHostType =
-            match hostPreference with
-            | Some h -> Promise.lift (Some h)
-            | None -> getMSbuildHostType ()
-
-        theMSbuildHostType
-        |> Promise.bind (fun t ->
-            match t with
-            | None -> Promise.empty
-            | Some h ->
-                let progressOpts = createEmpty<ProgressOptions>
-                progressOpts.location <- ProgressLocation.Window
-                window.withProgress(progressOpts, (fun p ->
-                    let pm = createEmpty<ProgressMessage>
-                    pm.message <- "Running MsBuild " + target
-                    p.report pm
-                    executeWithHost h)))
+        let progressOpts = createEmpty<ProgressOptions>
+        progressOpts.location <- ProgressLocation.Window
+        window.withProgress(progressOpts, (fun p ->
+            let pm = createEmpty<ProgressMessage>
+            pm.message <- "Running MsBuild " + target
+            p.report pm
+            executeWithHost () ))
 
     /// discovers the project that the active document belongs to and builds that
     let buildCurrentProject target =
@@ -181,7 +57,7 @@ module MSBuild =
             match currentProject with
             | Some p ->
                 logger.Debug("found project %s", p.Project)
-                invokeMSBuild p.Project target None
+                invokeMSBuild p.Project target
             | None ->
                 logger.Debug("could not find a project that contained the file %s", window.activeTextEditor.document.fileName)
                 Promise.empty
@@ -207,7 +83,7 @@ module MSBuild =
             }
 
     /// prompts the user to choose a project (if not specified) and builds that project
-    let buildProject target projOpt hostOpt =
+    let buildProject target projOpt =
         promise {
             logger.Debug "building project"
             let! chosen =
@@ -216,28 +92,11 @@ module MSBuild =
                 | Some h -> Some h |> Promise.lift
             return! match chosen with
                     | None -> { Code = Some 0; Signal = None } |> Promise.lift
-                    | Some proj -> invokeMSBuild proj target hostOpt
+                    | Some proj -> invokeMSBuild proj target
         }
 
-    let tryGetRightHost (project : Project) =
-        match host.value with
-        | Some h -> h
-        | None ->
-            match Project.isSDKProject project with
-            | true -> MSbuildHost.DotnetCli
-            | false -> MSbuildHost.MSBuildExe
-
-    let tryGetRightHost' (project : string) =
-        match host.value with
-        | Some h -> h
-        | None ->
-            match Project.isSDKProjectPath project with
-            | true -> MSbuildHost.DotnetCli
-            | false -> MSbuildHost.MSBuildExe
-
     let buildProjectPath target (project : Project) =
-        let host = tryGetRightHost project
-        invokeMSBuild project.Project target (Some host)
+        invokeMSBuild project.Project target
 
     let buildProjectPathFast  (project : Project) =
         promise {
@@ -252,13 +111,12 @@ module MSBuild =
         MailboxProcessor.Start(fun inbox->
             let rec messageLoop() = async {
                 let! (path,continuation) = inbox.Receive()
-                let host = tryGetRightHost' path
                 do!
                     window.withProgress(progressOpts, (fun p ->
                         let pm = createEmpty<ProgressMessage>
                         pm.message <- sprintf "Restoring: %s" path
                         p.report pm
-                        invokeMSBuild path "Restore" (Some host)
+                        invokeMSBuild path "Restore"
                         |> Promise.bind continuation))
                     |> Async.AwaitPromise
                 return! messageLoop()
@@ -266,8 +124,8 @@ module MSBuild =
             messageLoop()
         )
 
-    let restoreProject (projOpt: string option) hostOpt =
-        buildProject "Restore" projOpt hostOpt
+    let restoreProject (projOpt: string option) =
+        buildProject "Restore" projOpt
         |> Promise.onSuccess (fun exit ->
             let failed = exit.Code <> Some 0
             match failed, projOpt with
@@ -292,19 +150,8 @@ module MSBuild =
         restoreProjectAsync path
 
     let buildSolution target sln = promise {
-        match host.value with
-        | Some h ->
-            let! _ = invokeMSBuild sln target (Some h)
-            return ()
-        | None ->
-            let! host = pickMSbuildHostType ()
-            match host with
-            | Some h ->
-                let! _ = invokeMSBuild sln target (Some h)
-                return ()
-            | None ->
-                let! _ = window.showWarningMessage "Host needs to be chosen for solution build"
-                return ()
+        let! _ = invokeMSBuild sln target
+        return ()
     }
 
     let buildCurrentSolution target =
@@ -396,60 +243,10 @@ module MSBuild =
         let registerCommand2 com (action : obj -> obj -> _) = vscode.commands.registerCommand(com, action |> objfy3) |> context.subscriptions.Add
 
         /// typed msbuild cmd. Optional project and msbuild host
-        let typedMsbuildCmd f projOpt hostOpt =
+        let typedMsbuildCmd f projOpt =
             let p = if JS.isDefined projOpt then Some (unbox<string>(projOpt)) else None
-            let h =
-                match (if JS.isDefined hostOpt then unbox<int>(hostOpt) else 0) with
-                | 1 -> Some MSbuildHost.MSBuildExe
-                | 2 -> Some MSbuildHost.DotnetCli
-                | 0 | _ -> None
-            f p h
+            fun _ -> f p
 
-        let envMsbuild =
-            LanguageService.msbuild ()
-            |> Promise.bind (fun p ->
-                match p with
-                | Some p ->
-                    logger.Info("MSBuild (.NET) found at %s", p)
-                    Promise.lift p
-                | None -> Promise.reject "MSBuild not found"
-            )
-
-        let envDotnet =
-            LanguageService.dotnet ()
-            |> Promise.bind (fun p ->
-                match p with
-                | Some p -> logger.Info("Dotnet CLI (.NET Core) found at %s", p)
-                            Promise.lift p
-                | None -> Promise.reject "dotnet not found"
-            )
-
-        host.onMSbuildHostTypeDidChange
-        |> Event.invoke (fun host ->
-            match host with
-            | Some MSbuildHost.MSBuildExe ->
-                logger.Info("MSBuild (.NET) activated")
-            | Some MSbuildHost.DotnetCli ->
-                logger.Info("Dotnet CLI (.NET Core) activated")
-            | Some MSbuildHost.Auto ->
-                logger.Info("Automatic MSBuild detection")
-            | None ->
-                logger.Info("Active MSBuild: not choosen yet") )
-        |> context.subscriptions.Add
-
-        let reloadCfg _ = promise {
-            let! hostCfg = loadMSBuildHostCfg ()
-            host.value <- hostCfg
-        }
-
-        [envMsbuild; envDotnet]
-        |> Promise.all
-        |> Promise.bind (fun _ -> reloadCfg ())
-        |> ignore
-
-        vscode.workspace.onDidChangeConfiguration
-        |> Event.invoke reloadCfg
-        |> context.subscriptions.Add
 
         registerCommand "MSBuild.buildCurrent" (fun _ -> buildCurrentProject "Build")
         registerCommand "MSBuild.rebuildCurrent" (fun _ -> buildCurrentProject "Rebuild")
@@ -463,5 +260,3 @@ module MSBuild =
         registerCommand2 "MSBuild.rebuildSelected" (typedMsbuildCmd (buildProject "Rebuild"))
         registerCommand2 "MSBuild.cleanSelected" (typedMsbuildCmd (buildProject "Clean"))
         registerCommand2 "MSBuild.restoreSelected" (typedMsbuildCmd restoreProject)
-
-        registerCommand "MSBuild.switchMSbuildHostType" (fun _ -> switchMSbuildHostType ())

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -515,9 +515,9 @@ module SolutionExplorer =
             treeView.onDidChangeVisibility.Invoke(unbox onDidChangeTreeVisibility')
                 |> context.subscriptions.Add
 
-            commands.registerCommand("fsharp.revealInSolutionExplorer", (fun _ -> revealTextEditor treeView state window.activeTextEditor true) |> objfy2) 
+            commands.registerCommand("fsharp.revealInSolutionExplorer", (fun _ -> revealTextEditor treeView state window.activeTextEditor true) |> objfy2)
             |> context.subscriptions.Add
-                
+
 
     let private handleUntitled (fn : string) = if fn.EndsWith ".fs" || fn.EndsWith ".fsi" || fn.EndsWith ".fsx" then fn else (fn + ".fs")
 
@@ -539,11 +539,6 @@ module SolutionExplorer =
 
         commands.registerCommand("fsharp.explorer.clearCache", objfy2 (fun _ ->
             Project.clearCache ()
-            |> unbox
-        )) |> context.subscriptions.Add
-
-        commands.registerCommand("fsharp.explorer.msbuild.pickHost", objfy2 (fun _ ->
-            MSBuild.pickMSbuildHostType ()
             |> unbox
         )) |> context.subscriptions.Add
 


### PR DESCRIPTION
Removes an option to pick MsBuild host - always use `dotnet msbuild` to Build/Rebuild/Restore projects. 