### PR TITLE
Remove decorations when removing a file from a project

### DIFF
--- a/src/Components/LineLens.fs
+++ b/src/Components/LineLens.fs
@@ -304,6 +304,35 @@ let private textEditorsChangedHandler (textEditors: ResizeArray<TextEditor>) =
                 DecorationUpdate.setDecorationsForEditorIfCurrentVersion textEditor state
     | None -> ()
 
+let removeDocument (uri : Uri) =
+    match state with
+    | Some state ->
+        let documentExistInCache =
+            state.documents
+            // Try to find the document in the cache
+            // We use the path as the search value because parsed URI are not unified by VSCode
+            |> Seq.tryFind (fun element ->
+                element.Key.path = uri.path
+            )
+
+        match documentExistInCache with
+        | Some (KeyValue (uri, _)) ->
+            DecorationUpdate.documentClosed uri state
+
+            window.visibleTextEditors
+            // Find the text editor related to the document in cache
+            |> Seq.tryFind (fun textEditor ->
+                textEditor.document.uri = uri
+            )
+            // If the text editor is found, remove the decorations
+            |> Option.iter (fun textEditor ->
+                textEditor.setDecorations (state.decorationType, U2.Case1(ResizeArray()))
+            )
+
+        | None -> ()
+
+    | None -> ()
+
 let private documentParsedHandler (event: Notifications.DocumentParsedEvent) =
     match state with
     | None -> ()

--- a/src/Components/PipelineHints.fs
+++ b/src/Components/PipelineHints.fs
@@ -228,6 +228,35 @@ let private textEditorsChangedHandler (textEditors: ResizeArray<TextEditor>) =
                 DecorationUpdate.setDecorationsForEditorIfCurrentVersion textEditor state
     | None -> ()
 
+let removeDocument (uri : Uri) =
+    match state with
+    | Some state ->
+        let documentExistInCache =
+            state.documents
+            // Try to find the document in the cache
+            // We use the path as the search value because parsed URI are not unified by VSCode
+            |> Seq.tryFind (fun element ->
+                element.Key.path = uri.path
+            )
+
+        match documentExistInCache with
+        | Some (KeyValue (uri, _)) ->
+            DecorationUpdate.documentClosed uri state
+
+            window.visibleTextEditors
+            // Find the text editor related to the document in cache
+            |> Seq.tryFind (fun textEditor ->
+                textEditor.document.uri = uri
+            )
+            // If the text editor is found, remove the decorations
+            |> Option.iter (fun textEditor ->
+                textEditor.setDecorations (state.decorationType, U2.Case1(ResizeArray()))
+            )
+
+        | None -> ()
+
+    | None -> ()
+
 let private documentParsedHandler (event: Notifications.DocumentParsedEvent) =
     match state with
     | None -> ()

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -42,11 +42,11 @@
     <Compile Include="Components/MSBuild.fs" />
     <Compile Include="Components/Help.fs" />
     <Compile Include="Components/Debugger.fs" />
-    <Compile Include="Components/SolutionExplorer.fs" />
     <Compile Include="Components/HtmlConverter.fs" />
     <Compile Include="Components/InfoPanel.fs" />
     <Compile Include="Components/CodeLensHelpers.fs" />
     <Compile Include="Components/PipelineHints.fs" />
+    <Compile Include="Components/SolutionExplorer.fs" />
     <Compile Include="Components/TestExplorer.fs" />
     <Compile Include="Components/InlayHints.fs" />
     <Compile Include="fsharp.fs" />


### PR DESCRIPTION
Preview:

https://user-images.githubusercontent.com/4760796/194088735-d4407f9f-a2a7-4e7e-bcd3-253f40d0ff58.mp4

This PR remove the decorations added by the `PipelineHints` and `LineLens` when removing a file.

With this PR and when https://github.com/fsharp/FsAutoComplete/pull/1005 will be merged we should have everything cleaned when removing a file.

https://github.com/fsharp/FsAutoComplete/pull/1005 is needed to:
- Clean the diagnostics
- Not have the file still considered part of the project when re-opening it
	With the FSAC PR, if you re-open the file then it still consider that it can access others files content which is wrong :)

