### PR TITLE
Fix #529 and #1107: Backspace should delete one indent level

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1124,12 +1124,6 @@
 				"when": "editorFocus && editorLangId == 'fsharp'"
 			}
 		],
-		"configurationDefaults": {
-			"[fsharp]": {
-				"editor.useTabStops": false
-			}
-
-		},
 		"semanticTokenScopes": [
 			{
 				"language": "fsharp",


### PR DESCRIPTION
Fixes #529 and #1107: Backspace should delete one indent level

This PR removes the F# language configuration from the `package.json`, so that the `editor.useTabStops` setting in the `settings.json` of the user will prevail.