### PR TITLE
Fixes text highlighting on debug builds

### DIFF
--- a/build/Program.fs
+++ b/build/Program.fs
@@ -378,7 +378,12 @@ let buildTargetTree () =
     "YarnInstall" ==>! "RunScript"
     "DotNetRestore" ==>! "RunScript"
 
-    "Clean" ==> "Format" ==> "RunScript" ==>! "Default"
+    "Clean"
+        ==> "Format"
+        ==> "RunScript"
+        ==> "CopyGrammar"
+        ==> "CopySchemas"
+        ==>! "Default"
 
     "Clean"
     ==> "RunScript"


### PR DESCRIPTION
When running ionide in debug mode via "Build and Launch Extension" the text highlighting seemed to be off:

![image](https://user-images.githubusercontent.com/1490044/196455672-f1097c8d-256e-4fcf-a4ed-d5661c956d59.png)

vs

![image](https://user-images.githubusercontent.com/1490044/196456087-d38d858b-8156-40c2-bcd7-d2fae5937850.png)


This makes sure to add `CopyGrammar` and `CopySchema` to be part of the `Default` target so highlighting shows up.