### PR TITLE
Fix: `Implement Interface` emits members without indentation when user hasn't specified `FSharp.indentationSize`

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -616,9 +616,10 @@
           "type": "boolean"
         },
         "FSharp.indentationSize": {
+          "default": 4,
+          "minimum": 0,
           "description": "The number of spaces used for indentation when generating code, e.g. for interface stubs",
-          "type": "number",
-          "minimum": 0
+          "type": "number"
         },
         "FSharp.infoPanelReplaceHover": {
           "default": false,

--- a/release/package.json
+++ b/release/package.json
@@ -617,7 +617,7 @@
         },
         "FSharp.indentationSize": {
           "default": 4,
-          "minimum": 0,
+          "minimum": 1,
           "description": "The number of spaces used for indentation when generating code, e.g. for interface stubs",
           "type": "number"
         },


### PR DESCRIPTION
FSAC gets indentation from setting `indentationSize` (`FSharp.indentationSize` in Ionide).  
But when that's not set, VSCode still sends `indentationSize` with it's default value. But no `default` specified in `package.json` -> uses default `number` which is `0`  
-> `indentationSize=0` -> members don't get indented

Default is now `4` (just like in FSAC)

