### PR TITLE
add codepage flags to FSI invocations on windows to work around display issues

### DIFF
--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -253,11 +253,12 @@ module Fsi =
                     fsiParams
 
             if Environment.isWin then
-                [ "--fsi-server-input-codepage:65001" ] @ fsiParams
+                // these flags are added to work around issues with the vscode terminal shell on windows
+                [ "--fsi-server-input-codepage:28591"
+                  "--fsi-server-output-codepage:65001" ] @ fsiParams
             else
                 fsiParams
             |> Array.ofList
-
 
         promise {
             if isSdk


### PR DESCRIPTION
Bades on reporting and workarounds in our issue threads, windows FSI needs the following codepages set. We could wait for a full fix from upstream, but it's unknown that the cause has been pinpointed or will be fixed in a short timeframe.

Fixes #1498 #1520 (and maybe others)