### PR TITLE
Fixes #1620: reference patched FSAC attempting to fix stuck code lenses

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -30,7 +30,7 @@ let gitHome = "https://github.com/" + gitOwner
 // The name of the project on GitHub
 let gitName = "ionide-vscode-fsharp"
 
-let fsacDir = "paket-files/github.com/fsharp/FsAutoComplete"
+let fsacDir = !! "paket-files/github.com/**/FsAutoComplete" |> Seq.head
 
 // Read additional information from the release notes document
 let releaseNotesData =

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -11,9 +11,9 @@ nuget Fable.HtmlConverter ~> 2.1.0
 
 nuget Thoth.Json ~> 4.1.0
 
-git https://github.com/fsharp/FsAutoComplete.git 0.49.0 build:"build.cmd", OS: win
-git https://github.com/fsharp/FsAutoComplete.git 0.49.0 build:"build.sh",  OS: linux
-git https://github.com/fsharp/FsAutoComplete.git 0.49.0 build:"build.sh",  OS: osx
+git https://github.com/beauvankirk/FsAutoComplete.git bugfix/stuck-code-lenses build:"build.cmd", OS: win
+git https://github.com/beauvankirk/FsAutoComplete.git bugfix/stuck-code-lenses build:"build.sh",  OS: linux
+git https://github.com/beauvankirk/FsAutoComplete.git bugfix/stuck-code-lenses build:"build.sh",  OS: osx
 
 git https://github.com/ionide/ionide-fsgrammar.git master
 

--- a/paket.lock
+++ b/paket.lock
@@ -38,18 +38,18 @@ NUGET
       Fable.Core (>= 3.1.4)
       FSharp.Core (>= 4.7)
 GIT
-  remote: https://github.com/fsharp/FsAutoComplete.git
-     (7fdc3fe88ffc551bd9a68349bd90dc118b64c4ab)
+  remote: https://github.com/beauvankirk/FsAutoComplete.git
+     (f3b52b39004c8f09915e06fdc3b0c98001982147)
       build: build.cmd
       os: win
-     (7fdc3fe88ffc551bd9a68349bd90dc118b64c4ab)
+     (f3b52b39004c8f09915e06fdc3b0c98001982147)
       build: build.sh
       os: linux
-     (7fdc3fe88ffc551bd9a68349bd90dc118b64c4ab)
+     (f3b52b39004c8f09915e06fdc3b0c98001982147)
       build: build.sh
       os: osx
   remote: https://github.com/ionide/ionide-fsgrammar.git
-     (fc4cac6d9bc1787f54ce48bbc77bcbb1de8160ff)
+     (447ecc314c6f105d34a02083e95b63a2e04c8804)
 GITHUB
   remote: ionide/ionide-vscode-helpers
     src/Fable.Import.Showdown.fs (16eceef34bcee50f441f6727eed94c8bb9a136f5)


### PR DESCRIPTION
This change attempts to address the broken code lenses with the recent 5.9.0 release as raised in [1620](https://github.com/ionide/ionide-vscode-fsharp/issues/1620). 

The issue appears to be rooted in a change in the FSAutoComplete update, wherein the LspServer.CodeLensResolve method was altered to call an Option<_>-returning function (TryGetRecentTypeCheckResultsForFile in 0.49.0)  rather than an Async<Option<_>>-returning function (TryGetLatestTypeCheckResultsForFile in 0.48.1) to check for FCS Checker results. The line with the new call is [here](https://github.com/fsharp/FsAutoComplete/blob/7fdc3fe88ffc551bd9a68349bd90dc118b64c4ab/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L1895)

I'm not sure this is the best fix, but I revised the CodeLensResolve to instead call GetLatestTypeCheckResultsForFile, which returns an Async<_>. This seems to (correctly in my opinion) wait for FCS check results before resolving the code lens. The method I opted for is also the one that retained the same comment as the previous version's variant, so it seems perhaps that was the intended more-direct replacement?

If this seems reasonable I can open a PR on FSAC as well/instead. I wanted to start here since this is the only place the issue was raised.

Naturally a merged PR on FSAC would eliminate the need for any code change here. For now I was including these changes (which merely reference my FSAC branch) for initial feedback and to make sure CI/tests weren't any worse off.

For reference, this was a helpful diff view relating the relevant FSAC change:

![image](https://user-images.githubusercontent.com/20178486/141252961-c8059d3c-294c-44c4-8f55-71c139f193f8.png)
