### PR TITLE
Quickfix for overloading server with FSharpSignatureData requests

### DIFF
--- a/src/Components/LineLens.fs
+++ b/src/Components/LineLens.fs
@@ -195,8 +195,10 @@ module DecorationUpdate =
         textLine.range
 
     let private getSignature (uri: Uri) (range: DTO.Range) =
-        promise {
-            let! signaturesResult = LanguageService.signatureData uri range.StartLine (range.StartColumn - 1)
+        async {
+            let! signaturesResult =
+                LanguageService.signatureData uri range.StartLine (range.StartColumn - 1)
+                |> Async.AwaitPromise
 
             let signaturesResult =
                 if isNotNull signaturesResult then
@@ -224,7 +226,11 @@ module DecorationUpdate =
 
             let interesting = onePerLine interesting
 
-            let! signatures = interesting |> Array.map (getSignature uri) |> Promise.all
+            let! signatures =
+                interesting
+                |> Array.map (getSignature uri)
+                |> Async.Sequential
+                |> Async.StartAsPromise
 
             return signatures |> Seq.choose id
         }


### PR DESCRIPTION
👋 I noticed there's been an issue with larger files getting bombarded with `FSharpSignatureData`.  Since this was firing a lot of promises at the same time, this was causing VSCode to slow down to a crawl. 

While it would be better to only send up ranges you're currently viewing, this is a quick fix to try to stop the bleeding.