### PR TITLE
Upgrade fantomas + apply it to all the files

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "fantomas": {
-      "version": "5.0.0-alpha-007",
+      "version": "5.0.0-beta-001",
       "commands": [
         "fantomas"
       ]

--- a/release/README.md
+++ b/release/README.md
@@ -97,7 +97,7 @@ The library is available under [MIT license](https://github.com/ionide/ionide-vs
 
 Ionide couldn't be created without the support of [Lambda Factory](https://lambdafactory.io). If your company would be interested in supporting development of Ionide, or acquiring commercial support send us an email - lambda_factory@outlook.com.
 
-You can also support Ionide development on [Open Collective](https://opencollective.com/ionide). [![Open Collective](https://opencollective.com/ionide/donate/button.png?color=blue)](https://opencollective.com/ionide)
+You can also support Ionide development on [Open Collective](https://opencollective.com/ionide). 
 
 ### Partners
 

--- a/src/Components/CodeLensHelpers.fs
+++ b/src/Components/CodeLensHelpers.fs
@@ -1,6 +1,5 @@
 namespace Ionide.VSCode.FSharp
 
-open System
 open Fable.Core.JsInterop
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
@@ -8,7 +7,8 @@ open Fable.Import.VSCode.Vscode
 module CodeLensHelpers =
 
     type CustomIExports =
-        abstract registerCommand: command: string * callback: (obj -> obj -> obj -> obj option) * ?thisArg: obj -> Disposable
+        abstract registerCommand:
+            command: string * callback: (obj -> obj -> obj -> obj option) * ?thisArg: obj -> Disposable
 
     let showReferences (args: obj) (args2: obj) (args3: obj) =
         let uri = vscode.Uri.parse !!args
@@ -33,5 +33,6 @@ module CodeLensHelpers =
         commands.executeCommand ("editor.action.showReferences", Some(box uri), Some(box pos), Some(box locs))
 
     let activate (context: ExtensionContext) =
-        (unbox<CustomIExports>commands).registerCommand ("fsharp.showReferences",  unbox<(obj -> obj -> obj -> obj option)>(showReferences))
+        (unbox<CustomIExports> commands)
+            .registerCommand ("fsharp.showReferences", unbox<(obj -> obj -> obj -> obj option)> (showReferences))
         |> context.Subscribe

--- a/src/Components/Diagnostics.fs
+++ b/src/Components/Diagnostics.fs
@@ -5,7 +5,6 @@ open Fable.Core
 open Fable.Import
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
 open JsInterop
 
 open Ionide.VSCode.Helpers
@@ -107,8 +106,7 @@ Error: %A
 
 
 
-        Promise.all [ netcoreInfos ]
-        |> Promise.map (String.concat "\n")
+        Promise.all [ netcoreInfos ] |> Promise.map (String.concat "\n")
 
     let writeToFile (text: string) =
         promise {
@@ -121,11 +119,9 @@ Error: %A
             let! success = workspace.applyEdit (edit)
 
             if success then
-                window.showTextDocument (document, ?options = None)
-                |> ignore
+                window.showTextDocument (document, ?options = None) |> ignore
             else
-                window.showErrorMessage ("Error when printing diagnostic report.")
-                |> ignore
+                window.showErrorMessage ("Error when printing diagnostic report.") |> ignore
         }
 
     let getDiagnosticsInfos () =

--- a/src/Components/FSharpLiterate.fs
+++ b/src/Components/FSharpLiterate.fs
@@ -1,11 +1,7 @@
 namespace Ionide.VSCode.FSharp
 
-open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
 open Fable.Core.JsInterop
-
-module node = Node.Api
 
 module FSharpLiterate =
     module private Panel =
@@ -210,8 +206,7 @@ module FSharpLiterate =
                 p.webview.html <- str)
 
         let clear () =
-            panel
-            |> Option.iter (fun p -> p.webview.html <- "")
+            panel |> Option.iter (fun p -> p.webview.html <- "")
 
         let update (textEditor: TextEditor) =
             promise {
@@ -233,10 +228,7 @@ module FSharpLiterate =
                               "enableFindWidget" ==> true
                               "retainContextWhenHidden" ==> true ]
 
-                    let viewOpts =
-                        createObj
-                            [ "preserveFocus" ==> true
-                              "viewColumn" ==> -2 ]
+                    let viewOpts = createObj [ "preserveFocus" ==> true; "viewColumn" ==> -2 ]
 
                     let p =
                         window.createWebviewPanel ("fsharpLiterate", "F# Literate", !!viewOpts, opts)
@@ -271,8 +263,7 @@ module FSharpLiterate =
 
 
     let activate (context: ExtensionContext) =
-        workspace.onDidSaveTextDocument.Invoke(unbox fileSaved)
-        |> context.Subscribe
+        workspace.onDidSaveTextDocument.Invoke(unbox fileSaved) |> context.Subscribe
 
         window.onDidChangeActiveTextEditor.Invoke(unbox updatePanel)
         |> context.Subscribe

--- a/src/Components/FakeTargetsOutline.fs
+++ b/src/Components/FakeTargetsOutline.fs
@@ -6,7 +6,6 @@ open Fable.Core.JsInterop
 open Fable.Import
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
 open Ionide.VSCode.Helpers
 open System.Collections.Generic
 
@@ -20,8 +19,7 @@ module FakeTargetsOutline =
     let private configurationKey = "FAKE.targetsOutline"
 
     let private isEnabledFor (uri: Uri) =
-        configurationKey
-        |> Configuration.getInContext uri true
+        configurationKey |> Configuration.getInContext uri true
 
     type NodeEntry =
         { Key: string
@@ -31,6 +29,7 @@ module FakeTargetsOutline =
     type DependencyType =
         | SoftDependency
         | HardDependency
+
         member x.Arrow =
             match x with
             | SoftDependency -> "<=?"
@@ -48,6 +47,7 @@ module FakeTargetsOutline =
           Declaration: Declaration option
           Type: ModelType
           getChildren: unit -> ResizeArray<Model> }
+
         member x.IsTarget =
             match x.Type with
             | TargetModel -> true
@@ -60,13 +60,9 @@ module FakeTargetsOutline =
     let private getIconPath light dark =
         let plugPath = VSCodeExtension.ionidePluginPath ()
 
-        {| light =
-            node.path.join (plugPath, "images", light)
-            |> U2.Case1
+        {| light = node.path.join (plugPath, "images", light) |> U2.Case1
 
-           dark =
-            node.path.join (plugPath, "images", dark)
-            |> U2.Case1 |}
+           dark = node.path.join (plugPath, "images", dark) |> U2.Case1 |}
 
     let rec add' (state: NodeEntry) (symbol: Symbol) index =
         let sep = "."
@@ -78,11 +74,7 @@ module FakeTargetsOutline =
         else
             let endIndex = entry.IndexOf(sep, index)
 
-            let endIndex =
-                if endIndex = -1 then
-                    entry.Length
-                else
-                    endIndex
+            let endIndex = if endIndex = -1 then entry.Length else endIndex
 
             let key = entry.Substring(index, endIndex - index)
 
@@ -105,17 +97,11 @@ module FakeTargetsOutline =
         match node.Type with
         | ModelType.ErrorOrWarning ->
             if node.AllTargets.Length = 0 then // error
-                Some
-                <| getIconPath "error-inverse.svg" "error.svg"
+                Some <| getIconPath "error-inverse.svg" "error.svg"
             else
-                Some
-                <| getIconPath "warning-inverse.svg" "warning.svg"
-        | ModelType.TargetModel ->
-            Some
-            <| getIconPath "icon-function-light.svg" "icon-function-dark.svg"
-        | ModelType.DependencyModel _ ->
-            Some
-            <| getIconPath "auto-reveal-light.svg" "auto-reveal-dark.svg"
+                Some <| getIconPath "warning-inverse.svg" "warning.svg"
+        | ModelType.TargetModel -> Some <| getIconPath "icon-function-light.svg" "icon-function-dark.svg"
+        | ModelType.DependencyModel _ -> Some <| getIconPath "auto-reveal-light.svg" "auto-reveal-dark.svg"
 
     let tryFindTarget (allTargets: Target[]) (name: string) =
         allTargets
@@ -240,14 +226,8 @@ module FakeTargetsOutline =
                                     return generateErrorRoot "null response from fsac"
                             }
                             |> unbox
-                        | _ ->
-                            generateErrorRoot "No active F# document"
-                            |> U2.Case1
-                            |> Some
-                    | None ->
-                        generateErrorRoot "No active document"
-                        |> U2.Case1
-                        |> Some
+                        | _ -> generateErrorRoot "No active F# document" |> U2.Case1 |> Some
+                    | None -> generateErrorRoot "No active document" |> U2.Case1 |> Some
 
             override this.getParent(element: Model) : ProviderResult<Model> = None
 
@@ -303,9 +283,7 @@ module FakeTargetsOutline =
             Context.cachedSetter<bool> "fake.targetsOutline.showInExplorerActivity"
 
         let showInFsharpActivity () =
-            let showIn =
-                "FAKE.showTargetsOutlineIn"
-                |> Configuration.get "explorer"
+            let showIn = "FAKE.showTargetsOutlineIn" |> Configuration.get "explorer"
 
             showIn = "fsharp"
 
@@ -330,8 +308,7 @@ module FakeTargetsOutline =
         let newValue =
             match textEditor with
             | Some textEditor ->
-                if isFsharpFile textEditor.document
-                   || ShowInActivity.showInFsharpActivity () then
+                if isFsharpFile textEditor.document || ShowInActivity.showInFsharpActivity () then
                     isEnabledFor textEditor.document.uri
                 else
                     false
@@ -399,13 +376,9 @@ module FakeTargetsOutline =
                 | Some decl ->
                     let line = decl.Line
 
-                    let args =
-                        createObj
-                            [ "lineNumber" ==> line
-                              "at" ==> "center" ]
+                    let args = createObj [ "lineNumber" ==> line; "at" ==> "center" ]
 
-                    commands.executeCommand ("revealLine", Some(box args))
-                    |> unbox
+                    commands.executeCommand ("revealLine", Some(box args)) |> unbox
                 | None -> JS.undefined)
         )
         |> context.Subscribe
