### PR TITLE
remove **/*.sln from activationEvents

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1653,7 +1653,6 @@
 		"workspaceContains:**/*.fs",
 		"workspaceContains:**/*.fsx",
 		"workspaceContains:**/*.fsproj",
-		"workspaceContains:**/*.sln",
 		"onLanguage:fsharp",
 		"onCommand:fsi.Start",
 		"onCommand:fsharp.NewProject"


### PR DESCRIPTION
Correct me if I'm wrong, but the other patterns here should match any F# projects even without the .sln pattern, and the .sln pattern causes the extension to activate and create ionide files for C# projects as well (among others, I assume).