### PR TITLE
Add .gitattributes file to avoid generating a diff if the eol char changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Without this configuration when formatting or saving a file on my computer I get this diff result:

![image](https://user-images.githubusercontent.com/4760796/180639944-fb8b8f5d-46b0-41a4-81c7-c62434c1818d.png)

There is no real modification of the lines except the EOL characters.

[Documentation](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#example)

> text=auto Git will handle the files in whatever way it thinks is best. This is a good default option.