@@ -429,10 +402,7 @@ module FakeTargetsOutline =
                                preArg
                                targetName |]
                         else
-                            [| "run"
-                               scriptName
-                               preArg
-                               targetName |]
+                            [| "run"; scriptName; preArg; targetName |]
 
                     let cfg: RequestLaunch =
                         { name = "Fake Script Debugging"
@@ -469,6 +439,25 @@ module FakeTargetsOutline =
                                 { new TaskDefinition with
                                     member this.Item
                                         with get (name: string): obj option = data.TryGet name
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
                                         and set (name: string) (v: obj option): unit =
                                             match v with

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -5,10 +5,8 @@ open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
 
 open DTO
-open Ionide.VSCode.Helpers
 
 module node = Node.Api
 
@@ -91,8 +89,7 @@ module Fsi =
                     let! res =
                         window.showInformationMessage (
                             "FSI Watcher is an experimental feature, and it needs to be enabled with `FSharp.addFsiWatcher` setting",
-                            [| Message.choice "Enable"
-                               Message.choice "Ignore" |]
+                            [| Message.choice "Enable"; Message.choice "Ignore" |]
                         )
 
                     match res with
@@ -102,10 +99,7 @@ module Fsi =
                     match panel with
                     | Some p -> p.reveal (!! -2, true)
                     | None ->
-                        let viewOpts =
-                            createObj
-                                [ "preserveFocus" ==> true
-                                  "viewColumn" ==> -2 ]
+                        let viewOpts = createObj [ "preserveFocus" ==> true; "viewColumn" ==> -2 ]
 
                         let p =
                             FsWebview.create (
@@ -124,13 +118,14 @@ module Fsi =
                         panel <- Some p
             }
 
-        let varsUri = path.join (VSCodeExtension.ionidePluginPath (), "watcher", "vars.txt")
+        let varsUri =
+            node.path.join (VSCodeExtension.ionidePluginPath (), "watcher", "vars.txt")
 
         let typesUri =
-            path.join (VSCodeExtension.ionidePluginPath (), "watcher", "types.txt")
+            node.path.join (VSCodeExtension.ionidePluginPath (), "watcher", "types.txt")
 
         let funcUri =
-            path.join (VSCodeExtension.ionidePluginPath (), "watcher", "funcs.txt")
+            node.path.join (VSCodeExtension.ionidePluginPath (), "watcher", "funcs.txt")
 
 
         let handler (context: ExtensionContext) =
@@ -160,11 +155,7 @@ module Fsi =
                                            Type = x[2]
                                            step = x[3] |})
                             // ensure column order
-                            let headers =
-                                [| "Name", "name"
-                                   "Value", "value"
-                                   "Type", "Type"
-                                   "Step", "step" |]
+                            let headers = [| "Name", "name"; "Value", "value"; "Type", "Type"; "Step", "step" |]
 
                             let grid, script = VsHtml.datagrid ("vars-content", datagridContent, headers)
 
@@ -198,9 +189,7 @@ module Fsi =
                                 VsHtml.datagrid (
                                     "funcs-content",
                                     datagridContent,
-                                    [| "Name", "name"
-                                       "Parameters", "parameters"
-                                       "Return Type", "returnType" |]
+                                    [| "Name", "name"; "Parameters", "parameters"; "Return Type", "returnType" |]
                                 )
 
                             funcsContent <- Some(html $"<h3>Declared functions</h3>{grid}", script)
@@ -244,9 +233,9 @@ module Fsi =
             )
 
         let activate context dispsables =
-            fs.watchFile (varsUri, (fun st st2 -> handler context))
-            fs.watchFile (typesUri, (fun st st2 -> handler context))
-            fs.watchFile (funcUri, (fun st st2 -> handler context))
+            node.fs.watchFile (varsUri, (fun st st2 -> handler context))
+            node.fs.watchFile (typesUri, (fun st st2 -> handler context))
+            node.fs.watchFile (funcUri, (fun st st2 -> handler context))
 
     let mutable fsiOutput: Terminal option = None
     let mutable fsiOutputPID: int option = None
@@ -274,8 +263,7 @@ module Fsi =
         | _ ->
             let msg = sprintf "# silentCd @\"%s\";;\n" dir
 
-            fsiOutput
-            |> Option.iter (fun n -> n.sendText (msg, false))
+            fsiOutput |> Option.iter (fun n -> n.sendText (msg, false))
 
             lastCd <- Some dir
 
@@ -284,8 +272,7 @@ module Fsi =
         | _ ->
             let msg = sprintf "# %d @\"%s\"\n;;\n" 1 file
 
-            fsiOutput
-            |> Option.iter (fun n -> n.sendText (msg, false))
+            fsiOutput |> Option.iter (fun n -> n.sendText (msg, false))
 
             lastCurrentFile <- Some file
 
@@ -298,7 +285,8 @@ module Fsi =
                 |> Configuration.get Array.empty<string>
                 |> List.ofArray
 
-            let p = path.join (VSCodeExtension.ionidePluginPath (), "watcher", "watcher.fsx")
+            let p =
+                node.path.join (VSCodeExtension.ionidePluginPath (), "watcher", "watcher.fsx")
 
             let fsiParams =
                 if addWatcher then
@@ -308,8 +296,7 @@ module Fsi =
 
             if Environment.isWin then
                 // these flags are added to work around issues with the vscode terminal shell on windows
-                [ "--fsi-server-input-codepage:28591"
-                  "--fsi-server-output-codepage:65001" ]
+                [ "--fsi-server-input-codepage:28591"; "--fsi-server-output-codepage:65001" ]
                 @ fsiParams
             else
                 fsiParams
@@ -344,11 +331,7 @@ module Fsi =
                         let! (fsiBinary, fsiArguments) = fsiBinaryAndParameters ()
                         let fsiArguments = U2.Case1(ResizeArray fsiArguments)
 
-                        let name =
-                            if isSdk () then
-                                fsiNetCoreName
-                            else
-                                fsiNetFrameworkName
+                        let name = if isSdk () then fsiNetCoreName else fsiNetFrameworkName
 
                         let options: TerminalOptions = createEmpty<_>
                         options.name <- Some name
@@ -374,9 +357,7 @@ module Fsi =
 
     let tryFindExistingTerminal () =
         window.terminals
