### PR TITLE
Solution explorer: Compile order and better support for directories

### DIFF
--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -586,21 +586,18 @@ module SolutionExplorer =
         commands.registerCommand("fsharp.explorer.moveUp", objfy2 (fun m ->
             match unbox m with
             | File (_, _, name, Some virtPath, proj) -> FsProjEdit.moveFileUpPath proj virtPath
-            // | File (_, _, name, proj) -> FsProjEdit.moveFileUpPath proj name
             | _ -> undefined
         )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.moveDown", objfy2 (fun m ->
             match unbox m with
             | File (_, _, name, Some virtPath, proj) -> FsProjEdit.moveFileDownPath proj virtPath
-            // | File (_, _, name, _, proj) -> FsProjEdit.moveFileDownPath proj name
             | _ -> undefined
         )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.removeFile", objfy2 (fun m ->
             match unbox m with
             | File (_, _, name, Some virtPath, proj) -> FsProjEdit.removeFilePath proj virtPath
-            // | File (_, _, name, _, proj) -> FsProjEdit.removeFilePath proj name
             | _ -> undefined
         )) |> context.subscriptions.Add
 

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -592,20 +592,22 @@ module SolutionExplorer =
 
         commands.registerCommand("fsharp.explorer.moveDown", objfy2 (fun m ->
             match unbox m with
-            | File (_, _, name, _, proj) -> FsProjEdit.moveFileDownPath proj name
+            | File (_, _, name, Some virtPath, proj) -> FsProjEdit.moveFileDownPath proj virtPath
+            // | File (_, _, name, _, proj) -> FsProjEdit.moveFileDownPath proj name
             | _ -> undefined
         )) |> context.subscriptions.Add
 
         commands.registerCommand("fsharp.explorer.removeFile", objfy2 (fun m ->
             match unbox m with
-            | File (_, _, name, _, proj) -> FsProjEdit.removeFilePath proj name
+            | File (_, _, name, Some virtPath, proj) -> FsProjEdit.removeFilePath proj virtPath
+            // | File (_, _, name, _, proj) -> FsProjEdit.removeFilePath proj name
             | _ -> undefined
         )) |> context.subscriptions.Add
 
 
         commands.registerCommand("fsharp.explorer.addAbove", objfy2 (fun m ->
             match unbox m with
-            | File (_, _, name, _, proj) ->
+            | File (_, _, name, Some virtPath, proj) ->
                 let opts = createEmpty<InputBoxOptions>
                 opts.placeHolder <- Some "new.fs"
                 opts.prompt <- Some "New file name, relative to project file"
@@ -614,7 +616,7 @@ module SolutionExplorer =
                 |> Promise.bind (fun file ->
                     if JS.isDefined file then
                         let file' = handleUntitled file
-                        FsProjEdit.addFileAbove proj name file'
+                        FsProjEdit.addFileAbove proj virtPath file'
                     else
                         Promise.empty
                 )
@@ -624,7 +626,7 @@ module SolutionExplorer =
 
         commands.registerCommand("fsharp.explorer.addBelow", objfy2 (fun m ->
             match unbox m with
-            | File (_, fr_om, name, _, proj) ->
+            | File (_, fr_om, name, Some virtPath, proj) ->
                 let opts = createEmpty<InputBoxOptions>
                 opts.placeHolder <- Some "new.fs"
                 opts.prompt <- Some "New file name, relative to project file"
@@ -633,7 +635,7 @@ module SolutionExplorer =
                 |> Promise.map (fun file ->
                     if JS.isDefined file then
                         let file' = handleUntitled file
-                        FsProjEdit.addFileBelow proj name file'
+                        FsProjEdit.addFileBelow proj virtPath file'
                     else
                         Promise.empty
                 )

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -610,7 +610,7 @@ module SolutionExplorer =
             | File (_, _, name, Some virtPath, proj) ->
                 let opts = createEmpty<InputBoxOptions>
                 opts.placeHolder <- Some "new.fs"
-                opts.prompt <- Some "New file name, relative to project file"
+                opts.prompt <- Some "New file name, relative to selected file"
                 opts.value <- Some "new.fs"
                 window.showInputBox(opts)
                 |> Promise.bind (fun file ->
@@ -629,7 +629,7 @@ module SolutionExplorer =
             | File (_, fr_om, name, Some virtPath, proj) ->
                 let opts = createEmpty<InputBoxOptions>
                 opts.placeHolder <- Some "new.fs"
-                opts.prompt <- Some "New file name, relative to project file"
+                opts.prompt <- Some "New file name, relative to selected file"
                 opts.value <- Some "new.fs"
                 window.showInputBox(opts)
                 |> Promise.map (fun file ->
@@ -648,7 +648,7 @@ module SolutionExplorer =
             | Project (_, proj, _, _,_,_,_,_) ->
                 let opts = createEmpty<InputBoxOptions>
                 opts.placeHolder <- Some "new.fs"
-                opts.prompt <- Some "New file name, relative to opened directory"
+                opts.prompt <- Some "New file name, relative to project file"
                 opts.value <- Some "new.fs"
                 window.showInputBox(opts)
                 |> Promise.map (fun file ->

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -427,9 +427,9 @@ module DTO =
     module FsProj =
         type DotnetProjectRequest = { Target: string; Reference: string }
 
-        type DotnetFileRequest = { FsProj: string; File: string }
+        type DotnetFileRequest = { FsProj: string; FileVirtualPath: string }
 
-        type DotnetFile2Request = { FsProj: string; File: string; NewFile: string }
+        type DotnetFile2Request = { FsProj: string; FileVirtualPath: string; NewFile: string }
 
     module FakeSupport =
         type FakeContext =

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -295,7 +295,7 @@ module LanguageService =
         | Some cl ->
             let req : FsProj.DotnetFileRequest  = {
                 FsProj = fsproj
-                File = file
+                FileVirtualPath = file
             }
             printfn "TEST8 %A" req
 
@@ -310,7 +310,7 @@ module LanguageService =
         | Some cl ->
             let req : FsProj.DotnetFileRequest  = {
                 FsProj = fsproj
-                File = file
+                FileVirtualPath = file
             }
 
             cl.sendRequest("fsproj/moveFileDown", req)
@@ -324,7 +324,7 @@ module LanguageService =
         | Some cl ->
             let req : FsProj.DotnetFile2Request   = {
                 FsProj = fsproj
-                File = file
+                FileVirtualPath = file
                 NewFile = newFile
             }
 
@@ -339,7 +339,7 @@ module LanguageService =
         | Some cl ->
             let req : FsProj.DotnetFile2Request   = {
                 FsProj = fsproj
-                File = file
+                FileVirtualPath = file
                 NewFile = newFile
             }
 
@@ -354,7 +354,7 @@ module LanguageService =
         | Some cl ->
             let req : FsProj.DotnetFileRequest   = {
                 FsProj = fsproj
-                File = file
+                FileVirtualPath = file
             }
 
             cl.sendRequest("fsproj/addFile", req)


### PR DESCRIPTION
This PR makes two changes to the Solution Explorer TreeView:
1. Compile order layout: The solution explorer tree now show shows all files in the same order they are listed in the fsproj by creating duplicate folder nodes. To do this it assumes that the list of Items provided by FSAC is in compile order (which seems to be the case).
Before: 
![image](https://user-images.githubusercontent.com/447391/103480140-60efe880-4dca-11eb-8f75-509551f7da82.png)
After;
![image](https://user-images.githubusercontent.com/447391/103480121-40c02980-4dca-11eb-88a2-8a97419ba6a4.png)
2. Improved file actions in subdirectories (https://github.com/ionide/ionide-vscode-fsharp/issues/1456): In combination with changes in FSAC, this improves actions on non-root directory files by storing the "virtual path" and passing this to the FSAC commands rather than just the file name.
a. Add file above/below now prompt for a file name relative to the selected file
b. Add file is still relative to project root
c. Move up/down still don't behave consistently with mixed path separators though