### PR TITLE
set rollforward args and env vars if .net 6.0 is detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
-  "scripts": {},
+  "scripts": {
+    "gen:semver": "ts2fable node_modules/@types/semver/{classes,functions,internals,ranges}/*.d.ts  node_modules/@types/semver/index.d.ts src/Imports/Semver.fs"
+  },
   "dependencies": {
-    "htmlparser2": "^4.1.0"
+    "htmlparser2": "^4.1.0",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
+    "@types/semver": "^7.3.8",
     "@types/showdown": "^1.9.3",
     "@types/vscode": "^1.52.0",
     "@types/ws": "^7.2.6",
@@ -15,6 +19,7 @@
     "mocha": "^8.1.3",
     "showdown": "^1.9.1",
     "toml": "^3.0.0",
+    "ts2fable": "^0.8.0-build.618",
     "vscode-debugadapter": "^1.44.0",
     "vscode-languageclient": "^7.0.0",
     "webpack": "^4.44.1",

--- a/src/Imports/Node.Util.fs
+++ b/src/Imports/Node.Util.fs
@@ -8,3 +8,11 @@ type IExports =
 
 [<Import("*", "util")>]
 let Util : IExports = jsNative
+
+
+type ObjectExports =
+    abstract member keys: o: obj -> ResizeArray<string>
+
+module Object =
+    [<Emit("Object.keys($0)")>]
+    let keys (o): ResizeArray<string> = jsNative

--- a/src/Imports/Semver.fs
+++ b/src/Imports/Semver.fs
@@ -1,0 +1,328 @@
+// ts2fable 0.8.0-build.618
+module rec Semver
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+type ReadonlyArray<'T> = System.Collections.Generic.IReadOnlyList<'T>
+
+
+type [<AllowNullLiteral>] IExports =
+    abstract Comparator: ComparatorStatic
+    abstract Range: RangeStatic
+    abstract SemVer: SemVerStatic
+    /// Returns cleaned (removed leading/trailing whitespace, remove '=v' prefix) and parsed version, or null if version is invalid.
+    abstract clean: version: string * ?optionsOrLoose: U2<bool, Semver.Options> -> string option
+
+    /// Pass in a comparison string, and it'll call the corresponding semver comparison function.
+    /// "===" and "!==" do simple string comparison, but are included for completeness.
+    /// Throws if an invalid comparison string is provided.
+    abstract cmp: v1: U2<string, SemVer> * operator: Semver.Operator * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// Coerces a string to SemVer if possible
+    abstract coerce: version: U3<string, float, SemVer> option * ?options: Semver.CoerceOptions -> SemVer option
+    /// <summary>
+    /// Compares two versions including build identifiers (the bit after <c>+</c> in the semantic version string).
+    ///
+    /// Sorts in ascending order when passed to <c>Array.sort()</c>.
+    /// </summary>
+    /// <returns>
+    /// - <c>0</c> if <c>v1</c> == <c>v2</c>
+    /// - <c>1</c> if <c>v1</c> is greater
+    /// - <c>-1</c> if <c>v2</c> is greater.
+    /// </returns>
+    abstract compareBuild: a: U2<string, SemVer> * b: U2<string, SemVer> -> CompareBuildReturn
+
+    abstract compareLoose: v1: U2<string, SemVer> * v2: U2<string, SemVer> -> CompareLooseReturn
+    /// <summary>
+    /// Compares two versions excluding build identifiers (the bit after <c>+</c> in the semantic version string).
+    ///
+    /// Sorts in ascending order when passed to <c>Array.sort()</c>.
+    /// </summary>
+    /// <returns>
+    /// - <c>0</c> if <c>v1</c> == <c>v2</c>
+    /// - <c>1</c> if <c>v1</c> is greater
+    /// - <c>-1</c> if <c>v2</c> is greater.
+    /// </returns>
+    abstract compare: v1: U2<string, SemVer> * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> CompareReturn
+    /// Returns difference between two versions by the release type (major, premajor, minor, preminor, patch, prepatch, or prerelease), or null if the versions are the same.
+    abstract diff: v1: U2<string, SemVer> * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> Semver.ReleaseType option
+
+    /// v1 == v2 This is true if they're logically equivalent, even if they're not the exact same string. You already know how to compare strings.
+    abstract eq: v1: U2<string, SemVer> * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// v1 > v2
+    abstract gt: v1: U2<string, SemVer> * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// v1 >= v2
+    abstract gte: v1: U2<string, SemVer> * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// Return the version incremented by the release type (major, minor, patch, or prerelease), or null if it's not valid.
+    abstract inc: version: U2<string, SemVer> * release: Semver.ReleaseType * ?optionsOrLoose: U2<bool, Semver.Options> * ?identifier: string -> string option
+    abstract inc: version: U2<string, SemVer> * release: Semver.ReleaseType * ?identifier: string -> string option
+
+    /// v1 < v2
+    abstract lt: v1: U2<string, SemVer> * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// v1 <= v2
+    abstract lte: v1: U2<string, SemVer> * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// Return the major version number.
+    abstract major: version: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> float
+
+    /// Return the minor version number.
+    abstract minor: version: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> float
+
+    /// v1 != v2 The opposite of eq.
+    abstract neq: v1: U2<string, SemVer> * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// Return the parsed version as a SemVer object, or null if it's not valid.
+    abstract parse: version: U2<string, SemVer> option * ?optionsOrLoose: U2<bool, Semver.Options> -> SemVer option
+
+    /// Return the patch version number.
+    abstract patch: version: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> float
+
+    /// Returns an array of prerelease components, or null if none exist.
+    abstract prerelease: version: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> ResizeArray<U2<string, float>> option
+
+    /// <summary>
+    /// The reverse of compare.
+    ///
+    /// Sorts in descending order when passed to <c>Array.sort()</c>.
+    /// </summary>
+    abstract rcompare: v1: U2<string, SemVer> * v2: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> RcompareReturn
+
+    /// <summary>Sorts an array of semver entries in descending order using <c>compareBuild()</c>.</summary>
+    abstract rsort: list: ResizeArray<'T> * ?optionsOrLoose: U2<bool, Semver.Options> -> ResizeArray<'T>
+
+    /// Return true if the version satisfies the range.
+    abstract satisfies: version: U2<string, SemVer> * range: U2<string, Range> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// <summary>Sorts an array of semver entries in ascending order using <c>compareBuild()</c>.</summary>
+    abstract sort: list: ResizeArray<'T> * ?optionsOrLoose: U2<bool, Semver.Options> -> ResizeArray<'T>
+
+    /// Return the parsed version as a string, or null if it's not valid.
+    abstract valid: version: U2<string, SemVer> option * ?optionsOrLoose: U2<bool, Semver.Options> -> string option
+
+    /// <summary>
+    /// Compares two identifiers, must be numeric strings or truthy/falsy values.
+    ///
+    /// Sorts in ascending order when passed to <c>Array.sort()</c>.
+    /// </summary>
+    abstract compareIdentifiers: a: string option * b: string option -> CompareIdentifiersReturn
+    /// <summary>
+    /// The reverse of compareIdentifiers.
+    ///
+    /// Sorts in descending order when passed to <c>Array.sort()</c>.
+    /// </summary>
+    abstract rcompareIdentifiers: a: string option * b: string option -> RcompareIdentifiersReturn
+    /// Return true if version is greater than all the versions possible in the range.
+    abstract gtr: version: U2<string, SemVer> * range: U2<string, Range> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// Return true if any of the ranges comparators intersect
+    abstract intersects: range1: U2<string, Range> * range2: U2<string, Range> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// Return true if version is less than all the versions possible in the range.
+    abstract ltr: version: U2<string, SemVer> * range: U2<string, Range> * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// Return the highest version in the list that satisfies the range, or null if none of them do.
+    abstract maxSatisfying: versions: ResizeArray<'T> * range: U2<string, Range> * ?optionsOrLoose: U2<bool, Semver.Options> -> 'T option
+
+    /// Return the lowest version in the list that satisfies the range, or null if none of them do.
+    abstract minSatisfying: versions: ResizeArray<'T> * range: U2<string, Range> * ?optionsOrLoose: U2<bool, Semver.Options> -> 'T option
+
+    /// Return the lowest version that can possibly match the given range.
+    abstract minVersion: range: U2<string, Range> * ?optionsOrLoose: U2<bool, Semver.Options> -> SemVer option
+
+    /// Return true if the version is outside the bounds of the range in either the high or low direction.
+    /// The hilo argument must be either the string '>' or '<'. (This is the function called by gtr and ltr.)
+    abstract outside: version: U2<string, SemVer> * range: U2<string, Range> * hilo: OutsideHilo * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+    /// <summary>
+    /// Return a "simplified" range that matches the same items in <c>versions</c> list as the range specified.
+    /// Note that it does *not* guarantee that it would match the same versions in all cases,
+    /// only for the set of versions provided.
+    /// This is useful when generating ranges by joining together multiple versions with <c>||</c> programmatically,
+    /// to provide the user with something a bit more ergonomic.
+    /// If the provided range is shorter in string-length than the generated range, then that is returned.
+    /// </summary>
+    abstract simplify: ranges: ResizeArray<string> * range: U2<string, Range> * ?options: Semver.Options -> U2<string, Range>
+
+    /// Return true if the subRange range is entirely contained by the superRange range.
+    abstract subset: sub: U2<string, Range> * dom: U2<string, Range> * ?options: Semver.Options -> bool
+
+    /// Mostly just for testing and legacy API reasons
+    abstract toComparators: range: U2<string, Range> * ?optionsOrLoose: U2<bool, Semver.Options> -> string
+
+    /// Return the valid range or null if it's not valid
+    abstract validRange: range: U2<string, Range> option * ?optionsOrLoose: U2<bool, Semver.Options> -> string option
+
+type [<AllowNullLiteral>] Comparator =
+    abstract semver: SemVer with get, set
+    abstract operator: ComparatorOperator with get, set
+    abstract value: string with get, set
+    abstract loose: bool with get, set
+    abstract options: Semver.Options with get, set
+    abstract parse: comp: string -> unit
+    abstract test: version: U2<string, SemVer> -> bool
+    abstract intersects: comp: Comparator * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+type [<AllowNullLiteral>] ComparatorStatic =
+    [<EmitConstructor>] abstract Create: comp: U2<string, Comparator> * ?optionsOrLoose: U2<bool, Semver.Options> -> Comparator
+
+type [<StringEnum>] [<RequireQualifiedAccess>] ComparatorOperator =
+    | [<CompiledName "">] Empty
+    | [<CompiledName "=">] Eq
+    | [<CompiledName "<">] LT
+    | [<CompiledName ">">] GT
+    | [<CompiledName "<=">] LTE
+    | [<CompiledName ">=">] GTE
+
+
+type [<AllowNullLiteral>] Range =
+    abstract range: string with get, set
+    abstract raw: string with get, set
+    abstract loose: bool with get, set
+    abstract options: Semver.Options with get, set
+    abstract includePrerelease: bool with get, set
+    abstract format: unit -> string
+    abstract inspect: unit -> string
+    abstract set: ReadonlyArray<ReadonlyArray<Comparator>> with get, set
+    abstract parseRange: range: string -> ResizeArray<Comparator>
+    abstract test: version: U2<string, SemVer> -> bool
+    abstract intersects: range: Range * ?optionsOrLoose: U2<bool, Semver.Options> -> bool
+
+type [<AllowNullLiteral>] RangeStatic =
+    [<EmitConstructor>] abstract Create: range: U2<string, Range> * ?optionsOrLoose: U2<bool, Semver.Options> -> Range
+
+type [<AllowNullLiteral>] SemVer =
+    abstract raw: string with get, set
+    abstract loose: bool with get, set
+    abstract options: Semver.Options with get, set
+    abstract format: unit -> string
+    abstract inspect: unit -> string
+    abstract major: float with get, set
+    abstract minor: float with get, set
+    abstract patch: float with get, set
+    abstract version: string with get, set
+    abstract build: ReadonlyArray<string> with get, set
+    abstract prerelease: ReadonlyArray<U2<string, float>> with get, set
+    /// <summary>Compares two versions excluding build identifiers (the bit after <c>+</c> in the semantic version string).</summary>
+    /// <returns>
+    /// - <c>0</c> if <c>this</c> == <c>other</c>
+    /// - <c>1</c> if <c>this</c> is greater
+    /// - <c>-1</c> if <c>other</c> is greater.
+    /// </returns>
+    abstract compare: other: U2<string, SemVer> -> SemVerCompareReturn
+    /// <summary>Compares the release portion of two versions.</summary>
+    /// <returns>
+    /// - <c>0</c> if <c>this</c> == <c>other</c>
+    /// - <c>1</c> if <c>this</c> is greater
+    /// - <c>-1</c> if <c>other</c> is greater.
+    /// </returns>
+    abstract compareMain: other: U2<string, SemVer> -> SemVerCompareMainReturn
+    /// <summary>Compares the prerelease portion of two versions.</summary>
+    /// <returns>
+    /// - <c>0</c> if <c>this</c> == <c>other</c>
+    /// - <c>1</c> if <c>this</c> is greater
+    /// - <c>-1</c> if <c>other</c> is greater.
+    /// </returns>
+    abstract comparePre: other: U2<string, SemVer> -> SemVerComparePreReturn
+    /// <summary>Compares the build identifier of two versions.</summary>
+    /// <returns>
+    /// - <c>0</c> if <c>this</c> == <c>other</c>
+    /// - <c>1</c> if <c>this</c> is greater
+    /// - <c>-1</c> if <c>other</c> is greater.
+    /// </returns>
+    abstract compareBuild: other: U2<string, SemVer> -> SemVerCompareBuildReturn
+    abstract inc: release: Semver.ReleaseType * ?identifier: string -> SemVer
+
+type [<RequireQualifiedAccess>] SemVerCompareReturn =
+    | N1 = 1
+    | N0 = 0
+
+type [<RequireQualifiedAccess>] SemVerCompareMainReturn =
+    | N1 = 1
+    | N0 = 0
+
+type [<RequireQualifiedAccess>] SemVerComparePreReturn =
+    | N1 = 1
+    | N0 = 0
+
+type [<RequireQualifiedAccess>] SemVerCompareBuildReturn =
+    | N1 = 1
+    | N0 = 0
+
+type [<AllowNullLiteral>] SemVerStatic =
+    [<EmitConstructor>] abstract Create: version: U2<string, SemVer> * ?optionsOrLoose: U2<bool, Semver.Options> -> SemVer
+
+type [<RequireQualifiedAccess>] CompareBuildReturn =
+    | N1 = 1
+    | N0 = 0
+
+type [<RequireQualifiedAccess>] CompareLooseReturn =
+    | N1 = 1
+    | N0 = 0
+
+type [<RequireQualifiedAccess>] CompareReturn =
+    | N1 = 1
+    | N0 = 0
+
+
+type [<RequireQualifiedAccess>] RcompareReturn =
+    | N1 = 1
+    | N0 = 0
+
+type [<RequireQualifiedAccess>] CompareIdentifiersReturn =
+    | N1 = 1
+    | N0 = 0
+
+type [<RequireQualifiedAccess>] RcompareIdentifiersReturn =
+    | N1 = 1
+    | N0 = 0
+
+type [<StringEnum>] [<RequireQualifiedAccess>] OutsideHilo =
+    | [<CompiledName ">">] GT
+    | [<CompiledName "<">] LT
+
+let [<Import("SEMVER_SPEC_VERSION","semver")>] SEMVER_SPEC_VERSION: string = jsNative
+
+type [<StringEnum>] [<RequireQualifiedAccess>] ReleaseType =
+    | Major
+    | Premajor
+    | Minor
+    | Preminor
+    | Patch
+    | Prepatch
+    | Prerelease
+
+type [<AllowNullLiteral>] Options =
+    abstract loose: bool option with get, set
+    abstract includePrerelease: bool option with get, set
+
+type [<AllowNullLiteral>] CoerceOptions =
+    inherit Options
+    /// <summary>Used by <c>coerce()</c> to coerce from right to left.</summary>
+    /// <default>false</default>
+    /// <example>
+    /// coerce('1.2.3.4', { rtl: true });
+    /// // =&gt; SemVer { version: '2.3.4', ... }
+    /// </example>
+    abstract rtl: bool option with get, set
+
+type [<StringEnum>] [<RequireQualifiedAccess>] Operator =
+    | [<CompiledName "===">] ExactlyEqual
+    | [<CompiledName "!==">] ExactlyUnequal
+    | [<CompiledName "">] Empty
+    | [<CompiledName "=">] EQ
+    | [<CompiledName "==">] DoubleEqual
+    | [<CompiledName "!=">] NE
+    | [<CompiledName ">">] GT
+    | [<CompiledName ">=">] GTE
+    | [<CompiledName "<">] LT
+    | [<CompiledName "<=">] LTE
+
+let [<Import("*","semver")>] semver: Semver.IExports = jsNative

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -21,7 +21,7 @@
       <Link>paket-files/Fable.Import.VSCode.LanguageServer.fs</Link>
     </Compile>
     <None Include="paket.references" />
-    <Compile Include="Imports/Node.Util.fs" />
+    <Compile Include="Imports/*.fs" />
     <Compile Include="Core/DTO.fs" />
     <Compile Include="Core/Utils.fs" />
     <Compile Include="Core/Environment.fs" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,6 +853,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
   integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
 
+"@types/semver@^7.3.8":
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
+  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
+
 "@types/showdown@^1.9.3":
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/@types/showdown/-/showdown-1.9.3.tgz#eaa881b03a32d3720184731754d3025fc450b970"
@@ -3613,6 +3618,13 @@ semver@^7.3.4:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-javascript@4.0.0, serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
@@ -3980,6 +3992,13 @@ toml@^3.0.0:
   resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
   integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
 
+ts2fable@^0.8.0-build.618:
+  version "0.8.0-build.618"
+  resolved "https://registry.yarnpkg.com/ts2fable/-/ts2fable-0.8.0-build.618.tgz#387d5aaa1d033caba9e15fa0a91058c72642db66"
+  integrity sha512-OtInEhVvfGiFXhvCqZFdYPa3FKy/fDHTBQ0EiDByWdwqWJVDQYBBbMAUYNLrn/1Lqm9dvb3ZMLgytXKg6xdnmg==
+  dependencies:
+    typescript "3.7.4"
+
 tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
@@ -3994,6 +4013,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This PR detects the dotnet SDK version in the rootPath and provides arguments and environment variables to add to the FSAC invocation if the detected SDK is 6.0+ or a prerelease.

This should eliminate most users' need to set the fsac.dotnetArgs parameter entirely and provide a seamless experience while we don't ship a multitargeted FSAC.