### PR TITLE
Fix #1460: Update to Fable 3

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,9 +9,15 @@
       ]
     },
     "paket": {
-      "version": "5.249.2",
+      "version": "5.257.0",
       "commands": [
         "paket"
+      ]
+    },
+    "fable": {
+      "version": "3.0.5",
+      "commands": [
+        "fable"
       ]
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ types.txt
 .ionide
 .fake
 fsacpath.txt
+/out/

--- a/build.fsx
+++ b/build.fsx
@@ -264,10 +264,6 @@ Target.create "RunScript" (fun _ ->
     Fable.run { Fable.DefaultArgs with Command = Fable.Build; Debug = false; Webpack = Fable.WithWebpack None }
 )
 
-Target.create "RunExpScript" (fun _ ->
-    Fable.run { Fable.DefaultArgs with Command = Fable.Build; Debug = false; Experimental = true; Webpack = Fable.WithWebpack None }
-)
-
 Target.create "RunDevScript" (fun _ ->
     Fable.run { Fable.DefaultArgs with Command = Fable.Build; Debug = true; Webpack = Fable.WithWebpack None }
 )
@@ -324,7 +320,6 @@ Target.create "ReleaseGitHub" (fun _ ->
 Target.create "Default" ignore
 Target.create "Build" ignore
 Target.create "BuildDev" ignore
-Target.create "BuildExp" ignore
 Target.create "Release" ignore
 Target.create "BuildPackages" ignore
 
@@ -363,11 +358,5 @@ Target.create "BuildPackages" ignore
 
 "RunDevScript"
 ==> "BuildDev"
-
-
-"YarnInstall" ==> "RunExpScript"
-"DotNetRestore" ==> "RunExpScript"
-"RunExpScript"
-==> "BuildExp"
 
 Target.runOrDefault "Default"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
-  "scripts": {
-    "build": "webpack",
-    "watch": "webpack --watch"
-  },
+  "scripts": {},
   "dependencies": {
     "htmlparser2": "^4.1.0"
   },
@@ -15,8 +12,6 @@
     "@types/ws": "^7.2.6",
     "axios": "^0.20.0",
     "babel-loader": "^8.1.0",
-    "fable-compiler": "^2.13.0",
-    "fable-loader": "^2.1.9",
     "mocha": "^8.1.3",
     "showdown": "^1.9.1",
     "toml": "^3.0.0",
@@ -24,7 +19,6 @@
     "vscode-languageclient": "^6.1.3",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
-    "webpack-node-externals": "^2.5.2",
     "ws": "^7.3.1",
     "xhr2": "^0.2.0"
   }

--- a/paket.lock
+++ b/paket.lock
@@ -48,10 +48,10 @@ GIT
      (fc4cac6d9bc1787f54ce48bbc77bcbb1de8160ff)
 GITHUB
   remote: ionide/ionide-vscode-helpers
-    src/Fable.Import.Showdown.fs (d446548df92f3691acce437f4313437e7a88976d)
-    src/Fable.Import.VSCode.fs (d446548df92f3691acce437f4313437e7a88976d)
-    src/Fable.Import.VSCode.LanguageServer.fs (d446548df92f3691acce437f4313437e7a88976d)
-    src/Helpers.fs (d446548df92f3691acce437f4313437e7a88976d)
+    src/Fable.Import.Showdown.fs (f9cfaa474910164482c2f5ae4a2fc1e54aa4ec72)
+    src/Fable.Import.VSCode.fs (f9cfaa474910164482c2f5ae4a2fc1e54aa4ec72)
+    src/Fable.Import.VSCode.LanguageServer.fs (f9cfaa474910164482c2f5ae4a2fc1e54aa4ec72)
+    src/Helpers.fs (f9cfaa474910164482c2f5ae4a2fc1e54aa4ec72)
 GROUP build
 STORAGE: NONE
 RESTRICTION: == netstandard2.0

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,11 +21,6 @@ module.exports = function(env, argv) {
   var outputPath = ionideExperimental ? "release-exp" : "release";
   console.log("Output path: " + outputPath);
 
-  var compilerDefines = isProduction ? [] : ["DEBUG"];
-  if (ionideExperimental) {
-    compilerDefines.push("IONIDE_EXPERIMENTAL");
-  }
-
   return {
   target: 'node',
   mode: isProduction ? "production" : "development",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 var path = require("path");
-var nodeExternals = require('webpack-node-externals');
 
 function resolve(filePath) {
   return path.join(__dirname, filePath)
@@ -31,7 +30,7 @@ module.exports = function(env, argv) {
   target: 'node',
   mode: isProduction ? "production" : "development",
   devtool: "source-map",
-  entry: resolve('./src/Ionide.FSharp.fsproj'),
+  entry: './out/fsharp.js',
   output: {
     filename: 'fsharp.js',
     path: resolve('./' + outputPath),
@@ -52,16 +51,6 @@ module.exports = function(env, argv) {
   },
   module: {
     rules: [
-      {
-        test: /\.fs(x|proj)?$/,
-        use: {
-          loader: "fable-loader",
-          options: {
-            babel: babelOptions,
-            define: compilerDefines
-          }
-        }
-      },
       {
         test: /\.js$/,
         exclude: /node_modules/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,23 +2038,6 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-fable-babel-plugins@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/fable-babel-plugins/-/fable-babel-plugins-2.3.0.tgz#cb4f652bbe78bd8e4a34e17c851d940fa6f3fa44"
-  integrity sha512-alGBNw5HZJzTEznXKfypFEkD5aWsspbCcoVDu9j8Mqdi77dgp4BSjhYSg61mQEg9UluIAZxRM5lhGARYbU97DQ==
-
-fable-compiler@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/fable-compiler/-/fable-compiler-2.13.0.tgz#3fa37b4eae3c8216e3555f0229751960b969807b"
-  integrity sha512-eEd+ue0CWhLpZBXqkIm4uWTGPfX8Q14RkCwSrbO0zPfB9hHW8IylipJ4YVfCZKd27sHDTpGOBwW8JMHqMBrXPQ==
-
-fable-loader@^2.1.9:
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/fable-loader/-/fable-loader-2.1.9.tgz#ca54f57359e5ee416d15c0313ab2beb708560050"
-  integrity sha512-ffFfAx4+92yGRjV7iZQOCzqsjQF1he6Lei6hDqfaW1Qjbyx9bhVa8jCX53+I1mhWEw2JWIQpFzwHnYwz2eT4Hw==
-  dependencies:
-    fable-babel-plugins "^2.3.0"
-
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -4195,11 +4178,6 @@ webpack-cli@^3.3.12:
     supports-color "^6.1.0"
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
-
-webpack-node-externals@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-2.5.2.tgz#178e017a24fec6015bc9e672c77958a6afac861d"
-  integrity sha512-aHdl/y2N7PW2Sx7K+r3AxpJO+aDMcYzMQd60Qxefq3+EwhewSbTBqNumOsCE1JsCUNoyfGj5465N0sSf6hc/5w==
 
 webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"


### PR DESCRIPTION
fixes #1460

Requires ionide/ionide-vscode-helpers#35


About Experimental Build:  
It seems like experimental builds aren't done via the build script, but by hand with probably a command like `webpack --mode=production --env.ionideExperimental` (which passes `IONIDE_EXPERIMENTAL` to Fable).  
With Fable 3, compilation to JS and bundling are now split in two between Fable and webpack. Which makes the command more complicated.  
I added a Build Target to for that: `BuildExp` -- existed already before, but was empty. Now it compiles with Fable with `IONIDE_EXPERIMENTAL` defined, and bundles with webpack and `--env.ionideExperimental` into `release-exp`. As far as I can tell that's how an experimental build was created before.  
If experimental build should be kept out of the build script (or requires more options): The full command is now:   
`dotnet fable ./src/Ionide.FSharp.fsproj --outDir ./out --define IONIDE_EXPERIMENTAL --run webpack --mode=production --env.ionideExperimental`