### PR TITLE
Get changes in place to use multitargeted FSAC and pivot accordingly.

### DIFF
--- a/build/Program.fs
+++ b/build/Program.fs
@@ -311,13 +311,17 @@ let initTargets () =
 
 
     Target.create "CopyFSACNetcore" (fun _ ->
-        let tfms = ["net6.0"; "net7.0"]
+        let tfms = [ "net6.0"; "net7.0" ]
+
         for tfm in tfms do
             let fsacBinNetcore = $"packages/fsac/fsautocomplete/tools/{tfm}/any"
-            let releaseBinNetcore = "release/bin/{tfm}"
 
-            copyFSACNetcore releaseBinNetcore fsacBinNetcore
-    )
+            if Directory.Exists fsacBinNetcore then
+                let releaseBinNetcore = "release/bin/{tfm}"
+                Trace.tracefn $"Copying FSAC binaries from {fsacBinNetcore} to {releaseBinNetcore}"
+                copyFSACNetcore releaseBinNetcore fsacBinNetcore
+            else
+                Trace.tracefn $"No FSAC binaries found for {tfm}")
 
     Target.create "CopyGrammar" (fun _ ->
         let fsgrammarDir = "paket-files/github.com/ionide/ionide-fsgrammar/grammars"

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -311,10 +311,13 @@ let initTargets () =
 
 
     Target.create "CopyFSACNetcore" (fun _ ->
-        let fsacBinNetcore = "packages/fsac/fsautocomplete/tools/net6.0/any"
-        let releaseBinNetcore = "release/bin"
+        let tfms = ["net6.0"; "net7.0"]
+        for tfm in tfms do
+            let fsacBinNetcore = $"packages/fsac/fsautocomplete/tools/{tfm}/any"
+            let releaseBinNetcore = "release/bin/{tfm}"
 
-        copyFSACNetcore releaseBinNetcore fsacBinNetcore)
+            copyFSACNetcore releaseBinNetcore fsacBinNetcore
+    )
 
     Target.create "CopyGrammar" (fun _ ->
         let fsgrammarDir = "paket-files/github.com/ionide/ionide-fsgrammar/grammars"

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -317,7 +317,7 @@ let initTargets () =
             let fsacBinNetcore = $"packages/fsac/fsautocomplete/tools/{tfm}/any"
 
             if Directory.Exists fsacBinNetcore then
-                let releaseBinNetcore = "release/bin/{tfm}"
+                let releaseBinNetcore = $"release/bin/{tfm}"
                 Trace.tracefn $"Copying FSAC binaries from {fsacBinNetcore} to {releaseBinNetcore}"
                 copyFSACNetcore releaseBinNetcore fsacBinNetcore
             else

--- a/paket.lock
+++ b/paket.lock
@@ -285,4 +285,4 @@ STORAGE: PACKAGES
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    fsautocomplete (0.57)
+    fsautocomplete (0.57.1)

--- a/paket.lock
+++ b/paket.lock
@@ -285,4 +285,4 @@ STORAGE: PACKAGES
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    fsautocomplete (0.56.2)
+    fsautocomplete (0.57)

--- a/release/README.md
+++ b/release/README.md
@@ -7,6 +7,7 @@ _Part of the [Ionide](https://ionide.io) plugin suite._ Read detailed documentat
 [![Rating](https://vsmarketplacebadge.apphb.com/rating-star/Ionide.Ionide-fsharp.svg)](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp)
 [![open collective backers](https://img.shields.io/opencollective/backers/ionide.svg?color=blue)](https://opencollective.com/ionide)
 [![open collective sponsors](https://img.shields.io/opencollective/sponsors/ionide.svg?color=blue)](https://opencollective.com/ionide)
+[![Open in Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/ionide/ionide-vscode-fsharp)
 
 You can support Ionide development on [Open Collective](https://opencollective.com/ionide).
 

--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -500,13 +500,13 @@ module MSBuild =
         |> context.Subscribe
 
         commands.registerCommand (
-            "MSBuild.buildSelected",
+            "MSBuild.rebuildSelected",
             fun _ -> buildProject "Rebuild" |> Promise.map box |> box |> Some
         )
         |> context.Subscribe
 
         commands.registerCommand (
-            "MSBuild.buildSelected",
+            "MSBuild.cleanSelected",
             fun _ -> buildProject "Clean" |> Promise.map box |> box |> Some
         )
         |> context.Subscribe

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -623,13 +623,13 @@ module SolutionExplorer =
         else
             (fn + ".fs")
 
-    let private createNewFileDialg (proj : string) (existingFiles : list<Model>) (prompt : string) =
+    let private createNewFileDialg (proj: string) (existingFiles: list<Model>) (prompt: string) =
         let opts = createEmpty<InputBoxOptions>
         opts.placeHolder <- Some "new.fs"
         opts.prompt <- Some prompt
 
         opts.validateInput <-
-            Some(fun userInput ->
+            fun userInput ->
                 let fileExist =
                     existingFiles
                     |> List.tryFind (fun file ->
@@ -656,8 +656,9 @@ module SolutionExplorer =
                             userInput.Replace("\\", "/") = relativeFilePathFromProject.Replace("\\", "/"))
 
                 match fileExist with
-                | Some _ -> U2.Case1 "File already exists"
-                | None -> undefined)
+                | Some _ -> Some <| U2.Case1 "File already exists"
+                | None -> None
+
 
         window.showInputBox opts
 
@@ -834,8 +835,7 @@ module SolutionExplorer =
                                 FsProjEdit.addFileBelow proj virtPath file'
                             | None -> Promise.empty)
                         |> unbox
-                    | _ ->
-                        undefined
+                    | _ -> undefined
 
                 | _ -> undefined)
         )

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -692,24 +692,27 @@ Consider:
                                 printfn $"FSAC (NETCORE): {e}"
                                 return [], [], ""
                             | Ok v ->
+                                printfn "Parsed SDK version at root path: %s" v.raw
                                 let tfm = tfmForSdkVersion v
+                                printfn "Parsed SDK version to tfm: %s" tfm
                                 let fsacPath = fsacPathForTfm tfm
+                                printfn "Parsed TFM to fsac path: %s" fsacPath
+                                return [], [], fsacPath
+                                // if v.major >= 6.0 then
+                                //     // when we run on a sdk higher than 6.x (aka what FSAC is currently built/targeted for),
+                                //     // we have to tell the runtime to allow it to actually run on that runtime (instead of presenting 6.x as 5.x)
+                                //     // in order for msbuild resolution to work
+                                //     let args = [ "--roll-forward"; "LatestMajor" ]
 
-                                if v.major >= 6.0 then
-                                    // when we run on a sdk higher than 5.x (aka what FSAC is currently built/targeted for),
-                                    // we have to tell the runtime to allow it to actually run on that runtime (instead of presenting 6.x as 5.x)
-                                    // in order for msbuild resolution to work
-                                    let args = [ "--roll-forward"; "LatestMajor" ]
+                                //     let envs =
+                                //         if v.prerelease <> null || v.prerelease.Count > 0 then
+                                //             [ "DOTNET_ROLL_FORWARD_TO_PRERELEASE", box 1 ]
+                                //         else
+                                //             []
 
-                                    let envs =
-                                        if v.prerelease <> null || v.prerelease.Count > 0 then
-                                            [ "DOTNET_ROLL_FORWARD_TO_PRERELEASE", box 1 ]
-                                        else
-                                            []
-
-                                    return args, envs, fsacPath
-                                else
-                                    return [], [], fsacPath
+                                //     return args, envs, fsacPath
+                                // else
+                                //     return [], [], fsacPath
                         }
 
                     let userDotnetArgs = "FSharp.fsac.dotnetArgs" |> Configuration.get [||]

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -694,6 +694,7 @@ Consider:
                             | Ok v ->
                                 let tfm = tfmForSdkVersion v
                                 let fsacPath = fsacPathForTfm tfm
+
                                 if v.major >= 6.0 then
                                     // when we run on a sdk higher than 5.x (aka what FSAC is currently built/targeted for),
                                     // we have to tell the runtime to allow it to actually run on that runtime (instead of presenting 6.x as 5.x)


### PR DESCRIPTION
We'll need to bump FSAC again because the 57.0 release didn't have the net7.0 TFM bits, but that change is already done - just needs a 0.57.1 bump.