### PR TITLE
Implement MSBuild functionality as a Task Provider

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -237,16 +237,16 @@
 			},
 			{
 				"command": "fsharp.explorer.showProjectLoadFailedInfo",
-                "title": "Show info about failed project loading",
-                "icon": {
+				"title": "Show info about failed project loading",
+				"icon": {
 					"light": "./images/icon-status-light.svg",
 					"dark": "./images/icon-status-dark.svg"
 				}
 			},
 			{
 				"command": "fsharp.explorer.showProjectStatus",
-                "title": "Show project status",
-                "icon": {
+				"title": "Show project status",
+				"icon": {
 					"light": "./images/icon-status-light.svg",
 					"dark": "./images/icon-status-dark.svg"
 				}
@@ -803,8 +803,8 @@
 				},
 				{
 					"command": "fsharp.explorer.showProjectLoadFailedInfo",
-                    "when": "viewItem == ionide.projectExplorer.projectLoadFailed",
-                    "group": "inline@98"
+					"when": "viewItem == ionide.projectExplorer.projectLoadFailed",
+					"group": "inline@98"
 				},
 				{
 					"command": "fsharp.explorer.openProjectFile",
@@ -839,8 +839,8 @@
 				},
 				{
 					"command": "fsharp.explorer.showProjectStatus",
-                    "when": "viewItem == ionide.projectExplorer.projectNotRestored",
-                    "group": "inline@98"
+					"when": "viewItem == ionide.projectExplorer.projectNotRestored",
+					"group": "inline@98"
 				},
 				{
 					"command": "fsharp.explorer.addProjecRef",
@@ -1129,10 +1129,18 @@
 			{
 				"language": "fsharp",
 				"scopes": {
-					"mutable": ["variable.fsharp.mutable"],
-					"disposable": ["variable.fsharp.mutable"],
-					"operator": ["keyword.symbol.fsharp"],
-					"cexpr": ["keyword.control.fsharp"]
+					"mutable": [
+						"variable.fsharp.mutable"
+					],
+					"disposable": [
+						"variable.fsharp.mutable"
+					],
+					"operator": [
+						"keyword.symbol.fsharp"
+					],
+					"cexpr": [
+						"keyword.control.fsharp"
+					]
 				}
 			}
 		],
@@ -1152,7 +1160,7 @@
 					"scope": "window"
 				},
 				"FSharp.fsac.dotnetArgs": {
-					"type" : "array",
+					"type": "array",
 					"default": [],
 					"description": "additional CLI arguments to be provided to the dotnet runner for FSAC",
 					"items": {
@@ -1230,17 +1238,17 @@
 					"default": "failwith \"Not Implemented\"",
 					"description": "The expression to fill in the right-hand side of record fields when generating missing fields for a record construction expression"
 				},
-                "FSharp.interfaceStubGeneration": {
+				"FSharp.interfaceStubGeneration": {
 					"type": "boolean",
 					"default": true,
 					"description": "Enables a codefix that generates missing interface members when inside of an interface implementation expression"
-                },
-                "FSharp.interfaceStubGenerationObjectIdentifier": {
+				},
+				"FSharp.interfaceStubGenerationObjectIdentifier": {
 					"type": "string",
 					"default": "this",
 					"description": "The name of the 'self' identifier in an interface member. For example, `this` in the expression `this.Member(x: int) = ()`"
-                },
-                "FSharp.interfaceStubGenerationMethodBody": {
+				},
+				"FSharp.interfaceStubGenerationMethodBody": {
 					"type": "string",
 					"default": "failwith \"Not Implemented\"",
 					"description": "The expression to fill in the right-hand side of interface members when generating missing members for an interface implementation expression"
@@ -1249,13 +1257,13 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enables a codefix that generates missing members for an abstract class when in an type inheriting from that abstract class."
-                },
-                "FSharp.abstractClassStubGenerationObjectIdentifier": {
+				},
+				"FSharp.abstractClassStubGenerationObjectIdentifier": {
 					"type": "string",
 					"default": "this",
 					"description": "The name of the 'self' identifier in an inherited member. For example, `this` in the expression `this.Member(x: int) = ()`"
-                },
-                "FSharp.abstractClassStubGenerationMethodBody": {
+				},
+				"FSharp.abstractClassStubGenerationMethodBody": {
 					"type": "string",
 					"default": "failwith \"Not Implemented\"",
 					"description": "The expression to fill in the right-hand side of inherited members when generating missing members for an abstract base class"
@@ -1395,14 +1403,14 @@
 					],
 					"default": "sameAsFileExplorer",
 					"scope": "window"
-                },
-                "FSharp.smartIndent": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enables smart indent feature"
+				},
+				"FSharp.smartIndent": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enables smart indent feature"
 				},
 				"FSharp.infoPanelUpdate": {
-                    "type": "string",
+					"type": "string",
 					"description": "Controls when the info panel is updated",
 					"enum": [
 						"onCursorMove",
@@ -1410,22 +1418,22 @@
 						"both",
 						"none"
 					],
-                    "default": "onCursorMove"
+					"default": "onCursorMove"
 				},
 				"FSharp.infoPanelReplaceHover": {
-                    "type": "boolean",
+					"type": "boolean",
 					"description": "Controls whether the info panel replaces tooltips",
-                    "default": false
+					"default": false
 				},
 				"FSharp.infoPanelStartLocked": {
-                    "type": "boolean",
+					"type": "boolean",
 					"description": "Controls whether the info panel should be locked at startup",
-                    "default": false
+					"default": false
 				},
 				"FSharp.infoPanelShowOnStartup": {
-                    "type": "boolean",
+					"type": "boolean",
 					"description": "Controls whether the info panel should be displayed at startup",
-                    "default": false
+					"default": false
 				},
 				"FSharp.verboseLogging": {
 					"type": "boolean",
@@ -1564,11 +1572,13 @@
 			}
 		],
 		"terminal": {
-			"profiles": [{
-				"icon": "terminal",
-				"id": "ionide-fsharp.fsi",
-				"title": "F# Interactive"
-			}]
+			"profiles": [
+				{
+					"icon": "terminal",
+					"id": "ionide-fsharp.fsi",
+					"title": "F# Interactive"
+				}
+			]
 		},
 		"taskDefinitions": [
 			{
@@ -1579,14 +1589,15 @@
 		]
 	},
 	"activationEvents": [
-		"onDebugDynamicConfigurations:coreclr",
-		"workspaceContains:**/*.fs",
-		"workspaceContains:**/*.fsx",
-		"workspaceContains:**/*.fsproj",
-		"workspaceContains:**/*.sln",
-		"onLanguage:fsharp",
+		"onCommand:fsharp.NewProject",
 		"onCommand:fsi.Start",
-		"onCommand:fsharp.NewProject"
+		"onCommand:workbench.action.tasks.runTask",
+		"onDebugDynamicConfigurations:coreclr",
+		"onLanguage:fsharp",
+		"workspaceContains:**/*.fs",
+		"workspaceContains:**/*.fsproj",
+		"workspaceContains:**/*.fsx",
+		"workspaceContains:**/*.sln"
 	],
 	"extensionDependencies": [
 		"ms-dotnettools.csharp"

--- a/release/package.json
+++ b/release/package.json
@@ -1497,6 +1497,10 @@
 			{
 				"fileMatch": "wsconfig.json",
 				"url": "./schemas/wsconfig.json"
+			},
+			{
+				"fileMatch": "**/launchSettings.json",
+				"url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/launchsettings.json"
 			}
 		],
 		"breakpoints": [
@@ -1565,7 +1569,14 @@
 				"id": "ionide-fsharp.fsi",
 				"title": "F# Interactive"
 			}]
