### PR TITLE
Fix auto comment indentation

### DIFF
--- a/src/Components/LanguageConfiguration.fs
+++ b/src/Components/LanguageConfiguration.fs
@@ -26,7 +26,7 @@ module LanguageConfiguration =
                         // Example: ///
                         jsOptions<OnEnterRule> (fun rule ->
                             rule.action <- jsOptions<EnterAction>(fun action ->
-                                action.indentAction <- IndentAction.Indent
+                                action.indentAction <- IndentAction.None
                                 action.appendText <- Some "/// "
                             )
                             rule.beforeText <- Regex("^\s*\/{3}.*$")


### PR DESCRIPTION
When pressing enter on a `///` comment line the indentation is incorrect

**Before**
![vscode_comment_indent_problem](https://user-images.githubusercontent.com/4760796/110019570-eb9c8780-7d28-11eb-8cb1-52b51a9c9ee7.gif)

**After**
![vscode_comment_indent_problem_after](https://user-images.githubusercontent.com/4760796/110019572-ec351e00-7d28-11eb-9c4a-8661a2fbba50.gif)
