### PR TITLE
wrap the path to dotnet.exe when it contains spaces

### DIFF
--- a/src/Core/Environment.fs
+++ b/src/Core/Environment.fs
@@ -45,6 +45,12 @@ module Environment =
             |> Some
             |> Promise.lift)
         |> Option.defaultWith (fun () -> tryGetTool "dotnet" )
+        |> Promise.map (Option.map (fun path ->
+            // paths with spaces must be wrapped to ensure a 'single' command
+            if path.Contains " "
+            then "\"" + path + "\""
+            else path
+        ))
 
 
     let ensureDirectory (path : string) =

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -676,7 +676,7 @@ Consider:
                 let! sdkVersionAtRootPath = runtimeVersion()
                 match sdkVersionAtRootPath with
                 | Error e ->
-                    printfn $"FSAC (NETCORE): {e}"
+                    printfn $"Error discovering .Net SDK version: {e}"
                     return [], []
                 | Ok v ->
                     if v.major >= 6.0


### PR DESCRIPTION
Potential solution for some errors reported in #1568.

The process-spawning library isn't auto-escaping fully-qualified commands that contain spaces, and by default the path to `dotnet.exe` on windows is such a path.  Will need to test on a windows machine to verify this.  If this is the case, then we'll want to push this space-escaping down into our process-helper library as a follow-up action, so that we can remove this small change as well as get this kind of protection everywhere we use the library.