### PR TITLE
implement vscode side of fsautocomplete#817

### DIFF
--- a/src/Components/SignatureData.fs
+++ b/src/Components/SignatureData.fs
@@ -17,48 +17,8 @@ module SignatureData =
             let line = editor.selection.active.line
             let col = editor.selection.active.character
 
-            LanguageService.generateDocumentation document.fileName (int line) (int col)
-            |> Promise.bind (fun (p: SignatureDataResult) ->
-                promise {
-                    let pms =
-                        p.Data.Parameters
-                        |> Seq.concat
-                        |> Seq.where (fun prm -> String.IsNullOrWhiteSpace prm.Name |> not)
-                        |> Seq.map (fun prm -> sprintf """/// <param name="%s"></param>""" prm.Name)
-                        |> String.concat "\n"
-
-                    let generics =
-                        p.Data.Generics
-                        |> Seq.map (fun generic -> sprintf """/// <typeparam name="'%s"></typeparam>""" generic)
-                        |> String.concat "\n"
-
-                    let comment =
-                        [ yield "/// <summary>"
-                          yield "/// "
-                          yield "/// </summary>"
-                          if pms <> "" then yield pms
-                          if generics <> "" then yield generics
-                          yield "/// <returns></returns>" ]
-                        |> String.concat "\n"
-
-                    let x = editor.selection.active.line
-                    let t = document.getText (vscode.Range.Create(x, 0., x, 1000.))
-                    let t' = t.TrimStart(' ')
-                    let spsC = t.Length - t'.Length
-                    let sps = String.replicate spsC " "
-
-                    let cmnt =
-                        comment
-                        |> String.split [| '\n' |]
-                        |> Seq.map (fun n -> sprintf "%s%s" sps n)
-                        |> String.concat "\n"
-
-                    let edit = vscode.WorkspaceEdit.Create()
-                    edit.insert (document.uri, vscode.Position.Create(x, 0.), cmnt + "\n")
-                    return! workspace.applyEdit edit
-                })
-            |> ignore
-        | _ -> ()
+            LanguageService.generateDocumentation (document.fileName, document.version) (int line, int col)
+        | _ -> Promise.lift ()
 
 
     let activate (context: ExtensionContext) =

--- a/src/Components/SignatureData.fs
+++ b/src/Components/SignatureData.fs
@@ -17,7 +17,7 @@ module SignatureData =
             let line = editor.selection.active.line
             let col = editor.selection.active.character
 
-            LanguageService.generateDocumentation (document.fileName, document.version) (int line, int col)
+            LanguageService.generateDocumentation (document.uri, document.version) (int line, int col)
         | _ -> Promise.lift ()
 
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -189,12 +189,12 @@ module LanguageService =
             cl.sendRequest ("fsharp/signatureData", req)
             |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<SignatureDataResult>)
 
-    let generateDocumentation (fn, version) (line, col) =
+    let generateDocumentation (fileUri: Uri, version) (line, col) =
         match client with
         | None -> Promise.empty
         | Some cl ->
             let req: Types.VersionedTextDocumentPositionParams =
-                { TextDocument = { Uri = handleUntitled fn; Version = version }
+                { TextDocument = { Uri = fileUri.toString(); Version = version }
                   Position = { Line = line; Character = col } }
 
             cl.sendRequest ("fsharp/documentationGenerator", req)

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -52,9 +52,14 @@ module LanguageService =
         type DocumentUri = string
 
         type TextDocumentIdentifier = { Uri: DocumentUri }
+        type VersionedTextDocumentIdentifier = { Uri: DocumentUri; Version: float }
 
         type TextDocumentPositionParams =
             { TextDocument: TextDocumentIdentifier
+              Position: Position }
+
+        type VersionedTextDocumentPositionParams =
+            { TextDocument: VersionedTextDocumentIdentifier
               Position: Position }
 
         type FileParams = { Project: TextDocumentIdentifier }
@@ -184,16 +189,16 @@ module LanguageService =
             cl.sendRequest ("fsharp/signatureData", req)
             |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<SignatureDataResult>)
 
-    let generateDocumentation fn line col =
+    let generateDocumentation (fn, version) (line, col) =
         match client with
         | None -> Promise.empty
         | Some cl ->
-            let req: Types.TextDocumentPositionParams =
-                { TextDocument = { Uri = handleUntitled fn }
+            let req: Types.VersionedTextDocumentPositionParams =
+                { TextDocument = { Uri = handleUntitled fn; Version = version }
                   Position = { Line = line; Character = col } }
 
             cl.sendRequest ("fsharp/documentationGenerator", req)
-            |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<SignatureDataResult>)
+            |> Promise.map (fun _ -> ())
 
     let lineLenses fn =
         match client with


### PR DESCRIPTION
This is the pair to https://github.com/fsharp/FsAutoComplete/pull/817 that removes the custom edit generation in vscode in favor of the workspace/applyEdit call from FSAC directly.