### PR TITLE
update callsites for FSAC being option-aware now

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -548,12 +548,6 @@
           "markdownDescription": "An array of additional command line parameters to pass to FSI when it is started. See [the Microsoft documentation](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/fsharp-interactive-options) for an exhaustive list.",
           "type": "array"
         },
-        "FSharp.fsiFilePath": {
-          "default": "",
-          "description": "The path to the F# Interactive tool used by Ionide-FSharp (.NET Framework only, on .NET Core \u0060FSharp.fsiSdkFilePath\u0060 is used)",
-          "scope": "machine-overridable",
-          "type": "string"
-        },
         "FSharp.fsiSdkFilePath": {
           "default": "",
           "description": "The path to the F# Interactive tool used by Ionide-FSharp (When using .NET SDK scripts)",
@@ -787,11 +781,6 @@
         "FSharp.unusedOpensAnalyzer": {
           "default": true,
           "description": "Enables detection of unused opens",
-          "type": "boolean"
-        },
-        "FSharp.useSdkScripts": {
-          "default": true,
-          "description": "Use \u0027dotnet fsi\u0027 instead of \u0027fsi.exe\u0027/\u0027fsharpi\u0027 to start an FSI session",
           "type": "boolean"
         },
         "FSharp.verboseLogging": {

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -320,9 +320,6 @@ module Fsi =
     let mutable lastCd: string option = None
     let mutable lastCurrentFile: string option = None
 
-    let isSdk () =
-        Configuration.get false "FSharp.useSdkScripts"
-
     let private sendCd (terminal: Terminal) (textEditor: TextEditor option) =
         let file, dir =
             match textEditor with
@@ -381,21 +378,14 @@ module Fsi =
             |> Array.ofList
 
         promise {
-            if isSdk () then
-                let! dotnet = LanguageService.tryFindDotnet ()
+            let! dotnet = LanguageService.tryFindDotnet ()
 
-                match dotnet with
-                | Ok dotnet ->
-                    let! fsiSetting = LanguageService.fsiSdk ()
-                    let fsiArg = defaultArg fsiSetting "fsi"
-                    return dotnet, [| yield fsiArg; yield! parms |]
-                | Error msg -> return failwith msg
-            else
-                let! fsi = LanguageService.fsi ()
-
-                match fsi with
-                | Some fsi -> return fsi, parms
-                | None -> return failwith ".Net Framework FSI was requested but not found"
+            match dotnet with
+            | Ok dotnet ->
+                let! fsiSetting = LanguageService.fsiSdk ()
+                let fsiArg = defaultArg fsiSetting "fsi"
+                return dotnet, [| yield fsiArg; yield! parms |]
+            | Error msg -> return failwith msg
         }
 
     let fsiNetCoreName = "F# Interactive (.Net Core)"
@@ -409,7 +399,7 @@ module Fsi =
                         let! (fsiBinary, fsiArguments) = fsiBinaryAndParameters ()
                         let fsiArguments = U2.Case1(ResizeArray fsiArguments)
 
-                        let name = if isSdk () then fsiNetCoreName else fsiNetFrameworkName
+                        let name = fsiNetCoreName
 
                         let options: TerminalOptions = createEmpty<_>
                         options.name <- Some name

--- a/src/Components/Help.fs
+++ b/src/Components/Help.fs
@@ -14,12 +14,15 @@ module Help =
 
         promise {
             let! res = LanguageService.f1Help (doc.uri) (int pos.line) (int pos.character)
-            let api = res.Data.Replace("#ctor", "-ctor")
+            match res with
+            | None -> return ()
+            | Some res ->
+                let api = res.Data.Replace("#ctor", "-ctor")
 
-            let uri =
-                vscode.Uri.parse (sprintf "https://docs.microsoft.com/en-us/dotnet/api/%s" api)
+                let uri =
+                    vscode.Uri.parse (sprintf "https://docs.microsoft.com/en-us/dotnet/api/%s" api)
 
-            return! commands.executeCommand ("vscode.open", Some(box uri))
+                return! commands.executeCommand ("vscode.open", Some(box uri))
         }
         |> ignore
 

--- a/src/Components/InfoPanel.fs
+++ b/src/Components/InfoPanel.fs
@@ -196,11 +196,9 @@ module InfoPanel =
                     let doc = textEditor.document
                     let pos = selections.[0].active
                     let! res = LanguageService.documentation doc.uri (int pos.line) (int pos.character)
-                    let res = mapContent res
-
-                    match res with
-                    | None -> ()
-                    | Some res -> setContent res
+                    res
+                    |> Option.bind mapContent
+                    |> Option.iter setContent
                 else
                     return ()
             }
@@ -211,11 +209,9 @@ module InfoPanel =
                 if isFsharpTextEditor textEditor && panel.IsSome then
                     let doc = textEditor.document
                     let! res = LanguageService.documentation doc.uri (int pos.line) (int pos.character)
-                    let res = mapContent res
-
-                    match res with
-                    | None -> ()
-                    | Some res -> setContent res
+                    res
+                    |> Option.bind mapContent
+                    |> Option.iter setContent
                 else
                     return ()
             }
@@ -224,11 +220,9 @@ module InfoPanel =
         let updateOnLink xmlSig assemblyName =
             promise {
                 let! res = LanguageService.documentationForSymbol xmlSig assemblyName
-                let res = mapContent res
-
-                match res with
-                | None -> ()
-                | Some res -> setContent res
+                res
+                |> Option.bind mapContent
+                |> Option.iter setContent
             }
 
     let mutable private timer = None

--- a/src/Components/QuickInfo.fs
+++ b/src/Components/QuickInfo.fs
@@ -113,8 +113,7 @@ module QuickInfo =
                     let doc = textEditor.document
                     let pos = selections.[0].active
                     let! o = LanguageService.signature (doc.uri) (int pos.line) (int pos.character)
-
-                    if isNotNull o then return Some o.Data else return None
+                    return o |> Option.map (fun o -> o.Data)
                 else
                     return None
             }

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -665,7 +665,10 @@ module SolutionExplorer =
     let newProject () =
         promise {
             let! templates = LanguageService.dotnetNewList ()
-
+            let templates =
+                match templates with
+                | None -> []
+                | Some templates -> templates.Data
             let n =
                 templates
                 |> List.map (fun t ->

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -143,12 +143,6 @@ module DTO =
           CurrentParameter: int
           Overloads: Overload[] }
 
-    type CompilerLocation =
-        { Fsc: string option
-          Fsi: string option
-          MSBuild: string option
-          SdkRoot: string option }
-
     type Range =
         { StartColumn: int
           StartLine: int
@@ -375,7 +369,6 @@ module DTO =
 
     type Result<'T> = { Kind: string; Data: 'T }
 
-    type CompilerLocationResult = Result<CompilerLocation>
     type HelptextResult = Result<Helptext>
     type CompletionResult = Result<Completion[]>
     type SymbolUseResult = Result<SymbolUses>

--- a/src/Core/Environment.fs
+++ b/src/Core/Environment.fs
@@ -17,9 +17,6 @@ module Environment =
     let private (</>) a b =
         if isWin then a + @"\" + b else a + "/" + b
 
-    let configFsiFilePath () =
-        Configuration.tryGet "FSharp.fsiFilePath"
-
     let configFsiSdkFilePath () =
         Configuration.tryGet "FSharp.fsiSdkFilePath"
 


### PR DESCRIPTION
These commits are reactions to https://github.com/fsharp/FsAutoComplete/pull/1069's changes in the response shapes of the custom PlainNotification endpoints - it turns out that many of the endpoints were already null-aware, but this made it more explicit.