### PR TITLE
Remove text insertion for type inlay hints

### DIFF
--- a/src/Components/InlayHints.fs
+++ b/src/Components/InlayHints.fs
@@ -57,7 +57,6 @@ let toInlayHint useLongTooltip isSetToToggle (fsacHint: LanguageService.Types.In
     let h = createEmpty<InlayHint>
     h.position <- vscode.Position.Create(fsacHint.pos.line, fsacHint.pos.character)
     h.label <- U2.Case1 fsacHint.text
-    h.textEdits <- fsacHint.insertText |> Option.map (fun text -> ResizeArray([createEdit (h.position, text)]))
 
     let tip kind =
         if useLongTooltip then


### PR DESCRIPTION
We'll remove this because it's not consistent enough to rely on. The full API in LSP 3.17 allows for multiple text edits, so FSAC can compute the correct thing. (In fact it should compute the textEdits lazily on resolve, since all we'd have to do at point of invocation is find the symbol, format the type, and add parens).