### PR TITLE
Fix some indexOf errors in the FSI watcher feature

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -19,6 +19,12 @@
       "commands": [
         "fable"
       ]
+    },
+    "fantomas-tool": {
+      "version": "4.6.0-alpha-008",
+      "commands": [
+        "fantomas"
+      ]
     }
   }
 }

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -130,58 +130,61 @@ module Fsi =
 
 
             node.fs.readFile(varsUri, (fun _ buf ->
-                let cnt = buf.ToString()
-                varsContent <-
-                    cnt
-                    |> String.split [| '\n' |]
-                    |> Seq.map (fun row ->
-                        let x = row.Split([|"###IONIDESEP###"|], StringSplitOptions.None)
-                        sprintf "<tr><td>%s</td><td><code>%s</code></td><td><code>%s</code></td></tr>" x.[0] x.[1] x.[2]
-                    )
-                    |> String.concat "\n"
-                    |> sprintf """</br><h3>Declared values</h3></br><table style="width:100%%"><tr><th style="width: 12%%">Name</th><th style="width: 65%%">Value</th><th style="width: 20%%">Type</th></tr>%s</table>"""
-
-
-                setContent (varsContent + "\n\n" + funcsContent + "\n\n" + typesContent)
-            ))
-
-            node.fs.readFile(funcUri, (fun _ buf ->
-                let cnt = buf.ToString()
-                funcsContent <-
-                    cnt
-                    |> String.split [| '\n' |]
-                    |> Seq.map (fun row ->
-                        let x = row.Split([|"###IONIDESEP###"|], StringSplitOptions.None)
-                        sprintf "<tr><td>%s</td><td><code>%s</code></td><td><code>%s</code></td></tr>" x.[0] x.[1] x.[2]
-                    )
-                    |> String.concat "\n"
-                    |> sprintf """</br><h3>Declared functions</h3></br><table style="width:100%%"><tr><th style="width: 12%%">Name</th><th style="width: 65%%">Parameters</th><th style="width: 20%%">Returned type</th></tr>%s</table>"""
-
-
-                setContent (varsContent + "\n\n" + funcsContent + "\n\n" + typesContent)
-            ))
-
-            node.fs.readFile(typesUri, (fun _ buf ->
-                let cnt = buf.ToString()
-                typesContent <-
-                    if String.IsNullOrWhiteSpace cnt then
-                        ""
-                    else
+                if not (Utils.isUndefined buf) then
+                    let cnt = buf.ToString()
+                    varsContent <-
                         cnt
                         |> String.split [| '\n' |]
                         |> Seq.map (fun row ->
                             let x = row.Split([|"###IONIDESEP###"|], StringSplitOptions.None)
-                            let signature =
-                                if x.[1].Contains "#|#" then
-                                   "| " + x.[1].Replace("#|#", "</br>| ")
-                                else x.[1]
-                            sprintf "<tr><td>%s</td><td><code>%s</code></td></tr>" x.[0] signature
+                            sprintf "<tr><td>%s</td><td><code>%s</code></td><td><code>%s</code></td></tr>" x.[0] x.[1] x.[2]
                         )
                         |> String.concat "\n"
-                        |> sprintf """</br><h3>Declared types</h3></br><table style="width:100%%"><tr><th style="width: 12%%">Name</th><th style="width: 85%%">Signature</th></tr>%s</table>"""
+                        |> sprintf """</br><h3>Declared values</h3></br><table style="width:100%%"><tr><th style="width: 12%%">Name</th><th style="width: 65%%">Value</th><th style="width: 20%%">Type</th></tr>%s</table>"""
 
 
-                setContent (varsContent + "\n\n" + funcsContent + "\n\n" + typesContent)
+                    setContent (varsContent + "\n\n" + funcsContent + "\n\n" + typesContent)
+            ))
+
+            node.fs.readFile(funcUri, (fun _ buf ->
+                if not (Utils.isUndefined buf) then
+                    let cnt = buf.ToString()
+                    funcsContent <-
+                        cnt
+                        |> String.split [| '\n' |]
+                        |> Seq.map (fun row ->
+                            let x = row.Split([|"###IONIDESEP###"|], StringSplitOptions.None)
+                            sprintf "<tr><td>%s</td><td><code>%s</code></td><td><code>%s</code></td></tr>" x.[0] x.[1] x.[2]
+                        )
+                        |> String.concat "\n"
+                        |> sprintf """</br><h3>Declared functions</h3></br><table style="width:100%%"><tr><th style="width: 12%%">Name</th><th style="width: 65%%">Parameters</th><th style="width: 20%%">Returned type</th></tr>%s</table>"""
+
+
+                    setContent (varsContent + "\n\n" + funcsContent + "\n\n" + typesContent)
+            ))
+
+            node.fs.readFile(typesUri, (fun _ buf ->
+                if not (Utils.isUndefined buf) then
+                    let cnt = buf.ToString()
+                    typesContent <-
+                        if String.IsNullOrWhiteSpace cnt then
+                            ""
+                        else
+                            cnt
+                            |> String.split [| '\n' |]
+                            |> Seq.map (fun row ->
+                                let x = row.Split([|"###IONIDESEP###"|], StringSplitOptions.None)
+                                let signature =
+                                    if x.[1].Contains "#|#" then
+                                    "| " + x.[1].Replace("#|#", "</br>| ")
+                                    else x.[1]
+                                sprintf "<tr><td>%s</td><td><code>%s</code></td></tr>" x.[0] signature
+                            )
+                            |> String.concat "\n"
+                            |> sprintf """</br><h3>Declared types</h3></br><table style="width:100%%"><tr><th style="width: 12%%">Name</th><th style="width: 85%%">Signature</th></tr>%s</table>"""
+
+
+                    setContent (varsContent + "\n\n" + funcsContent + "\n\n" + typesContent)
             ))
 
         let activate dispsables =

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -146,6 +146,9 @@ module Utils =
 
     let isNotNull o = o |> unbox <> null
 
+    [<Emit("$0 === undefined")>]
+    let isUndefined (x: 'a) : bool = jsNative
+
     type System.Collections.Generic.Dictionary<'key, 'value> with
         [<Emit("$0.has($1) ? $0.get($1) : null")>]
         member this.TryGet(key: 'key): 'value option = jsNative


### PR DESCRIPTION
This resolves about half of the random indexOf errors that users report. The `buf` in all cases is `undefined`, but when we call ToString() on it we get the string literal `"undefined"`, which then we attempt to process as if it was the output of the watcher.fsx script. The easy fix is to check if the buf is undefined before processing. I wonder if we can update the types for this so that `buf` can be an option?