### PR TITLE
Expand pipeline hints to final line and improve position

### DIFF
--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -374,6 +374,7 @@ module DTO =
     type PieplineHint = {
         Line: int
         Types: string []
+        PrecedingNonPipeExprLine : int option
     }
 
     type Result<'T> =


### PR DESCRIPTION
This is the ionide side of implementing this improvement: ionide/ionide-vscode-fsharp#1416
See description in https://github.com/fsharp/FsAutoComplete/pull/683

This just amends the processing of the return to create two type hints where appropriate.

I haven't updated the lock file, I'm not sure how to co-ordinate syncing this with FSAC!

The two effects are moving pipeline hints to the correct line when there are comments, and adding the type hint on the final line.
![image](https://user-images.githubusercontent.com/447391/102696967-26af1480-422a-11eb-959a-e400b1dd4c57.png)


