### PR TITLE
remove duplicate state initialization in FSI start loop

### DIFF
--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -320,7 +320,6 @@ module Fsi =
         )
 
     let private start () =
-        fsiOutput |> Option.iter (fun n -> n.dispose())
         promise {
             let ctok = vscode.CancellationTokenSource.Create().token
             let! profile =
@@ -340,8 +339,6 @@ module Fsi =
                 | U2.Case1 opts -> window.createTerminal opts
                 | U2.Case2 opts -> window.createTerminal opts
 
-            setupTerminalState terminal
-            sendCd window.activeTextEditor
             terminal.show(true)
             return terminal
         }


### PR DESCRIPTION
When rebasing the standalone terminal fixes back into the new vscode typings PR I messed up the initialization routine in FSI.fs

The `start` method now starts the terminal with a given profile, and the `handleOpenTerminal` handler is used to ensure that any started terminal is cleanly initialized and all mutables are updated accordingly.  This is necessary because we use the same shared terminal profile now when users manually start FSI via the terminal dropdowns as we do when they invoke FSI via any of the FSI commands.

This was the case in master before the typings MR as well.