-        |> Seq.tryFind (fun t ->
-            t.name = fsiNetFrameworkName
-            || t.name = fsiNetCoreName)
+        |> Seq.tryFind (fun t -> t.name = fsiNetFrameworkName || t.name = fsiNetCoreName)
 
     let private start () =
         promise {
@@ -392,8 +373,7 @@ module Fsi =
                 match profile with
                 | Some opts -> opts
                 | None ->
-                    window.showErrorMessage ("Unable to spawn FSI")
-                    |> ignore
+                    window.showErrorMessage ("Unable to spawn FSI") |> ignore
 
                     failwith "unable to spawn FSI"
 
@@ -418,10 +398,7 @@ module Fsi =
               i1 <- i2 ]
 
     let private send (msg: string) =
-        let msgWithNewline =
-            msg
-            + (if msg.Contains "//" then "\n" else "")
-            + ";;\n"
+        let msgWithNewline = msg + (if msg.Contains "//" then "\n" else "") + ";;\n"
 
         match fsiOutput with
         | None -> start ()
@@ -430,19 +407,12 @@ module Fsi =
             fp.show true
             fp.sendText (msgWithNewline, false)
             lastSelectionSent <- Some msg)
-        |> Promise.onFail (fun _ ->
-            window.showErrorMessage ("Failed to send text to FSI")
-            |> ignore)
+        |> Promise.onFail (fun _ -> window.showErrorMessage ("Failed to send text to FSI") |> ignore)
 
     let private moveCursorDownOneLine () =
-        let args =
-            createObj
-                [ "to" ==> "down"
-                  "by" ==> "line"
-                  "value" ==> 1 ]
+        let args = createObj [ "to" ==> "down"; "by" ==> "line"; "value" ==> 1 ]
 
-        commands.executeCommand ("cursorMove", Some(box args))
-        |> ignore
+        commands.executeCommand ("cursorMove", Some(box args)) |> ignore
 
     let private sendLine () =
         let editor = window.activeTextEditor.Value
@@ -482,10 +452,8 @@ module Fsi =
     let private sendLastSelection () =
         match lastSelectionSent with
         | Some x ->
-            if "FSharp.saveOnSendLastSelection"
-               |> Configuration.get false then
-                window.activeTextEditor.Value.document.save ()
-                |> Promise.ofThenable
+            if "FSharp.saveOnSendLastSelection" |> Configuration.get false then
+                window.activeTextEditor.Value.document.save () |> Promise.ofThenable
             else
                 Promise.lift true
             |> Promise.bind (fun _ -> send x)
@@ -517,9 +485,7 @@ module Fsi =
             sendCd window.activeTextEditor
 
             p.References
-            |> Seq.filter (fun n ->
-                n.EndsWith "FSharp.Core.dll" |> not
-                && n.EndsWith "mscorlib.dll" |> not)
+            |> Seq.filter (fun n -> n.EndsWith "FSharp.Core.dll" |> not && n.EndsWith "mscorlib.dll" |> not)
             |> Seq.toList
             |> referenceAssemblies
             |> Promise.suppress
@@ -548,8 +514,7 @@ module Fsi =
 
     // when a new terminal is created, if it's FSI and if we don't already have a terminal then setup the state for tracking FSI
     let private handleOpenTerminal (terminal: Terminal) =
-        if terminal.name = fsiNetCoreName
-           || terminal.name = fsiNetFrameworkName then
+        if terminal.name = fsiNetCoreName || terminal.name = fsiNetFrameworkName then
             clearOldTerminalState ()
             setupTerminalState terminal
             // initially have to set up the terminal to be in the correct start directory
@@ -565,9 +530,7 @@ module Fsi =
             |> Option.map (fun p ->
                 [| yield!
                        p.References
-                       |> Seq.filter (fun n ->
-                           n.EndsWith "FSharp.Core.dll" |> not
-                           && n.EndsWith "mscorlib.dll" |> not)
+                       |> Seq.filter (fun n -> n.EndsWith "FSharp.Core.dll" |> not && n.EndsWith "mscorlib.dll" |> not)
                        |> Seq.map (sprintf "#r @\"%s\"")
                    yield! p.Files |> Seq.map (sprintf "#load @\"%s\"") |])
 
@@ -576,9 +539,7 @@ module Fsi =
             | Some c ->
                 let path = node.path.join (workspace.rootPath.Value, "references.fsx")
 
-                let! td =
-                    vscode.Uri.parse ("untitled:" + path)
-                    |> workspace.openTextDocument
+                let! td = vscode.Uri.parse ("untitled:" + path) |> workspace.openTextDocument
 
                 let! te = window.showTextDocument (td, ViewColumn.Three)
 
@@ -595,9 +556,7 @@ module Fsi =
 
     let sendReferencesForProject project =
         project.References
-        |> Seq.filter (fun n ->
-            n.EndsWith "FSharp.Core.dll" |> not
-            && n.EndsWith "mscorlib.dll" |> not)
+        |> Seq.filter (fun n -> n.EndsWith "FSharp.Core.dll" |> not && n.EndsWith "mscorlib.dll" |> not)
         |> Seq.toList
         |> referenceAssemblies
         |> Promise.suppress
@@ -607,18 +566,14 @@ module Fsi =
         let ctn =
             [| yield!
                    project.References
-                   |> Seq.filter (fun n ->
-                       n.EndsWith "FSharp.Core.dll" |> not
-                       && n.EndsWith "mscorlib.dll" |> not)
+                   |> Seq.filter (fun n -> n.EndsWith "FSharp.Core.dll" |> not && n.EndsWith "mscorlib.dll" |> not)
                    |> Seq.map (sprintf "#r @\"%s\"")
                yield! project.Files |> Seq.map (sprintf "#load @\"%s\"") |]
 
         promise {
             let path = node.path.join (workspace.rootPath.Value, "references.fsx")
 
-            let! td =
-                vscode.Uri.parse ("untitled:" + path)
-                |> workspace.openTextDocument
+            let! td = vscode.Uri.parse ("untitled:" + path) |> workspace.openTextDocument
 
             let! te = window.showTextDocument (td, ViewColumn.Three)
 
@@ -638,14 +593,11 @@ module Fsi =
         window.registerTerminalProfileProvider ("ionide-fsharp.fsi", provider)
         |> context.Subscribe
 
-        window.onDidCloseTerminal.Invoke(handleCloseTerminal)
-        |> context.Subscribe
+        window.onDidCloseTerminal.Invoke(handleCloseTerminal) |> context.Subscribe
 
-        window.onDidOpenTerminal.Invoke(handleOpenTerminal)
-        |> context.Subscribe
+        window.onDidOpenTerminal.Invoke(handleOpenTerminal) |> context.Subscribe
 
-        commands.registerCommand ("fsi.Start", start |> objfy2)
-        |> context.Subscribe
+        commands.registerCommand ("fsi.Start", start |> objfy2) |> context.Subscribe
 
         commands.registerCommand ("fsi.SendLine", sendLine |> objfy2)
         |> context.Subscribe

--- a/src/Components/Help.fs
+++ b/src/Components/Help.fs
@@ -1,6 +1,5 @@
 namespace Ionide.VSCode.FSharp
 
-open Fable.Import
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 
@@ -27,7 +26,6 @@ module Help =
 
     let activate (context: ExtensionContext) =
         let registerCommand com (f: unit -> _) =
-            commands.registerCommand (com, f |> objfy2)
-            |> context.Subscribe
+            commands.registerCommand (com, f |> objfy2) |> context.Subscribe
 
         registerCommand "fsharp.getHelp" getHelp

--- a/src/Components/HtmlConverter.fs
+++ b/src/Components/HtmlConverter.fs
@@ -1,8 +1,6 @@
 namespace Ionide.VSCode.FSharp
 
 open Fable.Core.JsInterop
-open Fable.Import
-open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 open HtmlConverter.Converter
 

--- a/src/Components/InlayHints.fs
+++ b/src/Components/InlayHints.fs
@@ -3,7 +3,6 @@ module Ionide.VSCode.FSharp.InlayHints
 open Fable.Core
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
 open Fable.Core.JsInterop
 
 let private logger =
@@ -29,8 +28,7 @@ let allowParameterNames () : bool =
     Configuration.getUnsafe Config.parameterNamesEnabled
 
 let actuallyEnabled () =
-    enabled ()
-    && (allowTypeAnnotations () || allowParameterNames ())
+    enabled () && (allowTypeAnnotations () || allowParameterNames ())
 
 let isSetToToggle () =
     Configuration.tryGet Config.editorInlayHintsEnabled
@@ -175,15 +173,15 @@ let activate (context: ExtensionContext) =
     toggleSupported <- supportsToggle vscode.version
 
     let selector: DocumentSelector =
-        let filter: DocumentFilter = jsOptions<TextDocumentFilter> (fun f -> f.language <- Some "fsharp") |> DocumentFilter.Case1
+        let filter: DocumentFilter =
+            jsOptions<TextDocumentFilter> (fun f -> f.language <- Some "fsharp")
+            |> DocumentFilter.Case1
+
         [| U2.Case2 filter |]
 
     commands.registerCommand (
         Commands.disableLongTooltip,
-        (fun _ ->
-            Configuration.set Config.disableLongTooltip (Some true)
-            |> box
-            |> Some)
+        (fun _ -> Configuration.set Config.disableLongTooltip (Some true) |> box |> Some)
     )
     |> context.Subscribe
 
@@ -197,35 +195,22 @@ let activate (context: ExtensionContext) =
         )
         |> context.Subscribe
 
