### PR TITLE
Use base64 encoded name in test URIs

### DIFF
--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1,6 +1,7 @@
 module Ionide.VSCode.FSharp.TestExplorer
 
 open System
+open System.Text
 open Fable.Core
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
@@ -192,7 +193,11 @@ module DotnetTest =
 
                         if Seq.length testCases > 1 then
                             let ti =
-                                t.Test.children.get (t.Test.uri.Value.ToString() + " -- " + testName)
+                                t.Test.children.get (
+                                    t.Test.uri.Value.ToString()
+                                    + " -- "
+                                    + Convert.ToBase64String(Encoding.UTF8.GetBytes(testName))
+                                )
                                 |> Option.defaultWith (fun () ->
                                     tc.createTestItem (
                                         t.Test.uri.Value.ToString() + " -- " + testName,
@@ -217,7 +222,12 @@ module DotnetTest =
         }
 
 let rec mapTest (tc: TestController) (uri: Uri) (t: TestAdapterEntry) : TestItem =
-    let ti = tc.createTestItem (uri.ToString() + " -- " + string t.id, t.name, uri)
+    let ti =
+        tc.createTestItem (
+            uri.ToString() + " -- " + Convert.ToBase64String(Encoding.UTF8.GetBytes(t.name)),
+            t.name,
+            uri
+        )
 
     ti.range <-
         Some(


### PR DESCRIPTION
Currently the test URI is based upon the ID from the TestAdapterEntry from FsAutoComplete. However, this ID is based on the order of tests, and not based on the content. Thus, VSCode can incorrectly assign status to an unrelated test when the ordering of tests is changed, see below:

![test_explorer_uri_master](https://user-images.githubusercontent.com/36001967/224171116-cf2252a4-faa0-4b81-897c-82415ef9fb2a.gif)

This change uses the name of the test entry (base64 encoded) instead, which means that provided the test name is fixed, VSCode will continue to assign the correct status to that test:

![test_explorer_uri_new](https://user-images.githubusercontent.com/36001967/224171317-3ea0ab1c-75a4-4787-a9ec-546beaa33b89.gif)

I should note, there is a benefit of the existing ID based approach in that if a test is renamed, but is otherwise unchanged, VSCode will continue to assign the same status. I would suggest, however, that it make more sense to change the test URI in that case.