### PR TITLE
reenable sourcemaps and script-file xml generation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "fable": {
-      "version": "3.0.5",
+      "version": "3.2.9",
       "commands": [
         "fable"
       ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,23 +2,26 @@
 {
 	"version": "0.2.0",
 	"configurations": [
- 
 		{
-      "preLaunchTask": "Extension Build",
+			"preLaunchTask": "Extension Build",
 			"name": "Build and Launch Extension",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}/release" ],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}/release"
+			],
 			"stopOnEntry": false,
 			"request": "launch",
-			"sourceMaps": false
+			"sourceMaps": true
 		},
 		{
-      "preLaunchTask": "Extension Build (dev)",
+			"preLaunchTask": "Extension Build (dev)",
 			"name": "Build (dev) and Launch Extension",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}/release" ],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}/release"
+			],
 			"stopOnEntry": false,
 			"request": "launch",
 			"sourceMaps": true
@@ -27,10 +30,12 @@
 			"name": "Launch Only",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}/release" ],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}/release"
+			],
 			"stopOnEntry": false,
 			"request": "launch",
 			"sourceMaps": true
-		}
+		},
 	]
 }

--- a/build.fsx
+++ b/build.fsx
@@ -76,6 +76,7 @@ module Fable =
         ProjectPath: string
         OutDir: string option
         Defines: string list
+        SourceMaps: bool
         AdditionalFableArgs: string option
         Webpack: Webpack
     }
@@ -88,6 +89,7 @@ module Fable =
         OutDir = Some "./out"
         Defines = []
         AdditionalFableArgs = None
+        SourceMaps = true
         Webpack = WithoutWebpack
     }
 
@@ -115,9 +117,10 @@ module Fable =
                     (if args.Debug then "--mode=development" else "--mode=production")
                     (if args.Experimental then "--env.ionideExperimental" else "")
                     (webpackArgs |> Option.defaultValue "")
+        let sourceMaps = if args.SourceMaps then "-s" else ""
 
-        // $"{fableCmd} {fableProjPath} {fableOutDir} {fableDebug} {fableExperimental} {fableDefines} {fableAdditionalArgs} {webpackCmd}"
-        sprintf "%s %s %s %s %s %s %s %s" fableCmd fableProjPath fableOutDir fableDebug fableExperimental fableDefines fableAdditionalArgs webpackCmd
+        // $"{fableCmd} {fableProjPath} {sourcemaps} {fableOutDir} {fableDebug} {fableExperimental} {fableDefines} {fableAdditionalArgs} {webpackCmd}"
+        sprintf "%s %s %s %s %s %s %s %s %s" fableCmd fableProjPath sourceMaps fableOutDir fableDebug fableExperimental fableDefines fableAdditionalArgs webpackCmd
 
     let run args =
         let cmd = mkArgs args

--- a/src/Components/SignatureData.fs
+++ b/src/Components/SignatureData.fs
@@ -9,7 +9,7 @@ module SignatureData =
     let generateDoc () =
         let editor = window.activeTextEditor.document
         match editor with
-        | Document.FSharp  ->
+        | Document.FSharp | Document.FSharpScript  ->
             let line = window.activeTextEditor.selection.active.line
             let col = window.activeTextEditor.selection.active.character
             LanguageService.generateDocumentation editor.fileName (int line) (int col)


### PR DESCRIPTION
* Bump Fable to 3.2.x to get sourcemaps back
* change the xml generation function to allow f# scripts as well