-		}
+		},
+		"taskDefinitions": [
+			{
+				"type": "msbuild",
+				"required": [],
+				"properties": {}
+			}
+		]
 	},
 	"activationEvents": [
 		"onDebugDynamicConfigurations:coreclr",

--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -156,18 +156,10 @@ module Debugger =
 
     let chooseDefaultProject () =
         promise {
-            let projects =
-                Project.getInWorkspace ()
-                |> List.choose (fun n ->
-                    match n with
-                    | Project.ProjectLoadingState.Loaded x -> Some x
-                    | _ -> None)
-
-            if projects.Length = 0 then
-                return None
-            elif projects.Length = 1 then
-                return Some projects.Head
-            else
+            match Project.getLoaded () with
+            | [] -> return None
+            | project::[] -> return Some project
+            | projects ->
                 let picks =
                     projects
                     |> List.map (fun p ->

--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -280,13 +280,18 @@ module Debugger =
             if JS.isDefined ls.environmentVariables then
                 let vars =
                     ls.environmentVariables.Keys
-                    |> Array.map (fun k -> k, box (Environment.expand (ls.environmentVariables[k])))
+                    |> Array.choose (fun k ->
+                        let value = ls.environmentVariables[k]
+                        if JS.isDefined value then
+                            let replaced = Environment.expand value
+                            Some (k, box replaced)
+                        else None
+                    )
 
                 c?env <- createObj vars
 
                 if not (JS.isDefined ls.environmentVariables["ASPNETCORE_URLS"]) && Option.isSome ls.applicationUrl then
                     c?env?ASPNETCORE_URLS <- ls.applicationUrl.Value
-
 
             c?console <- "internalConsole"
             c?stopAtEntry <- false

--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -55,9 +55,10 @@ module LaunchJsonVersion2 =
         }
 
 module Debugger =
+    let outputChannel = window.createOutputChannel "Ionide: Debugger"
 
     let private logger =
-        ConsoleAndOutputChannelLogger(Some "Debug", Level.DEBUG, None, Some Level.DEBUG)
+        ConsoleAndOutputChannelLogger(Some "Debugger", Level.DEBUG, Some outputChannel, Some Level.DEBUG)
 
     let buildAndRun (project: Project) =
         promise {

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -250,7 +250,7 @@ module MSBuild =
 
             let t =
                 msbuildTasks
-                |> Seq.tryFind (fun t -> t.name = solutionFile && t.group = expectedGroup)
+                |> Seq.tryFind (fun t -> t.name = "solution" && t.group = expectedGroup)
 
             match t with
             | None -> logger.Debug("no task found for target %s for solution %s", target, solutionFile)
@@ -378,7 +378,7 @@ module MSBuild =
                                 vscode.Task.Create(
                                     msbuildTaskDef,
                                     U2.Case2 TaskScope.Workspace,
-                                    $"{solutionName}",
+                                    "solution",
                                     verb,
                                     U3.Case2 execution,
                                     U2.Case1 "$msCompile",

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -433,7 +433,7 @@ module VSCodeExtension =
 module Environment =
     /// expand any env variables in a string according to
     /// .NET's rules - that is any %-encoded name is an env var
-    [<Emit("$0.Replace(/%([^%]+)%/g, (_,n) => process.env[n])")>]
+    [<Emit("$0.replace(/%([^%]+)%/g, (_,n) => process.env[n])")>]
     let expand (s: string): string = jsNative
 
 [<AutoOpen>]


### PR DESCRIPTION
Fixes #1677 

- [x] task infrastructure
- [x] build tasks
- [x] clean tasks
- [x] rebuild tasks
- [ ] ~restore tasks? (maybe not necessary)~ not doing, restore is implicit/handled elsewhere in the extension
- [x] integration with the debug provider to set up the build task for each project as a `preLaunchTask` of that configuration
- [x] implement current MSBuild commands that currently exist
  - [x] current
  - [x] currentSolution
  - [x] selected
- [ ] ~ordering/grouping? task list can get large, so we likely need to group by project, then have the individual commands nested under them. is that possible?~ Cannot be done in current VSCode API

![image](https://user-images.githubusercontent.com/573979/160646276-3f83d483-1d9f-4b33-be51-b3b2f2c642f1.png)
![image](https://user-images.githubusercontent.com/573979/160646673-d09d315f-f0c2-420d-a6ec-c76fb5bf7c67.png)
![image](https://user-images.githubusercontent.com/573979/160647629-b1c76765-3d49-4bdf-82b6-7291d22ea179.png)
![tasklist](https://user-images.githubusercontent.com/573979/160647854-d6169cab-cb45-4e3a-8fd6-89b0b2bb73a2.gif)