-    commands.registerCommand (
-        Commands.hideAll,
-        (fun _ ->
-            Configuration.set Config.enabled (Some false)
-            |> box
-            |> Some)
-    )
+    commands.registerCommand (Commands.hideAll, (fun _ -> Configuration.set Config.enabled (Some false) |> box |> Some))
     |> context.Subscribe
 
     commands.registerCommand (
         Commands.hideParameterNames,
-        (fun _ ->
-            Configuration.set Config.parameterNamesEnabled (Some false)
-            |> box
-            |> Some)
+        (fun _ -> Configuration.set Config.parameterNamesEnabled (Some false) |> box |> Some)
     )
     |> context.Subscribe
 
     commands.registerCommand (
         Commands.hideTypeAnnotations,
-        (fun _ ->
-            Configuration.set Config.typeAnnotationsEnabled (Some false)
-            |> box
-            |> Some)
+        (fun _ -> Configuration.set Config.typeAnnotationsEnabled (Some false) |> box |> Some)
     )
     |> context.Subscribe
 
-    languages.registerInlayHintsProvider (selector, provider)
-    |> context.Subscribe
+    languages.registerInlayHintsProvider (selector, provider) |> context.Subscribe
 
     disposables |> Seq.iter context.Subscribe
 

--- a/src/Components/LanguageConfiguration.fs
+++ b/src/Components/LanguageConfiguration.fs
@@ -1,8 +1,6 @@
 namespace Ionide.VSCode.FSharp
 
 open Fable.Core.JsInterop
-open Fable.Import
-open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 open System.Text.RegularExpressions
 

--- a/src/Components/QuickInfo.fs
+++ b/src/Components/QuickInfo.fs
@@ -1,6 +1,5 @@
 namespace Ionide.VSCode.FSharp
 
-open Fable.Import
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 open Ionide.VSCode.Helpers
@@ -8,7 +7,6 @@ open Fable.Core
 
 module Fsdn =
 
-    open Fable.Core
     open Fable.Core.JsInterop
 
     let pickSignature (functions: string list) =
@@ -31,9 +29,7 @@ module Fsdn =
                 match chosen with
                 | Some chosen ->
                     let selected =
-                        projects
-                        |> List.tryFind (fun (qp, _) -> qp = chosen)
-                        |> Option.map snd
+                        projects |> List.tryFind (fun (qp, _) -> qp = chosen) |> Option.map snd
 
                     match selected with
                     | Some selected -> return Some selected
@@ -101,8 +97,7 @@ module QuickInfo =
             context.subscriptions.Add(unbox (box newItem))
 
         let private isFsharpTextEditor (textEditor: TextEditor) =
-            if JS.isDefined textEditor
-               && JS.isDefined textEditor.document then
+            if JS.isDefined textEditor && JS.isDefined textEditor.document then
                 let doc = textEditor.document
 
                 match doc with
@@ -114,16 +109,12 @@ module QuickInfo =
 
         let private getOverloadSignature (textEditor: TextEditor) (selections: ResizeArray<Selection>) =
             promise {
-                if isFsharpTextEditor textEditor
-                   && selections.Count > 0 then
+                if isFsharpTextEditor textEditor && selections.Count > 0 then
                     let doc = textEditor.document
                     let pos = selections.[0].active
                     let! o = LanguageService.signature (doc.uri) (int pos.line) (int pos.character)
 
-                    if isNotNull o then
-                        return Some o.Data
-                    else
-                        return None
+                    if isNotNull o then return Some o.Data else return None
                 else
                     return None
             }

--- a/src/Components/QuickInfoProject.fs
+++ b/src/Components/QuickInfoProject.fs
@@ -3,7 +3,6 @@ namespace Ionide.VSCode.FSharp
 open Fable.Core
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
 
 module node = Node.Api
 
@@ -27,10 +26,7 @@ module QuickInfoProject =
             match proj with
             | None ->
                 match te.document with
-                | Document.FSharp when
-                    path.extname te.document.fileName <> ".fsx"
-                    && not (te.document.isUntitled)
-                    ->
+                | Document.FSharp when node.path.extname te.document.fileName <> ".fsx" && not (te.document.isUntitled) ->
                     let loadingInfo =
                         if Project.isLoadingWorkspaceComplete () then
                             ""
@@ -39,17 +35,12 @@ module QuickInfoProject =
 
                     let fileNameOnly = node.path.basename fileName
 
-                    item.Value.text <-
-                        "$(circuit-board) Not in a F# project"
-                        + loadingInfo
+                    item.Value.text <- "$(circuit-board) Not in a F# project" + loadingInfo
 
                     item.Value.tooltip <- Some(U2.Case1 $"%s{fileNameOnly} is not in any project known to Ionide")
                     item.Value.command <- Some(U2.Case1 "fsharp.AddFileToProject")
 
-                    item.Value.color <-
-                        vscode.ThemeColor.Create "fsharp.statusBarWarnings"
-                        |> U2.Case2
-                        |> Some
+                    item.Value.color <- vscode.ThemeColor.Create "fsharp.statusBarWarnings" |> U2.Case2 |> Some
 
                     item.Value.show ()
                 | _ -> ()
@@ -76,8 +67,7 @@ module QuickInfoProject =
         item <- Some statusBarItem
         context.subscriptions.Add(unbox (box statusBarItem))
 
-        window.onDidChangeActiveTextEditor.Invoke(unbox handler)
-        |> context.Subscribe
+        window.onDidChangeActiveTextEditor.Invoke(unbox handler) |> context.Subscribe
 
         if window.visibleTextEditors.Count > 0 then
             handler window.activeTextEditor

--- a/src/Components/ScriptRunner.fs
+++ b/src/Components/ScriptRunner.fs
@@ -1,11 +1,9 @@
 namespace Ionide.VSCode.FSharp
 
-open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
+open Fable.Core
 
 module node = Node.Api
-open Fable.Core
 
 module ScriptRunner =
 
@@ -16,10 +14,7 @@ module ScriptRunner =
         promise {
             let! (fsiBinary, fsiParameters) = Fsi.fsiBinaryAndParameters ()
 
-            let flatArgs =
-                fsiParameters
-                |> Array.map (sprintf "\"%s\"")
-                |> String.concat " "
+            let flatArgs = fsiParameters |> Array.map (sprintf "\"%s\"") |> String.concat " "
 
             let (shellCmd, shellArgs, textToSend) =
                 match node.os.``type`` () with

--- a/src/Components/SignatureData.fs
+++ b/src/Components/SignatureData.fs
@@ -1,9 +1,6 @@
 namespace Ionide.VSCode.FSharp
 
-open System
-open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open DTO
 
 module SignatureData =
 

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -3,12 +3,9 @@ namespace Ionide.VSCode.FSharp
 open System
 open Fable.Core
 open Fable.Core.JsInterop
-open Fable.Import
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
 open Ionide.VSCode.Helpers
-open System.Collections.Generic
 open System.Text.RegularExpressions
 
 open DTO
@@ -82,10 +79,7 @@ module SolutionExplorer =
                 state.Children <- x :: state.Children
                 addhelper x xs
 
-        virtualPath.Split('/')
-        |> List.ofArray
-        |> addhelper root
-        |> ignore
+        virtualPath.Split('/') |> List.ofArray |> addhelper root |> ignore
 
 
     let getParentRef (model: Model) =
@@ -130,10 +124,7 @@ module SolutionExplorer =
 
     let rec toModel (projPath: string) (entry: NodeEntry) =
         if entry.Children.Length > 0 then
-            let childs =
-                entry.Children
-                |> Seq.map (toModel projPath)
-                |> Seq.toList
+            let childs = entry.Children |> Seq.map (toModel projPath) |> Seq.toList
 
             let result = Folder(ref None, entry.Key, entry.FilePath, childs, projPath)
             setParentRefs childs result
@@ -150,13 +141,9 @@ module SolutionExplorer =
               VirtualPath = ""
               Children = [] }
 
