### PR TITLE
Move the cursor down when sending a line to FSI

### DIFF
--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -367,6 +367,16 @@ module Fsi =
             window.showErrorMessage("Failed to send text to FSI", null) |> ignore
         )
 
+    let private moveCursorDownOneLine() =
+        let args =
+            createObj [
+                "to" ==> "down"
+                "by" ==> "line"
+                "value" ==> 1
+            ]
+        commands.executeCommand("cursorMove", Some(box args))
+        |> ignore
+
     let private sendLine () =
         let editor = window.activeTextEditor.Value
         let _ = editor.document.fileName
@@ -374,7 +384,7 @@ module Fsi =
         let line = editor.document.lineAt pos
         sendCd (Some editor)
         send line.text
-        |> Promise.onSuccess (fun _ -> commands.executeCommand("cursorDown", null) |> ignore)
+        |> Promise.onSuccess (fun _ -> moveCursorDownOneLine())
         |> Promise.suppress // prevent unhandled promise exception
         |> ignore
 


### PR DESCRIPTION
I'm not sure if this is a known issue, but several months ago, something broke the functionality that moves the cursor down when sending a line to FSI. I believe this PR fixes this issue by executing the `cursorMove` command per the vscode documentation: https://code.visualstudio.com/api/references/commands (see screenshot below):

![image](https://user-images.githubusercontent.com/2154029/143160347-a2f311b3-1928-44fd-b3c8-c4d4f97057a9.png)
 