### PR TITLE
Remove superfluous .fantomasignore file

### DIFF
--- a/src/.fantomasignore
+++ b/src/.fantomasignore
@@ -1,1 +1,0 @@
-fable_modules/


### PR DESCRIPTION
fable_modules is always excluded from formatting since Fantomas v4.7.9

See https://github.com/fsprojects/fantomas/releases/tag/v4.7.9