-        files
-        |> List.iter (fun (virtualPath, path) -> add' entry virtualPath path)
+        files |> List.iter (fun (virtualPath, path) -> add' entry virtualPath path)
 
-        entry.Children
-        |> Seq.rev
-        |> Seq.map (toModel projPath)
-        |> Seq.toList
+        entry.Children |> Seq.rev |> Seq.map (toModel projPath) |> Seq.toList
 
     let private getProjectModel (proj: Project) =
         let projects = Project.getLoaded () |> Seq.toArray
@@ -269,18 +256,14 @@ module SolutionExplorer =
             setParentRef s result
             result
         | WorkspacePeekFound.Directory dir ->
-            let items =
-                dir.Fsprojs
-                |> Array.map getProjItem
-                |> List.ofArray
+            let items = dir.Fsprojs |> Array.map getProjItem |> List.ofArray
 
             let result = Workspace items
             setParentRefs items result
             result
 
     let private getSolution () =
-        Project.getLoadedSolution ()
-        |> Option.map getSolutionModel
+        Project.getLoadedSolution () |> Option.map getSolutionModel
 
     let private getSubmodel node =
         match node with
@@ -399,12 +382,7 @@ module SolutionExplorer =
                         let options = createEmpty<obj>
                         options?preserveFocus <- true
 
-                        c.arguments <-
-                            Some(
-                                ResizeArray
-                                    [| Some(box (vscode.Uri.file p))
-                                       Some options |]
-                            )
+                        c.arguments <- Some(ResizeArray [| Some(box (vscode.Uri.file p)); Some options |])
 
                         Some c
                     | _ -> None
@@ -450,13 +428,9 @@ module SolutionExplorer =
                     | WorkspaceFolder _ -> vscode.ThemeIcon.Folder |> U4.Case4 |> Some, None
                     | PackageReference (_, path, _, _)
                     | ProjectReference (_, path, _, _) ->
-                        let light =
-                            (plugPath + "/images/circuit-board-light.svg")
-                            |> U2.Case1
+                        let light = (plugPath + "/images/circuit-board-light.svg") |> U2.Case1
 
-                        let dark =
-                            (plugPath + "/images/circuit-board-dark.svg")
-                            |> U2.Case1
+                        let dark = (plugPath + "/images/circuit-board-dark.svg") |> U2.Case1
 
                         let p = {| light = light; dark = dark |} |> U4.Case3
                         p |> Some, vscode.Uri.file path |> Some
@@ -481,9 +455,7 @@ module SolutionExplorer =
                     | File (_, _, _, _, pp) ->
                         (resourceUri
                          |> Option.map (fun u -> (label ti + "||" + u.toString () + "||" + pp)))
-                    | _ ->
-                        (resourceUri
-                         |> Option.map (fun u -> (label ti + "||" + u.toString ())))
+                    | _ -> (resourceUri |> Option.map (fun u -> (label ti + "||" + u.toString ())))
 
                 U2.Case1 ti
 
@@ -509,9 +481,7 @@ module SolutionExplorer =
             Context.cachedSetter<bool> "fsharp.showProjectExplorerInExplorerActivity"
 
         let initializeAndGetId () : string =
-            let showIn =
-                "FSharp.showProjectExplorerIn"
-                |> Configuration.get "fsharp"
+            let showIn = "FSharp.showProjectExplorerIn" |> Configuration.get "fsharp"
 
             let inFsharpActivity = (showIn = "fsharp")
             setInFsharpActivity inFsharpActivity
@@ -542,8 +512,7 @@ module SolutionExplorer =
 
         let private findModelFromUri (state: State option ref) (uri: Uri) =
             if uri.scheme = "file" && JS.isDefined uri.fsPath then
-                state.Value
-                |> Option.bind (fun s -> s.ModelPerFile |> Map.tryFind uri.fsPath)
+                state.Value |> Option.bind (fun s -> s.ModelPerFile |> Map.tryFind uri.fsPath)
             else
                 None
 
@@ -618,8 +587,7 @@ module SolutionExplorer =
             (state: State option ref)
             (change: TreeViewVisibilityChangeEvent)
             =
-            if change.visible
-               && RevealConfiguration.getAutoReveal () then
+            if change.visible && RevealConfiguration.getAutoReveal () then
                 // Done out of the event call to avoid VSCode double-selecting due to a race-condition
                 JS.setTimeout (fun () -> revealTextEditor tree state window.activeTextEditor true) 0
                 |> ignore
@@ -634,8 +602,7 @@ module SolutionExplorer =
 
             let onModelChanged' = onModelChanged treeView state
 
-            rootChanged.Invoke(unbox onModelChanged')
-            |> context.Subscribe
+            rootChanged.Invoke(unbox onModelChanged') |> context.Subscribe
 
             let onDidChangeTreeVisibility' = onDidChangeTreeVisibility treeView state
 
@@ -651,9 +618,7 @@ module SolutionExplorer =
 
 
     let private handleUntitled (fn: string) =
-        if fn.EndsWith ".fs"
-           || fn.EndsWith ".fsi"
-           || fn.EndsWith ".fsx" then
+        if fn.EndsWith ".fs" || fn.EndsWith ".fsi" || fn.EndsWith ".fsx" then
             fn
         else
             (fn + ".fs")
@@ -689,17 +654,9 @@ module SolutionExplorer =
 
                     match dir, name with
                     | Some dir, Some name ->
-                        let output =
-                            if String.IsNullOrWhiteSpace dir then
-                                None
-                            else
-                                Some dir
+                        let output = if String.IsNullOrWhiteSpace dir then None else Some dir
 
-                        let projName =
-                            if String.IsNullOrWhiteSpace name then
-                                None
-                            else
-                                Some name
+                        let projName = if String.IsNullOrWhiteSpace name then None else Some name
 
                         match template.description with
                         | None -> return ()
@@ -715,14 +672,12 @@ module SolutionExplorer =
                                     else if output.IsSome then
                                         output.Value + ".fsproj"
                                     else
-                                        (path.dirname workspace.rootPath.Value)
-                                        + ".fsproj"
+                                        (node.path.dirname workspace.rootPath.Value) + ".fsproj"
 
-                                let proj = path.join (workspace.rootPath.Value, dir, name, pname)
+                                let proj = node.path.join (workspace.rootPath.Value, dir, name, pname)
                                 let args = [ "sln"; slnName; "add"; proj ]
 
-                                Project.execWithDotnet MSBuild.outputChannel (ResizeArray args)
-                                |> ignore
+                                Project.execWithDotnet MSBuild.outputChannel (ResizeArray args) |> ignore
                             | _ ->
                                 //If it's the first project in the workspace we need to init the workspace
                                 if Project.getInWorkspace().IsEmpty then
@@ -731,9 +686,7 @@ module SolutionExplorer =
                         ()
                     | _ -> ()
                 | None -> ()
-            | None ->
-                window.showErrorMessage ("No open folder.")
-                |> ignore
+            | None -> window.showErrorMessage ("No open folder.") |> ignore
         }
 
     let activate (context: ExtensionContext) =
@@ -917,13 +870,10 @@ module SolutionExplorer =
                             project)) ->
                     let files = project.Files
 
-                    let projRefs =
-                        project.ProjectReferences
-                        |> Array.map (fun n -> n.ProjectFileName)
+                    let projRefs = project.ProjectReferences |> Array.map (fun n -> n.ProjectFileName)
 
                     let packageRefs =
-                        project.PackageReferences
-                        |> Array.map (fun n -> n.Name + " " + n.Version)
+                        project.PackageReferences |> Array.map (fun n -> n.Name + " " + n.Version)
 
                     let refs =
                         refs
@@ -1012,10 +962,7 @@ module SolutionExplorer =
                           error ]
                     | _ -> [ error ]
 
