### PR TITLE
Fixes duplicate tree view folders

### DIFF
--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -56,7 +56,7 @@ module SolutionExplorer =
         let rec addhelper state items =
             match items, state.Children with
             | [], _ -> state
-            | [ key ], children when children |> List.exists (fun c -> c.Key = key) -> state
+            | [ key ], children when children |> List.exists (fun c -> c.Key = Uri.UnescapeDataString key) -> state
             | [ key ], _ ->
                 let x =
                     { Key = Uri.UnescapeDataString key
@@ -66,7 +66,8 @@ module SolutionExplorer =
 
                 state.Children <- x :: state.Children
                 state
-            | dirName :: xs, lastFileOrDir :: _ when dirName = lastFileOrDir.Key -> addhelper lastFileOrDir xs
+            | dirName :: xs, lastFileOrDir :: _ when Uri.UnescapeDataString dirName = lastFileOrDir.Key ->
+                addhelper lastFileOrDir xs
             | dirName :: xs, _ ->
                 let dirPath = pathCombine state.FilePath dirName
 


### PR DESCRIPTION
Given the fsproj file

```xml
  <ItemGroup>
    <Compile Include="hello/foo.fs" />
    <Compile Include="goodbye world/foo2.fs" />
    <Compile Include="goodbye world/foo3.fs" />
    <Compile Include="hello/foo1.fs" />
    <Compile Include="goodbye world/foo4.fs" />
    <Compile Include="Library.fs" />
  </ItemGroup>
```

Current Version will duplicate foo2 and foo3's folder:

<img width="370" alt="image" src="https://user-images.githubusercontent.com/1490044/197914031-141dd867-8ce4-4b04-a97c-9b3895a9ae2b.png">


This fix:

<img width="336" alt="image" src="https://user-images.githubusercontent.com/1490044/197914125-ee8ec750-b7d8-4426-a04f-b80d5791d842.png">
