### PR TITLE
use the new ranges from the updated FSAC endpoint

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -35,13 +35,13 @@ NUGET
       FSharp.Core (>= 4.7)
 GIT
   remote: https://github.com/fsharp/FsAutoComplete.git
-     (2f57e13296dea36438ca417f6223c29ac842b91b)
+     (49ca2e91f06b2456f9ed8b8c8bd4ccf59bad7180)
       build: build.cmd
       os: win
-     (2f57e13296dea36438ca417f6223c29ac842b91b)
+     (49ca2e91f06b2456f9ed8b8c8bd4ccf59bad7180)
       build: build.sh
       os: linux
-     (2f57e13296dea36438ca417f6223c29ac842b91b)
+     (49ca2e91f06b2456f9ed8b8c8bd4ccf59bad7180)
       build: build.sh
       os: osx
   remote: https://github.com/ionide/ionide-fsgrammar.git
@@ -216,7 +216,7 @@ NUGET
       System.Security.AccessControl (>= 5.0)
       System.Security.Principal.Windows (>= 5.0)
     Mono.Posix.NETStandard (1.0)
-    MSBuild.StructuredLogger (2.1.215)
+    MSBuild.StructuredLogger (2.1.272)
       Microsoft.Build (>= 16.4)
       Microsoft.Build.Framework (>= 16.4)
       Microsoft.Build.Tasks.Core (>= 16.4)

--- a/src/Components/HighlightingProvider.fs
+++ b/src/Components/HighlightingProvider.fs
@@ -24,10 +24,10 @@ module HighlightingProvider =
                 promise {
                     let builder = SemanticTokensBuilder(legend)
                     let! res = LanguageService.getHighlighting (textDocument.fileName)
-                    res.Data.Highlights
-                    |> Array.sortBy(fun n -> n.Range.StartLine * 1000000 + n.Range.StartColumn)
+                    res.highlights
+                    |> Array.sortBy(fun n -> n.range.start.line * 1000000. + n.range.start.character)
                     |> Array.iter (fun n ->
-                        builder.push(CodeRange.fromDTO n.Range, n.TokenType)
+                        builder.push(n.range, n.tokenType)
                     )
 
                     return builder.build()

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -325,10 +325,10 @@ module DTO =
     type FsdnResponse =
         { Functions: string [] }
 
-    type HighlightingRange = {Range: Range; TokenType: string}
+    type HighlightingRange = { range: Fable.Import.vscode.Range; tokenType: string}
 
     type HighlightingResponse = {
-        Highlights: HighlightingRange []
+        highlights: HighlightingRange []
     }
 
     type ResponseError<'T> =

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -67,7 +67,6 @@ module LanguageService =
         type FSharpLiterateRequest = {FileName: string}
         type FSharpPipelineHintsRequest = {FileName: string}
 
-
     let mutable client : LanguageClient option = None
 
     let private handleUntitled (fn : string) = if fn.EndsWith ".fs" || fn.EndsWith ".fsi" || fn.EndsWith ".fsx" then fn else (fn + ".fsx")
@@ -466,7 +465,7 @@ module LanguageService =
             cl.sendRequest("fsharp/loadAnalyzers", req)
             |> Promise.map (ignore)
 
-    let getHighlighting (f) =
+    let getHighlighting (f): JS.Promise<HighlightingResponse> =
         match client with
         | None -> Promise.empty
         | Some cl ->
@@ -474,9 +473,7 @@ module LanguageService =
                 FileName = f
             }
             cl.sendRequest("fsharp/highlighting", req)
-            |> Promise.map (fun (res: Types.PlainNotification) ->
-                res.content |> ofJson<HighlightingResult>
-            )
+            |> Promise.map (fun (res: obj) -> res?data)
 
     let fsharpLiterate (f) =
         match client with


### PR DESCRIPTION
This depends on https://github.com/fsharp/FsAutoComplete/pull/693, but updates Ionide to use the new API types exposed as part of that work.  Casing of some things has changed, as the payload we get back from the request is no longer a bare string, instead it's already been hydrated as a JS object due to the LSP back-and-forth.