### PR TITLE
Fix: Log Filter (`fsacSilencedLogs`) doesn't work when multiple categories specified

### DIFF
--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -684,7 +684,7 @@ Consider:
                     if fsacSilencedLogs <> null && fsacSilencedLogs.Length > 0
                     then
                         yield "--filter"
-                        yield fsacSilencedLogs |> String.concat ","
+                        yield! fsacSilencedLogs
                 ] |> ResizeArray
 
             createObj [


### PR DESCRIPTION
Reason: Categories are combined into comma-separated list of categories, which is emitted as single string:  
* Setting:
  ```json
  "FSharp.fsac.silencedLogs": [
    "FileSystem",
    "Compiler",
  ]
  ```
* passed into FsAutoComplete:
  ```
  --filter "FileSystem,Compiler"
  ```
-> interpreted in FsAutoComplete as single category "FileSystem,Compiler" instead of two categories.

Correct filter for FsAutoComplete:
```
--filter FileSystem Compiler
```
(List with categories separated by space)