### PR TITLE
 Contribution Guide and README edits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,10 +143,10 @@ Remove the settings from steps 3 and 4 to go back to FSAC bundled in Ionide exte
 
 ### FSAC Dependencies
 
-[dotnet]: https://www.microsoft.com/net/download/core
-[nodejs]: https://nodejs.org/en/download/
-[yarn]: https://yarnpkg.com/en/docs/install
-[vscode]: https://code.visualstudio.com/Download
+[dotnet](https://www.microsoft.com/net/download/core)
+[nodejs](https://nodejs.org/en/download/)
+[yarn](https://yarnpkg.com/en/docs/install)
+[vscode](https://code.visualstudio.com/Download)
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,10 +143,10 @@ Remove the settings from steps 3 and 4 to go back to FSAC bundled in Ionide exte
 
 ### FSAC Dependencies
 
-[dotnet](https://www.microsoft.com/net/download/core)
-[nodejs](https://nodejs.org/en/download/)
-[yarn](https://yarnpkg.com/en/docs/install)
-[vscode](https://code.visualstudio.com/Download)
+- [dotnet](https://www.microsoft.com/net/download/core)
+- [nodejs](https://nodejs.org/en/download/)
+- [yarn](https://yarnpkg.com/en/docs/install)
+- [vscode](https://code.visualstudio.com/Download)
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,168 @@
 
 Please take a moment to review this document in order to make the contribution process easy and effective for everyone involved!
 
-## Using the issue tracker
+For Getting Started instructions, see:
 
-Use the issues tracker for:
+- [**Building** and **Running** Ionide Locally](#getting-started)
+- [Submitting **Pull Requests**](#pull-requests)
 
-* [bug reports](#bug-reports)
-* [feature requests](#feature-requests)
-* [submitting pull requests](#pull-requests)
+For issue reporting, use [Github Issues](https://github.com/ionide/ionide-vscode-fsharp/issues) and follow the procedures documented here:
+
+- [Submitting **Bug Reports**](#bug-reports)
+- [Submitting **Feature Requests**](#feature-requests)
 
 Personal support request should be discussed on [F# Software Foundation Slack](https://fsharp.org/guides/slack/).
+
+## Getting Started 
+
+First things first! In order to build & develop Ionide locally, you'll need to install the following.
+
+### Prerequisites
+
+- [Visual Studio Code][vscode] 🙄
+- [.NET Core 3.1][dotnet]
+- [Node.js][nodejs]
+- [Yarn][yarn]
+
+### First-Time Build
+
+1. **Fork the Ionide repo** https://github.com/ionide/ionide-vscode-fsharp on github.
+
+1. **Clone your fork**:
+    ```bash
+    git clone git@github.com:YOUR_GITHUB_USER/ionide-vscode-fsharp.git
+    ```
+    or if you don't use ssh:
+
+    ```bash
+    git clone https://github.com/YOUR_GITHUB_USER/ionide-vscode-fsharp.git
+    ```
+3. **Open the repo** in your terminal:
+    ```bash
+    cd ionide-vscode-fsharp
+    ```
+3. Then **build the project** by running the build script: 
+    (on Mac/Linux)
+    ```bash
+    ./build.sh
+    ```
+    (or on Windows)
+    ```bash
+    build.cmd # (might need ./build Build instead here.)
+    ```
+4. **Voilà!** You're ready to run Ionide.
+
+**Skip to the [Launching Ionide](#launching-ionide) section** if the build succeeded.
+
+Otherwise, check out the [Troubleshooting Build Failures](#troubleshooting-build-failures) guide.
+
+### Running a Full Build
+
+This should *always* be done __at least once after any clone/pull__.  
+
+```bash
+./build.sh -t Build
+```
+
+This will re-install any necesssary packages and files.
+
+### Troubleshooting Build Failures
+
+- If the `FsAutoComplete` dependency fails to build, you can re-run it manually:
+  ```bash
+    # browse to the FsAutoComplete source code folder
+    cd paket-files/github.com/fsharp/FsAutoComplete
+    # build FsAutoComplete (Mac/Linux)
+    ./build.sh LocalRelease
+    # build FsAutoComplete (Windows)
+    build.cmd LocalRelease
+  ```
+
+- If `dotnet restore` gives the error ` The tools version "14.0" is unrecognized`, then you need to install [msbuildtools2015][msbuildtools2015]
+
+- If `dotnet restore` gives the error `error MSB4126: The specified solution configuration "Debug|x64" is invalid`, there's a good chance you have the `Platform` environment variable set to "x64".  Unset the variable and try the restore command again.
+
+- If `./build.sh` gives errors, you may need to run `./build.sh -t Build` one time.
+
+
+### Launching Ionide
+
+When you're ready to test out some code changes, you can use vscode's [Run View](https://code.visualstudio.com/Docs/editor/debugging#_run-view) to build and launch Ionide in a new  [Extension Development Host instance](https://code.visualstudio.com/api/get-started/your-first-extension), which is a separate "dev mode" instance of VS code used for developing extensions. 
+
+First, open the Ionide project folder in vscode.
+  ```bash
+  cd ionide-vscode-fsharp # or whereever you cloned the ionide repo.
+  code .
+  ```
+Then, you can open Ionide in a new `Extension Development Host` using one of the following methods:
+
+#### `Build and Launch Extension`
+
+This builds the extension and launches it immediately in a new vscode extension host.
+
+1. Open the "Run and Debug" menu (`cmd`+`shift`+`d` or `ctrl`+`shift`+`d`).
+2. Choose the `Build and Launch Extension` launch configuration
+3. Run it by pressing `F5`.
+
+#### Watch Mode (Recommended)
+
+There are **two steps** involved in running Ionide in Watch Mode. 
+
+TL;DR: watch this video clip:
+
+https://user-images.githubusercontent.com/2154029/143313128-94b7b5ce-64d3-4008-97ac-ff44fdce58cc.mp4
+
+1. **Start the `Watch` task**.
+    - Open the command palette (`cmd`+`p` or `ctl`+`p`)
+    - Enter `tasks watch`.  
+    - **Wait a few seconds**. It might take 15-30 seconds for the initial build to complete
+2. **Run the `Launch Only` launch configuration**.
+    - Open the Run and Debug menu (`cmd`+`shift`+`d` or `ctrl`+`shift`+`d`)
+    - Choose the `Launch Only` configuration
+    - Run it by pressing `F5`.
+
+Note: Step 1 starts a new "Watch" task that rebuilds Ionide in the background while you're making source code changes. You should wait for this to finish before opening the Extension Host.
+
+If you're curious what's going on, you can view the log output for this task by running `Tasks: Show Running Tasks` from the command palete. 
+
+### Working with FSAC
+
+1. Open FSAC from a new instance of VSCode from the directory: `paket-files/github.com/fsharp/FsAutoComplete`
+2. Build the FSAC solution and copy the dll output from the output log, it should be something like: `paket-files/github.com/fsharp/FsAutoComplete/src/FsAutoComplete/bin/Debug/net5.0/fsautocomplete.dll`.
+3. In the instance of VSCode that you have Ionide open, open settings (`CMD ,` or `Ctrl ,`), and find the section `FSharp > Fsac: Net Core Dll Path` and paste the output you copied from step 3.
+4. Now find the section `FSharp > Fsac: Attach Debugger` and check the check box.
+5. Close settings
+6. Goto the debug section and hit `Build and Launch extension`, after a while another instance of VSCode will start, you can use this instance to test Ionide/FsAutoComplete.
+7. To attach the debugger go back to the instance of VSCode where you open FSAC and goto the debug section, hit `.NET Core Attach` in the list shown you should see all the dotnet processes running, choose one that has `fsautocomplete.dll --mode lsp --attachdebugger` shown.
+8. Now you will be able to use breakpoints in the FsAutocomplete solution to debug the instance from step 6.
+
+There is a video [here](https://www.youtube.com/watch?v=w36_PvHNoPY) that goes through the steps and fixing a bug in a little more detail.
+
+Remove the settings from steps 3 and 4 to go back to FSAC bundled in Ionide extension.
+
+### FSAC Dependencies
+
+[dotnet]: https://www.microsoft.com/net/download/core
+[nodejs]: https://nodejs.org/en/download/
+[yarn]: https://yarnpkg.com/en/docs/install
+[vscode]: https://code.visualstudio.com/Download
+
+## Pull requests
+
+Good pull requests - patches, improvements, new features - are a fantastic
+help. They should remain focused in scope and avoid containing unrelated
+commits.
+
+**IMPORTANT**: By submitting a patch, you agree that your work will be
+licensed under the license used by the project.
+
+If you have any large pull request in mind (e.g. implementing features,
+refactoring code, etc), **please ask first** otherwise you risk spending
+a lot of time working on something that the project's developers might
+not want to merge into the project.
+
+Please adhere to the coding conventions in the project (indentation,
+accurate comments, etc.).
 
 ## Bug reports
 
@@ -62,97 +215,3 @@ Feature requests are welcome and should be discussed on issue tracker. But take 
 out whether your idea fits with the scope and aims of the project. It's up to *you*
 to make a strong case to convince the community of the merits of this feature.
 Please provide as much detail and context as possible.
-
-## Pull requests
-
-Good pull requests - patches, improvements, new features - are a fantastic
-help. They should remain focused in scope and avoid containing unrelated
-commits.
-
-**IMPORTANT**: By submitting a patch, you agree that your work will be
-licensed under the license used by the project.
-
-If you have any large pull request in mind (e.g. implementing features,
-refactoring code, etc), **please ask first** otherwise you risk spending
-a lot of time working on something that the project's developers might
-not want to merge into the project.
-
-Please adhere to the coding conventions in the project (indentation,
-accurate comments, etc.).
-
-## How to build and test a local version of Ionide
-
-### Prerequisites
-
-- [Visual Studio Code][vscode] 🙄
-- [.NET Core 3.1][dotnet]
-- [Node.js][nodejs]
-- [Yarn][yarn]
-
-### Building
-
-Fork, from the github interface https://github.com/ionide/ionide-vscode-fsharp
- - if you don't use a certificate for committing to github:
-```bash
-git clone https://github.com/YOUR_GITHUB_USER/ionide-vscode-fsharp.git
-```
- - if you use a certificate for github authentication:
-```bash
-git clone git@github.com:YOUR_GITHUB_USER/ionide-vscode-fsharp.git
-```
-
-#### First time build:
-```bash
-cd ionide-vscode-fsharp
-./build.sh  # or build.cmd if your OS is Windows  (might need ./build Build here)
-```
-
-If `dotnet restore` gives the error ` The tools version "14.0" is unrecognized`, then you need to install [msbuildtools2015][msbuildtools2015]
-
-If `dotnet restore` gives the error `error MSB4126: The specified solution configuration "Debug|x64" is invalid`, there's a good chance you have the `Platform` environment variable set to "x64".  Unset the variable and try the restore command again.
-
-If `./build.sh` gives errors, you may need to run `./build.sh -t Build` one time.
-
-
-Everything is done via `build.cmd` \ `build.sh`.
-
-- `build -t Build` does a full-build, including package installation and copying some necessary files.<br/>
-  It should always be done at least once after any clone/pull.
-- If a git dependency fails to build paket won't re-do it you can run their build scripts manually:
-  - In `paket-files\github.com\fsharp\FsAutoComplete` run `build LocalRelease`
-
-### Launching the extension
-
-Once the initial build on the command line is completed, you should use vscode itself to build and launch the development extension.   To do this,
-
-- open the project folder in vscode
-- Use one of the following two configurations which will build the project and launch a new vscode instance running your vscode extension
-- In VSCode two configurations are possible to run:
-  - Use `Build and Launch Extension`
-  - Start the `Watch` task and when a build is done start `Launch Only`
-
-These two options can be reached in VsCode in the side bar (look for a Beetle symbol), or by typing `control-P Debug <space> ` and then selecting either `Build and Launch` or `Watch`
-
-The new extension window will appear with window title `Extension development host`
-
-### Working with FSAC
-
-1. Open FSAC from a new instance of VSCode from the directory: `paket-files/github.com/fsharp/FsAutoComplete`
-2. Build the FSAC solution and copy the dll output from the output log, it should be something like: `paket-files/github.com/fsharp/FsAutoComplete/src/FsAutoComplete/bin/Debug/net5.0/fsautocomplete.dll`.
-3. In the instance of VSCode that you have Ionide open, open settings (`CMD ,` or `Ctrl ,`), and find the section `FSharp > Fsac: Net Core Dll Path` and paste the output you copied from step 3.
-4. Now find the section `FSharp > Fsac: Attach Debugger` and check the check box.
-5. Close settings
-6. Goto the debug section and hit `Build and Launch extension`, after a while another instance of VSCode will start, you can use this instance to test Ionide/FsAutoComplete.
-7. To attach the debugger go back to the instance of VSCode where you open FSAC and goto the debug section, hit `.NET Core Attach` in the list shown you should see all the dotnet processes running, choose one that has `fsautocomplete.dll --mode lsp --attachdebugger` shown.
-8. Now you will be able to use breakpoints in the FsAutocomplete solution to debug the instance from step 6.
-
-There is a video [here](https://www.youtube.com/watch?v=w36_PvHNoPY) that goes through the steps and fixing a bug in a little more detail.
-
-Remove the settings from steps 3 and 4 to go back to FSAC bundled in Ionide extension.
-
-### Dependencies
-
-[dotnet]: https://www.microsoft.com/net/download/core
-[nodejs]: https://nodejs.org/en/download/
-[yarn]: https://yarnpkg.com/en/docs/install
-[vscode]: https://code.visualstudio.com/Download

--- a/README.md
+++ b/README.md
@@ -47,38 +47,44 @@ You can support Ionide development on [Open Collective](https://opencollective.c
 - Solution / project explorer
 - And more...
 
-## How to contribute
+## How to Contribute
 
-*Imposter syndrome disclaimer*: I want your help. No really, I do.
+Ths project is hosted on [GitHub](https://github.com/ionide/ionide-vscode-fsharp) where you can [report issues](https://github.com/ionide/ionide-vscode-fsharp/issues), participate in [discussions](https://github.com/ionide/ionide-vscode-fsharp/discussions), fork
+the project and submit pull requests.
+
+### Building and Running
+
+See these instructions for [setting up your local dev environment](https://github.com/ionide/ionide-vscode-fsharp/blob/master/CONTRIBUTING.md#getting-started).
+
+### Guidelines
+
+The [Contribution Guide](https://github.com/ionide/ionide-vscode-fsharp/blob/master/CONTRIBUTING.md) outlines the process and guidelines for getting a patch merged. By making expectations and process explicit, I hope it will make it easier for you to contribute!
+
+### Releasing
+
+* Update `RELEASE_NOTES.md` with the new version number, date (DD.MM.YYYY format please), and brief release notes.
+* Push the change to the main branch
+* A maintainer can run the `release` workflow from Github's actions page at that point
+
+### Imposter Syndrome Disclaimer
+
+I want your help. *No really, I do*.
 
 There might be a little voice inside that tells you you're not ready; that you need to do one more tutorial, or learn another framework, or write a few more blog posts before you can help me with this project.
 
 I assure you, that's not the case.
 
-This project has some clear Contribution Guidelines and expectations that you can [read here](https://github.com/ionide/ionide-vscode-fsharp/blob/master/CONTRIBUTING.md).
-
-The contribution guidelines outline the process that you'll need to follow to get a patch merged. By making expectations and process explicit, I hope it will make it easier for you to contribute.
-
 And you don't just have to write code. You can help out by writing documentation, tests, or even by giving feedback about this work. (And yes, that includes giving feedback about the contribution guidelines.)
 
 Thank you for contributing!
 
-
-## Contributing and copyright
-
-The project is hosted on [GitHub](https://github.com/ionide/ionide-vscode-fsharp) where you can [report issues](https://github.com/ionide/ionide-vscode-fsharp/issues), participate in [discussions](https://github.com/ionide/ionide-vscode-fsharp/discussions), fork
-the project and submit pull requests.
-
-The library is available under [MIT license](https://github.com/ionide/ionide-vscode-fsharp/blob/master/LICENSE.md), which allows modification and redistribution for both commercial and non-commercial purposes.
+## Code of Conduct
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+## Copyright
 
-## Releasing
-
-* Update `RELEASE_NOTES.md` with the new version number, date (DD.MM.YYYY format please), and brief release notes.
-* Push the change to the main branch
-* A maintainer can run the `release` workflow from Github's actions page at that point
+The library is available under [MIT license](https://github.com/ionide/ionide-vscode-fsharp/blob/master/LICENSE.md), which allows modification and redistribution for both commercial and non-commercial purposes.
 
 ## Our Sponsors
 


### PR DESCRIPTION
I had some finding the build & set-up instructions in the readme and thought it might help to make these visible.

I also noticed that the the contribution guide was a bit out of date and could use a little TLC. I updated the setup instructions (with a video demoing how to run Ionide in watch mode) and added a ToC to make them easier to locate. 

I hope you don't mind that I took some editorial liberties. I tried my best to rephrase so the language would be more succinct and direct without changing the meaning/intent.