### PR TITLE
Restrict document filter schemes to file and untitled (fixes #1810)

### DIFF
--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -635,10 +635,22 @@ Consider:
             let opts = createEmpty<Client.LanguageClientOptions>
 
             let selector: DocumentSelector =
-                let filter: DocumentFilter =
-                    jsOptions<TextDocumentFilter> (fun f -> f.language <- Some "fsharp") |> U2.Case1
+                let fileSchemeFilter: DocumentFilter =
+                    jsOptions<TextDocumentFilter> (fun f ->
+                        f.language <- Some "fsharp"
+                        f.scheme <- Some "file"
+                    ) |> U2.Case1
 
-                [| U2.Case2 filter |]
+                let untitledSchemeFilter: DocumentFilter =
+                    jsOptions<TextDocumentFilter> (fun f ->
+                        f.language <- Some "fsharp"
+                        f.scheme <- Some "untitled"
+                    ) |> U2.Case1
+
+                [|
+                    U2.Case2 fileSchemeFilter
+                    U2.Case2 untitledSchemeFilter
+                |]
 
             let initOpts = createObj [ "AutomaticWorkspaceInit" ==> false ]
 


### PR DESCRIPTION
VSCode won't send URI documents of `file:` or `untitled:` scheme with this change.

Note I saw this way in a PHP language client: https://github.com/felixfbecker/vscode-php-intellisense/blob/df5632182eb16d3127c46789b9de43e676233019/src/extension.ts#L114 .