### PR TITLE
Fail promise if msbuild has exit code > 0

### DIFF
--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -115,10 +115,14 @@ module Debugger =
                 cfg?preLaunchTask <- None
 
                 let folder = workspace.workspaceFolders.[0]
-                let! _ = MSBuild.buildProjectPath "Build" project
-                // let! res = vscode.commands.executeCommand("vscode.startDebug", cfg)
-                let! res =  debug.startDebugging(folder, unbox cfg)
-                return ()
+                let! msbuildExit = MSBuild.buildProjectPath "Build" project
+                match msbuildExit.Code with
+                    | Some code when code <> 0 ->
+                        return! Promise.reject (sprintf "msbuild 'Build' failed with exit code %i" code)
+                    | _ ->
+                        // let! res = vscode.commands.executeCommand("vscode.startDebug", cfg)
+                        let! res =  debug.startDebugging(folder, unbox cfg)
+                        return ()
         }
 
     let mutable startup = None


### PR DESCRIPTION
If "F#: Debug Default project" fails to build, it currently continues and runs the previous build which can be misleading.
This is a crude approach that just stops and tells the user it hasn't worked.

To handle this properly (e.g. focus the error output), `invokeMSBuild` should handle the failure, but that requires pushing the handling done by some other consuming functions up/down. Should I have a go at doing this?