-                [ "<b>Status:</b> failed to load"
-                  ""
-                  "<b>Error:</b>" ]
-                @ errorMsg
+                [ "<b>Status:</b> failed to load"; ""; "<b>Error:</b>" ] @ errorMsg
                 |> String.concat "<br />"
 
             let mutable e = None
@@ -1090,10 +1037,7 @@ module SolutionExplorer =
                     let launchRequestCfg =
                         let debuggerRuntime = Debugger.debuggerRuntime proj
                         // create or update right launch setting
-                        match
-                            configurations :> seq<_>
-                            |> Seq.tryPick (findCoreclrLaunch debuggerRuntime)
-                            with
+                        match configurations :> seq<_> |> Seq.tryPick (findCoreclrLaunch debuggerRuntime) with
                         | Some cfg -> cfg
                         | None ->
                             //TODO is possibile to programmatically run the "Add Configuration" for .net console?
@@ -1239,9 +1183,7 @@ module SolutionExplorer =
             "fsharp.explorer.project.generateFSI",
             objfy2 (fun m ->
                 match unbox m with
-                | Project (_, _, _, _, _, _, _, pr) ->
-                    Fsi.generateProjectReferencesForProject pr
-                    |> unbox
+                | Project (_, _, _, _, _, _, _, pr) -> Fsi.generateProjectReferencesForProject pr |> unbox
                 | _ -> undefined)
         )
         |> context.Subscribe
@@ -1277,8 +1219,7 @@ module SolutionExplorer =
                             | Some proj ->
                                 let args = [ "sln"; name; "add"; proj ]
 
-                                Project.execWithDotnet MSBuild.outputChannel (ResizeArray args)
-                                |> ignore
+                                Project.execWithDotnet MSBuild.outputChannel (ResizeArray args) |> ignore
                             | None -> ()
                     }
                     |> unbox

--- a/src/Components/Webview.fs
+++ b/src/Components/Webview.fs
@@ -1,7 +1,6 @@
 namespace Ionide.VSCode.FSharp
 
 open Fable.Core
-open Fable.Core.JsInterop
 
 module Webviews =
     open Fable.Import.VSCode.Vscode

--- a/src/Core/FsProjEdit.fs
+++ b/src/Core/FsProjEdit.fs
@@ -1,15 +1,8 @@
 namespace Ionide.VSCode.FSharp
 
-open System
 open Fable.Core
 open Fable.Core.JsInterop
-open Fable.Import
-open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
-
-open DTO
-open Ionide.VSCode.Helpers
 
 module node = Node.Api
 
@@ -53,8 +46,8 @@ module FsProjEdit =
                         | Some editor ->
 
                             let relativePathToFile =
-                                let dir = path.dirname projectPath
-                                path.relative (dir, editor.document.fileName)
+                                let dir = node.path.dirname projectPath
+                                node.path.relative (dir, editor.document.fileName)
 
                             addFile projectPath relativePathToFile
                         | None -> Promise.empty

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -3,8 +3,6 @@ namespace Ionide.VSCode.FSharp
 [<AutoOpen>]
 module Logging =
     open Fable.Core
-    open global.Node
-    open Fable.Import.VSCode
     open Fable.Import.VSCode.Vscode
     open Ionide.VSCode.FSharp.Node.Util
     open System
@@ -14,6 +12,7 @@ module Logging =
         | INFO
         | WARN
         | ERROR
+
         static member GetLevelNum =
             function
             | DEBUG -> 10
@@ -29,12 +28,10 @@ module Logging =
             | DEBUG -> "DEBUG"
 
         member this.isGreaterOrEqualTo level =
-            Level.GetLevelNum(this)
-            >= Level.GetLevelNum(level)
+            Level.GetLevelNum(this) >= Level.GetLevelNum(level)
 
         member this.isLessOrEqualTo level =
-            Level.GetLevelNum(this)
-            <= Level.GetLevelNum(level)
+            Level.GetLevelNum(this) <= Level.GetLevelNum(level)
 
     let mutable private ionideLogsMemory = []
 
@@ -90,10 +87,7 @@ module Logging =
         (template: string)
         (args: obj[])
         =
-        if
-            out.IsSome
-            && level.isGreaterOrEqualTo (chanMinLevel)
-        then
+        if out.IsSome && level.isGreaterOrEqualTo (chanMinLevel) then
             writeOutputChannel out.Value level source template args
 
         // Only write FSAC logs into the file
@@ -101,8 +95,8 @@ module Logging =
             try
                 if string args.[0] <> "parse" then
                     writeToFile level template args
-            with
-            | _ -> () // Do nothing
+            with _ ->
+                () // Do nothing
 
     let inline private writeBothIfConfigured
         (out: OutputChannel option)
@@ -113,10 +107,7 @@ module Logging =
         (template: string)
         (args: obj[])
         =
-        if
-            consoleMinLevel.IsSome
-            && level.isGreaterOrEqualTo (consoleMinLevel.Value)
-        then
+        if consoleMinLevel.IsSome && level.isGreaterOrEqualTo (consoleMinLevel.Value) then
             writeDevToolsConsole level source template args
 
         writeOutputChannelIfConfigured out chanMinLevel level source template args
@@ -178,5 +169,4 @@ module Logging =
         /// The templates may use node util.format placeholders: %s, %d, %j, %%
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.ErrorOnFailed text (p: JS.Promise<_>) =
-            p
-            |> Promise.catchEnd (fun err -> this.Error(text + ": %O", err))
+            p |> Promise.catchEnd (fun err -> this.Error(text + ": %O", err))

--- a/src/Core/Project.fs
+++ b/src/Core/Project.fs
@@ -3,10 +3,8 @@ namespace Ionide.VSCode.FSharp
 open System
 open Fable.Core
 open Fable.Core.JsInterop
-open Fable.Import
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
-open global.Node
 open Ionide.VSCode.Helpers
 
 open DTO
@@ -56,21 +54,12 @@ module Project =
 
     let excluded =
         "FSharp.excludeProjectDirectories"
-        |> Configuration.get
-            [| ".git"
-               "paket-files"
-               ".fable"
-               "packages"
-               "node_modules" |]
+        |> Configuration.get [| ".git"; "paket-files"; ".fable"; "packages"; "node_modules" |]
 
-    let deepLevel =
-        "FSharp.workspaceModePeekDeepLevel"
-        |> Configuration.get 2
-        |> max 0
+    let deepLevel = "FSharp.workspaceModePeekDeepLevel" |> Configuration.get 2 |> max 0
 
     let isNetCoreApp (project: Project) =
-        project.Info.TargetFramework
-        :: project.Info.TargetFrameworks
+        project.Info.TargetFramework :: project.Info.TargetFrameworks
         |> Seq.exists (fun tfm -> tfm = "net5.0" || tfm.StartsWith "netcoreapp")
 
     let isSDKProjectPath (project: string) =
@@ -85,9 +74,7 @@ module Project =
         | _ -> false
 
     let getInWorkspace () =
-        loadedProjects
-        |> Seq.toList
-        |> List.map (fun n -> n.Value)
+        loadedProjects |> Seq.toList |> List.map (fun n -> n.Value)
 
     let tryFindInWorkspace (path: string) =
         loadedProjects
@@ -118,9 +105,7 @@ module Project =
                 | MsbuildFormat _proj -> [| item.Name |]
                 | Folder folder -> folder.Items |> Array.collect getProjs
 
-            sln.Items
-            |> Array.collect getProjs
-            |> Array.toList
+            sln.Items |> Array.collect getProjs |> Array.toList
         | Some (WorkspacePeekFound.Directory dir) -> dir.Fsprojs |> Array.toList
 
 
@@ -162,8 +147,8 @@ module Project =
                         [ s ]
                     else
                         []
