### PR TITLE
Improve error message if dotnet is not found

### DIFF
--- a/build/Program.fs
+++ b/build/Program.fs
@@ -386,10 +386,8 @@ let buildTargetTree () =
     "YarnInstall" ==>! "Build"
     "DotNetRestore" ==>! "Build"
 
-    // Disable Fantomas because it generates invalid code F# code
-    // "Format"
-    // ==> "Build"
-    "Build"
+    "Format"
+    ==> "Build"
     ==> "SetVersion"
     ==> "BuildPackage"
     ==> "ReleaseGitHub"

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -1,4 +1,4 @@
-﻿open System
+open System
 open System.IO
 open Fake.Core
 open Fake.JavaScript
@@ -386,8 +386,10 @@ let buildTargetTree () =
     "YarnInstall" ==>! "Build"
     "DotNetRestore" ==>! "Build"
 
-    "Format"
-    ==> "Build"
+    // Disable Fantomas because it generates invalid code F# code
+    // "Format"
+    // ==> "Build"
+    "Build"
     ==> "SetVersion"
     ==> "BuildPackage"
     ==> "ReleaseGitHub"

--- a/src/Components/Diagnostics.fs
+++ b/src/Components/Diagnostics.fs
@@ -95,13 +95,13 @@ Error: %A
     let getRuntimeInfos () =
         let netcoreInfos =
             promise {
-                let! dotnet = Environment.dotnet
+                let! dotnet = LanguageService.tryFindDotnet ()
 
                 match dotnet with
-                | Some dotnet ->
+                | Ok dotnet ->
                     let! version = execCommand dotnet [ "--version" ]
                     return Templates.netcoreRuntime version
-                | None -> return "No dotnet installation found"
+                | Error msg -> return msg
             }
 
 

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -304,14 +304,14 @@ module Fsi =
 
         promise {
             if isSdk () then
-                let! dotnet = LanguageService.dotnet ()
+                let! dotnet = LanguageService.tryFindDotnet ()
 
                 match dotnet with
-                | Some dotnet ->
+                | Ok dotnet ->
                     let! fsiSetting = LanguageService.fsiSdk ()
                     let fsiArg = defaultArg fsiSetting "fsi"
                     return dotnet, [| yield fsiArg; yield! parms |]
-                | None -> return failwith "dotnet fsi requested but no dotnet SDK was found."
+                | Error msg -> return failwith msg
             else
                 let! fsi = LanguageService.fsi ()
 

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -22,9 +22,7 @@ module MSBuild =
         LanguageService.tryFindDotnet ()
         |> Promise.bind (function
             | Ok msbuild -> Promise.lift msbuild
-            | Error msg ->
-                Promise.reject (exn msg)
-        )
+            | Error msg -> Promise.reject (exn msg))
 
     let invokeMSBuild project target =
         let autoshow =

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -19,14 +19,12 @@ module MSBuild =
         ConsoleAndOutputChannelLogger(Some "msbuild", Level.DEBUG, Some outputChannel, Some Level.DEBUG)
 
     let private dotnetBinary () =
-        LanguageService.dotnet ()
+        LanguageService.tryFindDotnet ()
         |> Promise.bind (function
-            | Some msbuild -> Promise.lift msbuild
-            | None ->
-                Promise.reject (
-                    exn
-                        "dotnet SDK not found. Please install it from the [Dotnet SDK Download Page](https://www.microsoft.com/net/download)"
-                ))
+            | Ok msbuild -> Promise.lift msbuild
+            | Error msg ->
+                Promise.reject (exn msg)
+        )
 
     let invokeMSBuild project target =
         let autoshow =

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -163,24 +163,6 @@ Consider:
                     return Core.Error msg
         }
 
