### PR TITLE
Test Explorer: support test cases

### DIFF
--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -16,7 +16,7 @@ let private lastOutput = Collections.Generic.Dictionary<string, string>()
 let private outputChannel = window.createOutputChannel "F# - Test Adapter"
 
 let private logger =
-    ConsoleAndOutputChannelLogger(Some "TestExplorer", Level.DEBUG, Some outputChannel, Some Level.DEBUG)
+    ConsoleAndOutputChannelLogger(Some "TestExplorer", Level.DEBUG, None, Some Level.DEBUG)
 
 type TestItemCollection with
 

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -159,7 +159,7 @@ module DotnetTest =
 
             let tests =
                 mappedTests
-                |> Array.map (fun (t, testCases) ->
+                |> Array.collect (fun (t, testCases) ->
                     testCases
                     |> Array.map (fun (fullName, testName, executionId) ->
                         let outcome =
@@ -215,7 +215,6 @@ module DotnetTest =
                           Expected = expected
                           Actual = actual
                           Timing = timing }))
-                |> Array.concat
 
             return
                 { Project = projectWithTests.Project

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1,4 +1,4 @@
-module Ionide.VSCode.FSharp.TestExploer
+module Ionide.VSCode.FSharp.TestExplorer
 
 open System
 open Fable.Core

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -208,16 +208,18 @@ module DotnetTest =
                                   Timing = timing }
                             | Some testCaseName ->
                                 let ti =
-                                    tc.createTestItem (
-                                        t.Test.uri.Value.ToString() + " -- " + trxTestName,
-                                        testCaseName,
-                                        t.Test.uri.Value
-                                    )
+                                    t.Test.children.get (t.Test.uri.Value.ToString() + " -- " + trxTestName)
+                                    |> Option.defaultWith (fun () ->
+                                        tc.createTestItem (
+                                            t.Test.uri.Value.ToString() + " -- " + trxTestName,
+                                            trxTestName,
+                                            t.Test.uri.Value
+                                        ))
 
                                 t.Test.children.add ti
 
                                 { Test = ti
-                                  FullTestName = trxTestName
+                                  FullTestName = testCaseName
                                   Outcome = !!outcome
                                   ErrorMessage = errorInfoMessage
                                   ErrorStackTrace = errorStackTrace

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -152,11 +152,6 @@ module DotnetTest =
                             remainingTests, ([| yield! mappedTests; (t, linkedTests) |]))
                     (testDefinitions, [||])
 
-            let unmappedTestNames =
-                unmappedTests |> Array.map (fun (fullName, _, _) -> fullName)
-
-            logger.Debug("Unmapped tests", unmappedTestNames)
-
             let tests =
                 mappedTests
                 |> Array.collect (fun (t, testCases) ->

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -87,7 +87,7 @@ let activate (context: ExtensionContext) : JS.Promise<Api> =
         tryActivate "codelens" CodeLensHelpers.activate context
         tryActivate "gitignore" Gitignore.activate context
         tryActivate "pipelinehints" PipelineHints.activate context
-        tryActivate "testExplorer" TestExploer.activate context
+        tryActivate "testExplorer" TestExplorer.activate context
         tryActivate "inlayhints" InlayHints.activate context
 
         let buildProject project =


### PR DESCRIPTION
Add support in VSCode Test Explorer for showing multiple tests that belong to one method.

Implementation details:

- Assume project test items from FSAutoComplete may actually refer to multiple tests
- Sort project tests by longest name and find test results that start with that test name.
  - Sorting ensures that a test method that is a substring of another doesn't get associated with the longer method name's tests.
- If more than one test is found for that project test, nest all results under that project test

Fixes #1756

![test_explorer_test_cases_example](https://user-images.githubusercontent.com/36001967/222962954-2a3323de-5304-40ea-8e96-7ccf221025d6.gif)