-                with
-                | _ -> [])
+                with _ ->
+                    [])
 
         match workspace.rootPath with
         | None -> []
@@ -183,14 +168,12 @@ module Project =
                         []
                     elif node.fs.statSync(U2.Case1 s).isDirectory () then
                         findProjs (s)
-                    elif s.EndsWith ".fsproj"
-                         || s.EndsWith ".csproj"
-                         || s.EndsWith ".vbproj" then
+                    elif s.EndsWith ".fsproj" || s.EndsWith ".csproj" || s.EndsWith ".vbproj" then
                         [ s ]
                     else
                         []
-                with
-                | _ -> [])
+                with _ ->
+                    [])
 
         match workspace.rootPath with
         | None -> []
@@ -231,8 +214,7 @@ module Project =
                 | Some (path, state) ->
                     updateInWorkspace path state
 
-                    loadedWorkspace
-                    |> Option.iter (workspaceChangedEmitter.fire)
+                    loadedWorkspace |> Option.iter (workspaceChangedEmitter.fire)
 
                     setAnyProjectContext true
                 | None -> ())
@@ -269,10 +251,7 @@ module Project =
             match loadedWorkspace with
             | None -> Array.empty
             | Some (WorkspacePeekFound.Directory dir) -> dir.Fsprojs
-            | Some (WorkspacePeekFound.Solution sln) ->
-                sln.Items
-                |> Array.collect foldFsproj
-                |> Array.map fst
+            | Some (WorkspacePeekFound.Solution sln) -> sln.Items |> Array.collect foldFsproj |> Array.map fst
 
         let loadingInProgress p =
             match tryFindInWorkspace p with
@@ -308,8 +287,8 @@ module Project =
                             [ s ]
                         else
                             []
-                    with
-                    | _ -> [])
+                    with _ ->
+                        [])
 
         match workspace.rootPath with
         | None -> []
@@ -318,16 +297,12 @@ module Project =
     let clearCache () =
         let cached = getCaches ()
 
-        cached
-        |> Seq.iter (U2.Case1 >> node.fs.unlinkSync)
+        cached |> Seq.iter (U2.Case1 >> node.fs.unlinkSync)
 
-        window.showInformationMessage ("Project Cache cleared")
-        |> ignore
+        window.showInformationMessage ("Project Cache cleared") |> ignore
 
     let countProjectsInSln (sln: WorkspacePeekFoundSolution) =
-        sln.Items
-        |> Array.map foldFsproj
-        |> Array.sumBy Array.length
+        sln.Items |> Array.map foldFsproj |> Array.sumBy Array.length
 
     [<RequireQualifiedAccess>]
     type ConfiguredWorkspace =
@@ -356,14 +331,14 @@ module Project =
                 try
                     let stats = fs.statSync (U2.Case1 dir)
                     not (isNull stats) && (stats.isDirectory ())
-                with
-                | _ -> false
+                with _ ->
+                    false
             | ConfiguredWorkspace.Solution sln ->
                 try
                     let stats = fs.statSync (U2.Case1 sln)
                     not (isNull stats) && (stats.isFile ())
-                with
-                | _ -> false
+                with _ ->
+                    false
 
         let private parseAndValidate (config: string option) =
             match config with
@@ -412,10 +387,7 @@ module Project =
                 let relativePath =
                     let raw = path.relative (workspace.rootPath.Value, configuredPath)
 
-                    if
-                        not (path.isAbsolute raw)
-                        && not (raw.StartsWith "..")
-                    then
+                    if not (path.isAbsolute raw) && not (raw.StartsWith "..") then
                         "./" + raw
                     else
                         raw
@@ -491,9 +463,7 @@ module Project =
                 match chosen with
                 | Some chosen ->
                     let selected =
-                        projects
-                        |> List.tryFind (fun (qp, _) -> qp = chosen)
-                        |> Option.map snd
+                        projects |> List.tryFind (fun (qp, _) -> qp = chosen) |> Option.map snd
 
                     match selected with
                     | Some selected ->
@@ -535,7 +505,8 @@ module Project =
                         [ "run"
                           "--project"
                           project.Project
-                          if not (List.isEmpty args) then " -- " ]
+                          if not (List.isEmpty args) then
+                              " -- " ]
                         @ args
                     )
 
@@ -555,7 +526,8 @@ module Project =
                         [ "run"
                           "--project"
                           project.Project
-                          if not (List.isEmpty args) then " -- " ]
+                          if not (List.isEmpty args) then
+                              " -- " ]
                         @ args
                     )
 
@@ -631,8 +603,7 @@ module Project =
 
     let handleProjectParsedNotification res =
         let disableShowNotification =
-            "FSharp.disableFailedProjectNotifications"
-            |> Configuration.get false
+            "FSharp.disableFailedProjectNotifications" |> Configuration.get false
 
         let projStatus =
             match res with
@@ -651,8 +622,7 @@ module Project =
                     Some(true, d.Project, ProjectLoadingState.LanguageNotSupported(d.Project))
                 | _ ->
                     if not disableShowNotification then
-                        window.showErrorMessage ("Project loading failed")
-                        |> ignore
+                        window.showErrorMessage ("Project loading failed") |> ignore
 
                     None
             | Choice4Of4 msg ->
@@ -666,10 +636,10 @@ module Project =
         | Some (isDone, path, state) ->
             updateInWorkspace path state
 
-            loadedWorkspace
-            |> Option.iter (workspaceChangedEmitter.fire)
+            loadedWorkspace |> Option.iter (workspaceChangedEmitter.fire)
 
-            if isDone then setAnyProjectContext true
+            if isDone then
+                setAnyProjectContext true
         | None -> ()
 
     let private initWorkspaceHelper x =
@@ -680,20 +650,14 @@ module Project =
         let projs =
             match x with
             | WorkspacePeekFound.Directory dir -> dir.Fsprojs
-            | WorkspacePeekFound.Solution sln ->
-                sln.Items
-                |> Array.collect foldFsproj
-                |> Array.map fst
+            | WorkspacePeekFound.Solution sln -> sln.Items |> Array.collect foldFsproj |> Array.map fst
 
         match x with
         | WorkspacePeekFound.Solution _ -> setAnyProjectContext true
         | WorkspacePeekFound.Directory _ when not (projs |> Array.isEmpty) -> setAnyProjectContext true
         | _ -> ()
 
-        projs
-        |> List.ofArray
-        |> LanguageService.workspaceLoad
-        |> Promise.map ignore
+        projs |> List.ofArray |> LanguageService.workspaceLoad |> Promise.map ignore
 
 
     let initWorkspace () =
@@ -725,10 +689,7 @@ module Project =
             item.Value.tooltip <- Some(U2.Case1 tooltip)
             item.Value.command <- Some(U2.Case1 "showProjStatusFromIndicator")
 
-            item.Value.color <-
-                vscode.ThemeColor.Create "fsharp.statusBarWarnings"
-                |> U2.Case2
-                |> Some
+            item.Value.color <- vscode.ThemeColor.Create "fsharp.statusBarWarnings" |> U2.Case2 |> Some
 
             item.Value.show ()
 
@@ -736,25 +697,28 @@ module Project =
         let update () =
             let projs = getInWorkspace ()
 
-            match projs
-                  |> List.tryPick (function
-                      | ProjectLoadingState.Failed (p, er) -> Some p
-                      | _ -> None)
-                with
+            match
+                projs
+                |> List.tryPick (function
+                    | ProjectLoadingState.Failed (p, er) -> Some p
+                    | _ -> None)
+            with
             | Some p -> showItem "Project loading failed" p
             | None ->
-                match projs
-                      |> List.tryPick (function
-                          | ProjectLoadingState.Loading (p) -> Some p
-                          | _ -> None)
-                    with
+                match
+                    projs
+                    |> List.tryPick (function
+                        | ProjectLoadingState.Loading (p) -> Some p
+                        | _ -> None)
+                with
                 | Some p -> showItem "Project loading" p
                 | None ->
-                    match projs
-                          |> List.tryPick (function
-                              | ProjectLoadingState.NotRestored (p, _) -> Some p
-                              | _ -> None)
-                        with
+                    match
+                        projs
+                        |> List.tryPick (function
+                            | ProjectLoadingState.NotRestored (p, _) -> Some p
+                            | _ -> None)
+                    with
                     | Some p -> showItem "Project not restored" p
                     | None -> hideItem ()
 
