### PR TITLE
Adds FSharp.fsac.converveMemory flag

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -516,7 +516,7 @@
         },
         "FSharp.fsac.conserveMemory" : {
           "default" : false,
-          "description": "This will set DOTNET_GCConserveMemory. Requires restart.",
+          "description": "Configures FsAutoComplete with settings intended to reduce memory consumption. Requires restart.",
           "type" : "boolean"
         },
         "FSharp.fsac.dotnetArgs": {

--- a/release/package.json
+++ b/release/package.json
@@ -514,6 +514,11 @@
           "description": "Appends the \u0027--attachdebugger\u0027 argument to fsac, this will allow you to attach a debugger.",
           "type": "boolean"
         },
+        "FSharp.fsac.conserveMemory" : {
+          "default" : false,
+          "description": "This will set DOTNET_GCConserveMemory. Requires restart.",
+          "type" : "boolean"
+        },
         "FSharp.fsac.dotnetArgs": {
           "default": [],
           "description": "additional CLI arguments to be provided to the dotnet runner for FSAC",

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -678,6 +678,8 @@ Consider:
             let enableProjectGraph =
                 "FSharp.enableMSBuildProjectGraph" |> Configuration.get false
 
+            let convserveMemory = "FSharp.fsac.conserveMemory" |> Configuration.get false
+
             let fsacAttachDebugger = "FSharp.fsac.attachDebugger" |> Configuration.get false
 
             let fsacNetcorePath = "FSharp.fsac.netCoreDllPath" |> Configuration.get ""
@@ -765,6 +767,11 @@ Consider:
             let spawnNetCore dotnet : JS.Promise<Executable> =
                 promise {
                     let! (fsacDotnetArgs, fsacEnvVars, fsacPath) = discoverDotnetArgs ()
+
+                    let fsacEnvVars =
+                        [ yield! fsacEnvVars
+                          if convserveMemory then
+                              yield "DOTNET_GCConserveMemory", box "9" ]
 
                     printfn $"FSAC (NETCORE): '%s{fsacPath}'"
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -678,7 +678,7 @@ Consider:
             let enableProjectGraph =
                 "FSharp.enableMSBuildProjectGraph" |> Configuration.get false
 
-            let convserveMemory = "FSharp.fsac.conserveMemory" |> Configuration.get false
+            let conserveMemory = "FSharp.fsac.conserveMemory" |> Configuration.get false
 
             let fsacAttachDebugger = "FSharp.fsac.attachDebugger" |> Configuration.get false
 
@@ -770,7 +770,7 @@ Consider:
 
                     let fsacEnvVars =
                         [ yield! fsacEnvVars
-                          if convserveMemory then
+                          if conserveMemory then
                               yield "DOTNET_GCConserveMemory", box "9" ]
 
                     printfn $"FSAC (NETCORE): '%s{fsacPath}'"


### PR DESCRIPTION
This currently sets [DOTNET_GCConserveMemory ](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#conserve-memory) which should help with Large Object Heap allocations in FCS. Definitely another bandaid in a long line of bandaids but it does seem to help with larger projects.

<img width="448" alt="image" src="https://user-images.githubusercontent.com/1490044/219968994-d5e05982-d4b3-41d1-b0e9-d19d4605f2a7.png">

<img width="462" alt="image" src="https://user-images.githubusercontent.com/1490044/219968963-95c1cb0b-88fd-4395-b761-8ae455f08ef9.png">