-// Old implementation: How does compilerLocation work?
-// If dotnet is not found on the system, client cannot be run, no?
-//                let! dotnet = Environment.dotnet
-
-//                match dotnet with
-//                | None ->
-//                    let! location = compilerLocation ()
-//
-//                    match location.Data.SdkRoot with
-//                    | Some root ->
-//                        if Environment.isWin then
-//                            return Some(path.join (root, "dotnet.exe"))
-//                        else
-//                            return Some(path.join (root, "dotnet"))
-//                    | None -> return None
-//                | Some location -> return Some location
-
-
     /// runs `dotnet --version` in the current rootPath to determine the resolved sdk version from the global.json file.
     let runtimeVersion () =
         promise {

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -123,10 +123,10 @@ module LanguageService =
 
                 // Compute the full path
                 let dotnetFullPath =
-                    path.join(dotnetRoot, program)
+                    node.path.join(dotnetRoot, program)
 
                 // Check if the program exists at the computed location
-                if fs.existsSync (U2.Case1 dotnetFullPath) then
+                if node.fs.existsSync (U2.Case1 dotnetFullPath) then
                     return Ok dotnetFullPath
 
                 else

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -126,13 +126,10 @@ module LanguageService =
                     path.join(dotnetRoot, program)
 
                 // Check if the program exists at the computed location
-                match! Environment.tryGetTool dotnetFullPath with
-                // Everything is fine, return the path
-                | Some dotnet ->
-                    return Ok dotnet
+                if fs.existsSync (U2.Case1 dotnetFullPath) then
+                    return Ok dotnetFullPath
 
-                // The program does not exist, return the error
-                | None ->
+                else
                     let msg =
                         // The special syntax: %s{"\n" + dotnetFullPath}
                         // Force a new line to be added, if I put %s{dotnetFullPath}

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -475,11 +475,11 @@ module Project =
 
     let execWithDotnet outputChannel cmd =
         promise {
-            let! dotnet = LanguageService.dotnet ()
+            let! dotnet = LanguageService.tryFindDotnet ()
 
             match dotnet with
-            | Some dotnet -> return Process.spawnWithNotification dotnet cmd outputChannel
-            | None -> return! Promise.reject (exn "dotnet binary not found")
+            | Ok dotnet -> return Process.spawnWithNotification dotnet cmd outputChannel
+            | Error msg -> return! Promise.reject (exn msg)
         }
 
     let exec exe outputChannel cmd =
@@ -487,11 +487,11 @@ module Project =
 
     let private execWithDotnetWithShell cmd =
         promise {
-            let! dotnet = LanguageService.dotnet ()
+            let! dotnet = LanguageService.tryFindDotnet ()
 
             match dotnet with
-            | Some dotnet -> return Process.spawnWithShell dotnet cmd
-            | None -> return! Promise.reject (exn "dotnet binary not found")
+            | Ok dotnet -> return Process.spawnWithShell dotnet cmd
+            | Error msg -> return! Promise.reject (exn msg)
         }
 
     let private execWithShell exe cmd =


### PR DESCRIPTION
Hello,

this PR fix #1709.

~**:warning: Important:** I had to disable Fantomas formatting because it generates invalid F# code. I opened a bug about it https://github.com/fsprojects/fantomas/issues/2366~


## Changes:

- Rename `LanguageService.dotnet` to `LanguageService.tryFindDotnet`
- Improve `LanguageService.tryFindDotnet` to gives better errors message if dotnet is not found
- Remove `Environement.dotnet` and use `LanguageService.tryFindDotnet` instead
- Use a modal instead of the notification to display the error, this is because we cannot use multine in the notification making the error message not really readable
- New `dotnet` detection logic
- Return error message which differ depending on the context of the error. Did it occur because `Fsharp.dotnetRoot` is set or not.

**Important**

~Please test on Windows, if the detection works when `FSharp.dotnetRoot` is set to a valid location. In order, to detect if the file exist at that location I am calling `Environment.tryGetTool` with the full computed path. On Linux, it executes `which /home/mmangel/.dotnet/dotnet` which return OK if found, but I don't know if the Windows equivalent was with full path too.~

Test no needed anymore, I am now using the standard Note API to check if the file exist.

## Questions

### Generalise calling `windows.showErrorMessage` ?

Should we call `windows.showErrorMessage` everywhere where we handle an error result from calling `LanguageService.tryFindDotnet`? If yes, should we just call it directly from `LanguageService.tryFindDotnet` and make it return the dotnet path if found and `failwith ...` if not?

### What do to with `LanguageService.compilerLocation`?

What does `LanguageService.compilerLocation` do?

In the old code if `dotnet` is not found, then Ionide try to use the `compilerLocation` which comes from the (LSP?) client. But how can the LSP client be running if `dotnet` is not found ?

If my understanding is correct, shouldn't we just remove it? --> Need to remove the commented code

If not, we need to re-add that portion of the logic. Waiting for some explanation to understand how to wire it.

## Error preview

![image](https://user-images.githubusercontent.com/4760796/179313012-3616194b-71d0-473d-92da-244340ff4b80.png)
