### PR TITLE
Fix #1204: replace all rootPath usages with workspaceFolders

### DIFF
--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -69,7 +69,7 @@ module Debugger =
         }
 
     let setProgramPath project (cfg : LaunchJsonVersion2.RequestLaunch) =
-        let relativeOutPath = node.path.relative(workspace.rootPath.Value, project.Output).Replace("\\", "/")
+        let relativeOutPath = node.path.relative(workspace.workspaceFolders.Value.[0].uri.path, project.Output).Replace("\\", "/")
         let programPath = sprintf "${workspaceRoot}/%s" relativeOutPath
 
         // WORKAROUND the project.Output is the obj assembly, instead of bin assembly

--- a/src/Components/Diagnostics.fs
+++ b/src/Components/Diagnostics.fs
@@ -133,7 +133,7 @@ Error: %s
 
     let writeToFile (text : string) =
         promise {
-            let path = node.path.join(workspace.rootPath.Value, "Diagnostic info")
+            let path = node.path.join(workspace.workspaceFolders.Value.[0].uri.path, "Diagnostic info")
             let newFile = vscode.Uri.parse ("untitled:" + path)
             let! document = newFile |> workspace.openTextDocument
 

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -213,7 +213,7 @@ module Fsi =
                 let dir = node.path.dirname file
                 file, dir
             | None ->
-                let dir = workspace.rootPath.Value
+                let dir = workspace.workspaceFolders.Value.[0].uri.path
                 node.path.join(dir, "tmp.fsx"), dir
 
         match lastCd with
@@ -477,7 +477,7 @@ module Fsi =
         promise {
             match ctn with
             | Some c ->
-                let path = node.path.join(workspace.rootPath.Value, "references.fsx")
+                let path = node.path.join(workspace.workspaceFolders.Value.[0].uri.path, "references.fsx")
                 let! td = vscode.Uri.parse ("untitled:" + path) |> workspace.openTextDocument
                 let! te = window.showTextDocument(td, ViewColumn.Three)
                 let! _ = te.edit (fun e ->
@@ -501,7 +501,7 @@ module Fsi =
                 yield! project.Files |> Seq.map (sprintf "#load @\"%s\"")
             |]
         promise {
-            let path = node.path.join(workspace.rootPath.Value, "references.fsx")
+            let path = node.path.join(workspace.workspaceFolders.Value.[0].uri.path, "references.fsx")
             let! td = vscode.Uri.parse ("untitled:" + path) |> workspace.openTextDocument
             let! te = window.showTextDocument(td, ViewColumn.Three)
             let! _ = te.edit (fun e ->

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -549,7 +549,7 @@ module SolutionExplorer =
                     res
                 ) |> ResizeArray
 
-            let cwd = workspace.rootPath
+            let cwd = workspace.workspaceFolders |> Option.map (fun x -> x.[0])
             match cwd with
             | Some cwd ->
                 let! template = window.showQuickPick ( n |> U2.Case1)
@@ -577,10 +577,10 @@ module SolutionExplorer =
                                 let pname =
                                     if projName.IsSome then projName.Value + ".fsproj" else
                                     if output.IsSome then output.Value + ".fsproj" else
-                                    (path.dirname workspace.rootPath.Value) + ".fsproj"
+                                    cwd.name + ".fsproj"
 
                                 let proj =
-                                    path.join(workspace.rootPath.Value, dir, name, pname)
+                                    path.join(cwd.uri.path, dir, name, pname)
                                 let args = ["sln"; slnName; "add"; proj]
                                 Project.execWithDotnet MSBuild.outputChannel (ResizeArray args) |> ignore
                             | _ ->

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -1,4 +1,4 @@
-﻿namespace Ionide.VSCode.FSharp
+namespace Ionide.VSCode.FSharp
 
 open System
 open Fable.Core
@@ -73,7 +73,7 @@ module LanguageService =
 
     let private handleUntitled (fn : string) = if fn.EndsWith ".fs" || fn.EndsWith ".fsi" || fn.EndsWith ".fsx" then fn else (fn + ".fsx")
 
-    /// runs `dotnet --version` in the current rootPath to determine the resolved sdk version from the global.json file.
+    /// runs `dotnet --version` in the first workspaceFolder to determine the resolved sdk version from the global.json file.
     let runtimeVersion() = promise {
         let! dotnet = Environment.dotnet
         match dotnet with
@@ -673,8 +673,8 @@ Consider:
 
         let discoverDotnetArgs () = promise {
             let! (rollForwardArgs, necessaryEnvVariables) = promise {
-                let! sdkVersionAtRootPath = runtimeVersion()
-                match sdkVersionAtRootPath with
+                let! sdkVersionAtWorkspaceFolder = runtimeVersion()
+                match sdkVersionAtWorkspaceFolder with
                 | Error e ->
                     printfn $"FSAC (NETCORE): {e}"
                     return [], []


### PR DESCRIPTION
replace all rootPath usages with workspaceFolders using only the first one (support one workspace folder)