### PR TITLE
Add option to crack using msbuild project graph

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -35,13 +35,13 @@ NUGET
       FSharp.Core (>= 4.7)
 GIT
   remote: https://github.com/fsharp/FsAutoComplete.git
-     (d9bf1894493cc81de147e29b01b9e17e35ce604b)
+     (9a1938b876e749c450e510ae2a82b03ab80b946f)
       build: build.cmd
       os: win
-     (d9bf1894493cc81de147e29b01b9e17e35ce604b)
+     (9a1938b876e749c450e510ae2a82b03ab80b946f)
       build: build.sh
       os: linux
-     (d9bf1894493cc81de147e29b01b9e17e35ce604b)
+     (9a1938b876e749c450e510ae2a82b03ab80b946f)
       build: build.sh
       os: osx
   remote: https://github.com/ionide/ionide-fsgrammar.git

--- a/release/package.json
+++ b/release/package.json
@@ -1343,6 +1343,11 @@
 					"default": true,
 					"description": "Enables background services responsible for creating symbol cache and typechecking files in the background. Requires restart."
 				},
+				"FSharp.enableMSBuildProjectGraph": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enables experimental support for loading workspaces with MsBuild's ProjectGraph. This can improve load times. Requires restart."
+				},
 				"FSharp.enableReferenceCodeLens": {
 					"type": "boolean",
 					"default": true,

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -660,6 +660,7 @@ Consider:
         }
 
         let backgroundSymbolCache = "FSharp.enableBackgroundServices" |> Configuration.get true
+        let enableProjectGraph = "FSharp.enableMSBuildProjectGraph" |> Configuration.get false
         let fsacAttachDebugger = "FSharp.fsac.attachDebugger" |> Configuration.get false
         let fsacNetcorePath = "FSharp.fsac.netCoreDllPath" |> Configuration.get ""
         let fsacSilencedLogs = "FSharp.fsac.silencedLogs" |> Configuration.get [||]
@@ -678,6 +679,7 @@ Consider:
                         yield "--attachdebugger"
                         yield "--wait-for-debugger"
                     if backgroundSymbolCache then yield "--background-service-enabled"
+                    if enableProjectGraph then yield "--project-graph-enabled"
                     if verbose then yield  "--verbose"
                     if fsacSilencedLogs <> null && fsacSilencedLogs.Length > 0
                     then


### PR DESCRIPTION


This PR is a follow through from ionide/proj-info#102 and https://github.com/fsharp/FsAutoComplete/pull/736 to allow MSBuild ProjectGraph WorkspaceLoader. This pass a flag on the CLI to FSAC to turn on the ability to use this new loader while defaulting to the current one.