### PR TITLE
Create launch configurations from launchSettings.json and project metadata

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "fable": {
-      "version": "3.7.5",
+      "version": "3.7.8",
       "commands": [
         "fable"
       ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,11 @@
 			],
 			"stopOnEntry": false,
 			"request": "launch",
-			"sourceMaps": true
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceFolder}/release/*.js",
+				"!**/node_modules/**"
+			],
 		},
 		{
 			"preLaunchTask": "Extension Build (dev)",
@@ -24,7 +28,14 @@
 			],
 			"stopOnEntry": false,
 			"request": "launch",
-			"sourceMaps": true
+			"sourceMaps": true,
+			"pauseForSourceMap": true,
+			"sourceMapRenames": true,
+			"trace": true,
+			"outFiles": [
+				"${workspaceFolder}/release/*.js",
+				"!**/node_modules/**"
+			],
 		},
 		{
 			"name": "Launch Only",

--- a/release/package.json
+++ b/release/package.json
@@ -42,6 +42,12 @@
 	},
 	"main": "./fsharp",
 	"contributes": {
+		"debuggers": [
+			{
+				"type": "coreclr",
+				"label": "Ionide LaunchSettings"
+			}
+		],
 		"languages": [
 			{
 				"id": "fsharp",
@@ -1562,7 +1568,7 @@
 		}
 	},
 	"activationEvents": [
-		"onDebugInitialConfigurations",
+		"onDebugDynamicConfigurations:coreclr",
 		"workspaceContains:**/*.fs",
 		"workspaceContains:**/*.fsx",
 		"workspaceContains:**/*.fsproj",

--- a/release/package.json
+++ b/release/package.json
@@ -1562,6 +1562,7 @@
 		}
 	},
 	"activationEvents": [
+		"onDebugInitialConfigurations",
 		"workspaceContains:**/*.fs",
 		"workspaceContains:**/*.fsx",
 		"workspaceContains:**/*.fsproj",

--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -287,7 +287,7 @@ module Debugger =
             if JS.isDefined ls.environmentVariables then
                 let vars =
                     ls.environmentVariables.Keys
-                    |> Array.map (fun k -> k, box ls.environmentVariables[k])
+                    |> Array.map (fun k -> k, box (Environment.expand (ls.environmentVariables[k])))
 
                 c?env <- createObj vars
 

--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -291,6 +291,9 @@ module Debugger =
 
                 c?env <- createObj vars
 
+                if not (JS.isDefined ls.environmentVariables["ASPNETCORE_URLS"]) && Option.isSome ls.applicationUrl then
+                    c?env?ASPNETCORE_URLS <- ls.applicationUrl.Value
+
 
             c?console <- "internalConsole"
             c?stopAtEntry <- false

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -700,8 +700,7 @@ Consider:
                 promise {
                     let fsautocompletePath =
                         if String.IsNullOrEmpty fsacNetcorePath then
-                            VSCodeExtension.ionidePluginPath ()
-                            + "/bin/fsautocomplete.dll"
+                            path.join (VSCodeExtension.ionidePluginPath (), "bin", "fsautocomplete.dll")
                         else
                             fsacNetcorePath
 

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -430,6 +430,12 @@ module VSCodeExtension =
         sprintf "workbench.view.extension.%s" extensionName
 
 
+module Environment =
+    /// expand any env variables in a string according to
+    /// .NET's rules - that is any %-encoded name is an env var
+    [<Emit("$0.Replace(/%([^%]+)%/g, (_,n) => process.env[n])")>]
+    let expand (s: string): string = jsNative
+
 [<AutoOpen>]
 module Objectify =
     let inline objfy2 (f: 'a -> 'b) : ResizeArray<obj option> -> obj option = unbox f

--- a/src/Imports/Node.Util.fs
+++ b/src/Imports/Node.Util.fs
@@ -13,6 +13,10 @@ let Util: IExports = jsNative
 type ObjectExports =
     abstract member keys: o: obj -> ResizeArray<string>
 
+module JSON =
+    [<Emit("JSON.parse($0)")>]
+    let parse (s: string) : 't = jsNative
+
 module Object =
     [<Emit("Object.keys($0)")>]
     let keys (o) : ResizeArray<string> = jsNative

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -18,7 +18,6 @@ type Api =
       DebugProject: DTO.Project -> string [] -> JS.Promise<unit> }
 
 let activate (context: ExtensionContext) : JS.Promise<Api> =
-
     let solutionExplorer = "FSharp.enableTreeView" |> Configuration.get true
 
     let showExplorer =

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = function(env, argv) {
   return {
   target: 'node',
   mode: isProduction ? "production" : "development",
-  devtool: "source-map-eval",
+  devtool: "source-map",
   entry: './out/fsharp.js',
   output: {
     filename: 'fsharp.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = function(env, argv) {
   return {
   target: 'node',
   mode: isProduction ? "production" : "development",
-  devtool: "source-map",
+  devtool: "source-map-eval",
   entry: './out/fsharp.js',
   output: {
     filename: 'fsharp.js',


### PR DESCRIPTION
This looks for `Properties/launchSettings.json` in projects that exist, and makes launch/debugging configurations for those that do. This is nice because launchSettings.json can be shared across VS, VSCode, Rider, and the dotnet CLI, instead of each system needing separate files.

Notes on the design:
* These are accessed by the "Debug: Select and Start debugging" command palette option, underneath the `.NET 5+ and .NET Core` menu item
![image](https://user-images.githubusercontent.com/573979/160305690-67ce8d17-594a-439b-9c96-5195d1360461.png)
![image](https://user-images.githubusercontent.com/573979/160305696-987bffd8-ebe9-42b5-9506-48fe18e21343.png)
* The name of each configuration is `<project file name>: <launchSettings profile name>`
![image](https://user-images.githubusercontent.com/573979/160305703-35b3a64a-bd9f-4cb6-9a35-7a93725611fb.png)
* only profiles of `commandName = "Project"` are handled. This is in line with `dotnet run`, but could be expanded. Other options mostly deal with IIS Express.
* if `launchBrowser` is true in the launch settings profile, the `serverReadyAction` is set to look for the server url in the classic Kestrel log message `Now listening on: <url>`, so make sure that's logged
* `environmentVariables` are pushed into the launch configuration
* If your project has an OutputType of Exe, a default launch configuration will be generated for it

Unfortunately, VSCode currently restricts compound launch configurations to those listed in launch.json, so these dynamically-generated launches are not suitable for multi-project run scenarios.
 
