### PR TITLE
Fix CONTRIBUTING links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,10 +143,10 @@ Remove the settings from steps 3 and 4 to go back to FSAC bundled in Ionide exte
 
 ### FSAC Dependencies
 
-- [dotnet](https://www.microsoft.com/net/download/core)
-- [nodejs](https://nodejs.org/en/download/)
-- [yarn](https://yarnpkg.com/en/docs/install)
-- [vscode](https://code.visualstudio.com/Download)
+- [.NET 6][dotnet]
+- [Node.js][nodejs]
+- [Yarn][yarn]
+- [Visual Studio Code][vscode]
 
 ## Pull requests
 
@@ -215,3 +215,9 @@ Feature requests are welcome and should be discussed on issue tracker. But take 
 out whether your idea fits with the scope and aims of the project. It's up to *you*
 to make a strong case to convince the community of the merits of this feature.
 Please provide as much detail and context as possible.
+
+
+[dotnet]: https://www.microsoft.com/net/download/core
+[nodejs]: https://nodejs.org/en/download/
+[yarn]: https://yarnpkg.com/en/docs/install
+[vscode]: https://code.visualstudio.com/Download


### PR DESCRIPTION
Currently some of them are not pointing to the correct place.

Notice that in the beginning of the file there is the following, which looks like links that were not applied because of missing md related parts:

![image](https://user-images.githubusercontent.com/2532492/189469153-d1872467-b7e0-4f13-9a97-9b6d876d27f0.png)


