### PR TITLE
Fix #1562 and some improvements to Fsi.fs

### DIFF
--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -586,6 +586,19 @@ module Fsi =
             return ()
         }
 
+    let private generateProjectReferences () =
+        let projectOpt =
+            window.activeTextEditor.Value.document.fileName
+            |> Project.tryFindLoadedProjectByFile
+
+        promise {
+            match projectOpt with
+            | Some project ->
+                return! generateProjectReferencesForProject project
+
+            | None -> return ()
+        }
+
     let activate (context: ExtensionContext) =
         Watcher.activate context (!!context.subscriptions)
         SdkScriptsNotify.activate context


### PR DESCRIPTION
Originally, I just wanted to fix #1562. However, with the old code I had some error with the terminal being dispose incorrectly.

So in the end, I ended up re-structuring the code. The diff isn't really readable but if you compare the functions from the old file to the new ones, you will see that not that much is happening in the end.

I hope that the changes proposed are ok for you. 

List of changes:

- Fix #1562: Invalid __SOURCE_DIRECTORY__ on first "FSI: Send Selection"
- Show an error notification if file is not inside a project when executing
    - FSI: Send references from project
    - FSI: Generate script file with references from project
- Mutualise code logic where possible
- Remove dead code from Fsi.fs
- Rename `fsiOutput` to `fsiTerminal`
- Rename `fsiOutputPID` to `fsiTerminalPID`
- Remove registration of `fsi.SendText` command (it doesn't exist)