### PR TITLE
Only show info panel for fsharp files

### DIFF
--- a/src/Components/InfoPanel.fs
+++ b/src/Components/InfoPanel.fs
@@ -14,6 +14,15 @@ module node = Fable.Import.Node.Exports
 
 module InfoPanel =
 
+    let private isFsharpTextEditor (textEditor : TextEditor) =
+            if JS.isDefined textEditor && JS.isDefined textEditor.document then
+                let doc = textEditor.document
+                match doc with
+                | Document.FSharp -> true
+                | _ -> false
+            else
+                false
+
     module Panel =
 
         let showdownOptions = Fable.Import.Showdown.showdown.getDefaultOptions() :?> Fable.Import.Showdown.Showdown.ConverterOptions
@@ -24,15 +33,6 @@ module InfoPanel =
         let mutable panel : WebviewPanel option = None
 
         let mutable locked = false
-
-        let private isFsharpTextEditor (textEditor : TextEditor) =
-            if JS.isDefined textEditor && JS.isDefined textEditor.document then
-                let doc = textEditor.document
-                match doc with
-                | Document.FSharp -> true
-                | _ -> false
-            else
-                false
 
         let setContent str =
             panel |> Option.iter (fun p ->
@@ -325,4 +325,6 @@ module InfoPanel =
         commands.registerCommand("fsharp.showDocumentation", showDocumentation |> unbox<Func<obj,obj>>) |> context.subscriptions.Add
 
         if startLocked then Panel.locked <- true
-        if show then openPanel () |> ignore
+        if show && window.visibleTextEditors |> Seq.exists isFsharpTextEditor
+         then openPanel () |> ignore
+         else ()


### PR DESCRIPTION
As discussed in #1176 

I noticed 2 issues when opening C# projects with vscode after installing ionide extension:
1. With `"FSharp.infoPanelShowOnStartup": true`, InfoPanel launches for a C# project & displays a blank panel (because of .sln activation). Closing the panel, then closing & re-opening C# project in vscode does not resolve the issue. A blank info panel is displayed.
2. With `"FSharp.showExplorerOnStartup": true`, when launching a C# project the F# solution explorer triggers it's startup, grabs focus but then reports a failure in attempting to load csproj files.

A more ideal behaviour would be to try and have a minimal ionide fsharp launch when opening C# projects.

This fix resolves issue 1), by only showing the InfoPanel if there is an fsharp compatible file open in a window. I imagine issue 2) is by design, and can easily be resolved by setting `"FSharp.showExplorerOnStartup": false`.

Behaviour before code change:
![ionide-infopanel-displaying-for-csharp](https://user-images.githubusercontent.com/1066103/100012165-ba77f700-2dca-11eb-8b8f-29e200c79b6d.gif)

Behaviour after code change:
![ionide-infopanel-only-for-fsharp](https://user-images.githubusercontent.com/1066103/100012187-c499f580-2dca-11eb-854a-da028689b562.gif)

Thanks to @baronfel for excellent instructions in #1176 👍
