### PR TITLE
reenable sourcemaps and script-file xml generation, and add in escape hatch for .net 6 support

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "fable": {
-      "version": "3.0.5",
+      "version": "3.2.9",
       "commands": [
         "fable"
       ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,23 +2,26 @@
 {
 	"version": "0.2.0",
 	"configurations": [
- 
 		{
-      "preLaunchTask": "Extension Build",
+			"preLaunchTask": "Extension Build",
 			"name": "Build and Launch Extension",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}/release" ],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}/release"
+			],
 			"stopOnEntry": false,
 			"request": "launch",
-			"sourceMaps": false
+			"sourceMaps": true
 		},
 		{
-      "preLaunchTask": "Extension Build (dev)",
+			"preLaunchTask": "Extension Build (dev)",
 			"name": "Build (dev) and Launch Extension",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}/release" ],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}/release"
+			],
 			"stopOnEntry": false,
 			"request": "launch",
 			"sourceMaps": true
@@ -27,10 +30,12 @@
 			"name": "Launch Only",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}/release" ],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}/release"
+			],
 			"stopOnEntry": false,
 			"request": "launch",
 			"sourceMaps": true
-		}
+		},
 	]
 }

--- a/build.fsx
+++ b/build.fsx
@@ -76,6 +76,7 @@ module Fable =
         ProjectPath: string
         OutDir: string option
         Defines: string list
+        SourceMaps: bool
         AdditionalFableArgs: string option
         Webpack: Webpack
     }
@@ -88,6 +89,7 @@ module Fable =
         OutDir = Some "./out"
         Defines = []
         AdditionalFableArgs = None
+        SourceMaps = true
         Webpack = WithoutWebpack
     }
 
@@ -115,9 +117,10 @@ module Fable =
                     (if args.Debug then "--mode=development" else "--mode=production")
                     (if args.Experimental then "--env.ionideExperimental" else "")
                     (webpackArgs |> Option.defaultValue "")
+        let sourceMaps = if args.SourceMaps then "-s" else ""
 
-        // $"{fableCmd} {fableProjPath} {fableOutDir} {fableDebug} {fableExperimental} {fableDefines} {fableAdditionalArgs} {webpackCmd}"
-        sprintf "%s %s %s %s %s %s %s %s" fableCmd fableProjPath fableOutDir fableDebug fableExperimental fableDefines fableAdditionalArgs webpackCmd
+        // $"{fableCmd} {fableProjPath} {sourcemaps} {fableOutDir} {fableDebug} {fableExperimental} {fableDefines} {fableAdditionalArgs} {webpackCmd}"
+        sprintf "%s %s %s %s %s %s %s %s %s" fableCmd fableProjPath sourceMaps fableOutDir fableDebug fableExperimental fableDefines fableAdditionalArgs webpackCmd
 
     let run args =
         let cmd = mkArgs args

--- a/release/package.json
+++ b/release/package.json
@@ -1145,6 +1145,14 @@
 			"type": "object",
 			"title": "F#",
 			"properties": {
+				"FSharp.fsac.dotnetArgs": {
+					"type" : "array",
+					"default": [],
+					"description": "additional CLI arguments to be provided to the dotnet runner for FSAC",
+					"items": {
+						"type": "string"
+					}
+				},
 				"FSharp.fsac.netCoreDllPath": {
 					"type": "string",
 					"default": "",

--- a/src/Components/SignatureData.fs
+++ b/src/Components/SignatureData.fs
@@ -9,7 +9,7 @@ module SignatureData =
     let generateDoc () =
         let editor = window.activeTextEditor.document
         match editor with
-        | Document.FSharp  ->
+        | Document.FSharp | Document.FSharpScript  ->
             let line = window.activeTextEditor.selection.active.line
             let col = window.activeTextEditor.selection.active.character
             LanguageService.generateDocumentation editor.fileName (int line) (int col)

--- a/src/Components/SignatureData.fs
+++ b/src/Components/SignatureData.fs
@@ -57,7 +57,7 @@ module SignatureData =
 
 
     let activate (context : ExtensionContext) =
-        commands.registerCommand("fsharp.generateDoc", generateDoc |> objfy2) 
+        commands.registerCommand("fsharp.generateDoc", generateDoc |> objfy2)
         |> context.subscriptions.Add
 
         ()

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -665,14 +665,14 @@ Consider:
         let fsacNetcorePath = "FSharp.fsac.netCoreDllPath" |> Configuration.get ""
         let fsacSilencedLogs = "FSharp.fsac.silencedLogs" |> Configuration.get [||]
         let verbose = "FSharp.verboseLogging" |> Configuration.get false
-
+        let fsacDotnetArgs = "FSharp.fsac.dotnetArgs" |> Configuration.get [||]
         let spawnNetCore dotnet =
             let fsautocompletePath =
                 if String.IsNullOrEmpty fsacNetcorePath then VSCodeExtension.ionidePluginPath () + "/bin/fsautocomplete.dll"
                 else fsacNetcorePath
             printfn "FSAC (NETCORE): '%s'" fsautocompletePath
             let args =
-                [
+                [   yield! fsacDotnetArgs
                     yield fsautocompletePath
                     if fsacAttachDebugger
                     then


### PR DESCRIPTION
Couple of fixes I've accumulated:


* reenable sourcemaps for local debugging
* remove an artificial constraint around xml doc comment generation that prevented it from working on script files
* Add in `FSharp.fsac.dotnetArgs` as a way for users to specify addition args to the `dotnet` cli itself. the primary intended purpose will be to set `--fx-version` to whatever their latest installed runtime is until we provide a .net 6-first compatible build.