@@ -772,8 +736,7 @@ module Project =
         workspaceNotificationAvaiable <- true
         ProjectStatus.item <- Some(window.createStatusBarItem (StatusBarAlignment.Right, 9000.))
 
-        statusUpdated.Invoke(!!ProjectStatus.statusUpdateHandler)
-        |> context.Subscribe
+        statusUpdated.Invoke(!!ProjectStatus.statusUpdateHandler) |> context.Subscribe
 
         commands.registerCommand (
             "fsharp.changeWorkspace",
@@ -793,9 +756,7 @@ module Project =
             (fun _ ->
                 let name = path.basename (ProjectStatus.path)
 
-                ShowStatus.CreateOrShow(ProjectStatus.path, name)
-                |> box
-                |> Some)
+                ShowStatus.CreateOrShow(ProjectStatus.path, name) |> box |> Some)
         )
         |> context.Subscribe
 

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -8,6 +8,7 @@ open Fable.Core
 [<AutoOpen>]
 module ContextExtensions =
     type ExtensionContext with
+
         member inline x.Subscribe< ^t when ^t: (member dispose: unit -> obj option)>(item: ^t) =
             x.subscriptions.Add(unbox (box item))
 
@@ -16,6 +17,7 @@ module PromiseBuilder =
     type Foo = JS.PromiseConstructor
 
     type Promise.PromiseBuilder with
+
         member x.Source(p: Thenable<'t>) : JS.Promise<'t> = box p |> unbox
         member x.Source(p: JS.Promise<'t>) : JS.Promise<'t> = p
 
@@ -118,8 +120,7 @@ module Option =
 [<RequireQualifiedAccess>]
 module Document =
     let (|FSharp|CSharp|VB|FSharpScript|Markdown|Other|) (document: TextDocument) =
-        if document.languageId = "fsharp"
-           && document.fileName.EndsWith "fsx" then
+        if document.languageId = "fsharp" && document.fileName.EndsWith "fsx" then
             FSharpScript
         else if document.languageId = "fsharp" then
             FSharp
@@ -138,24 +139,17 @@ module Configuration =
     let tryGet key =
         let configuredValue = workspace.getConfiguration().get (key)
 
-        if configuredValue = Some "" then
-            None
-        else
-            configuredValue
+        if configuredValue = Some "" then None else configuredValue
 
     /// get a key of a given value, asusming that a default has been set by extension configuration settings
     let getUnsafe key =
         workspace.getConfiguration().get(key).Value
 
     let get defaultValue key =
-        workspace
-            .getConfiguration()
-            .get (key, defaultValue)
+        workspace.getConfiguration().get (key, defaultValue)
 
     let getInContext context defaultValue key =
-        workspace
-            .getConfiguration(scope = U4.Case1 context)
-            .get (key, defaultValue)
+        workspace.getConfiguration(scope = U4.Case1 context).get (key, defaultValue)
 
     /// write the value to the given key in the workspace configuration
     let set key value =
@@ -179,6 +173,7 @@ module Utils =
     let isUndefined (x: 'a) : bool = jsNative
 
     type System.Collections.Generic.Dictionary<'key, 'value> with
+
         [<Emit("$0.has($1) ? $0.get($1) : null")>]
         member this.TryGet(key: 'key) : 'value option = jsNative
 
@@ -190,17 +185,15 @@ module Message =
 
 [<AutoOpen>]
 module JS =
-    open Fable.Core
-    open global.Node
 
     /// Schedules execution of a one-time callback after delay milliseconds.
     /// Returns a Timeout for use with `clearTimeout`.
     [<Emit("setTimeout($0, $1)")>]
-    let setTimeout (callback: unit -> unit) (delay: float) : Base.Timer = jsNative
+    let setTimeout (callback: unit -> unit) (delay: float) : Node.Base.Timer = jsNative
 
     /// Cancels a Timeout object created by `setTimeout`.
     [<Emit("clearTimeout($0)")>]
-    let clearTimeout (timeout: Base.Timer) : unit = jsNative
+    let clearTimeout (timeout: Node.Base.Timer) : unit = jsNative
 
     [<Emit("debugger")>]
     let debugger () : unit = failwith "JS Only"
@@ -270,10 +263,7 @@ module Patterns =
         (^t: (member get_title: unit -> string) (item))
 
     let inline (|HasTitle|_|) expected t =
-        if title t = expected then
-            Some()
-        else
-            None
+        if title t = expected then Some() else None
 
 [<RequireQualifiedAccess>]
 module Array =
@@ -304,16 +294,13 @@ module Promise =
             Promise.reject reason)
 
     let suppress (pr: JS.Promise<'T>) =
-        pr
-        |> Promise.either (fun _ -> U2.Case1()) (fun _ -> U2.Case1())
+        pr |> Promise.either (fun _ -> U2.Case1()) (fun _ -> U2.Case1())
 
     let executeForAll f items =
         match items with
         | [] -> empty
         | [ x ] -> f x
-        | x :: tail ->
-            tail
-            |> List.fold (fun acc next -> acc |> Promise.bind (fun _ -> f next)) (f x)
+        | x :: tail -> tail |> List.fold (fun acc next -> acc |> Promise.bind (fun _ -> f next)) (f x)
 
 module Event =
 
@@ -369,7 +356,9 @@ type ShowStatus private (panel: WebviewPanel, body: string) as this =
 
         panel.onDidChangeViewState.Invoke(
             (fun _ev ->
-                if panel.visible then this.Update()
+                if panel.visible then
+                    this.Update()
+
                 None),
             this,
             _disposables
@@ -437,8 +426,8 @@ module VSCodeExtension =
         let path =
             try
                 (VSCode.getPluginPath (sprintf "Ionide.%s" extensionName))
-            with
-            | _ -> (VSCode.getPluginPath (sprintf "Ionide.%s" oldExtensionName))
+            with _ ->
+                (VSCode.getPluginPath (sprintf "Ionide.%s" oldExtensionName))
 
         match path with
         | Some p -> p

--- a/src/Imports/Semver.fs
+++ b/src/Imports/Semver.fs
@@ -3,9 +3,7 @@ module rec Semver
 
 #nowarn "3390" // disable warnings for invalid XML comments
 
-open System
 open Fable.Core
-open Fable.Core.JS
 
 type ReadonlyArray<'T> = System.Collections.Generic.IReadOnlyList<'T>
 

--- a/src/Imports/XPath.fs
+++ b/src/Imports/XPath.fs
@@ -39,7 +39,4 @@ module XPath =
         member this.TrySelectString(xpath: string) : string option =
             let s = this.SelectString(xpath)
 
-            if System.String.IsNullOrWhiteSpace(s) then
-                None
-            else
-                Some s
+            if System.String.IsNullOrWhiteSpace(s) then None else Some s

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -20,16 +20,13 @@ type Api =
 let activate (context: ExtensionContext) : JS.Promise<Api> =
     let solutionExplorer = "FSharp.enableTreeView" |> Configuration.get true
 
-    let showExplorer =
-        "FSharp.showExplorerOnStartup"
-        |> Configuration.get true
+    let showExplorer = "FSharp.showExplorerOnStartup" |> Configuration.get true
 
     let tryActivate label activationFn =
         fun ctx ->
             try
                 activationFn ctx
-            with
-            | ex ->
+            with ex ->
                 printfn $"Error while activating feature '{label}': {ex}"
                 Unchecked.defaultof<_>
 


### PR DESCRIPTION
Fix #1736 

Changes:

* Upgrade Fantomas to the latest beta version
* Apply Fantomas to all the F# files in `src` and `build` folders.
* Remove unused `open` statements
* Rewrite access to Node API because of a bug in Fantomas (see below)

When executing Fantomas, I had a bunch of error due to `open global.Node` being rewritten to ``open `global`.Node``.

I made the decision to fix this error by changing:

```fs
open global.Node

let myFunc = path.join(..., ...)
```

to 

```fs
module node = Node.Api

let myFunc = node.path.join(..., ...)
```

The `module node = Node.Api` is something that is already used in different places of the code. And so like that all the nodes are now consistent.

The other solutions would be to disable Fantomas for 8-10 files in the project because that bug.