### PR TITLE
Handle tests within nested modules

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -242,4 +242,4 @@ STORAGE: PACKAGES
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    fsautocomplete (0.59.1)
+    fsautocomplete (0.59.2)

--- a/src/Components/Help.fs
+++ b/src/Components/Help.fs
@@ -14,6 +14,7 @@ module Help =
 
         promise {
             let! res = LanguageService.f1Help (doc.uri) (int pos.line) (int pos.character)
+
             match res with
             | None -> return ()
             | Some res ->

--- a/src/Components/InfoPanel.fs
+++ b/src/Components/InfoPanel.fs
@@ -196,9 +196,7 @@ module InfoPanel =
                     let doc = textEditor.document
                     let pos = selections.[0].active
                     let! res = LanguageService.documentation doc.uri (int pos.line) (int pos.character)
-                    res
-                    |> Option.bind mapContent
-                    |> Option.iter setContent
+                    res |> Option.bind mapContent |> Option.iter setContent
                 else
                     return ()
             }
@@ -209,9 +207,7 @@ module InfoPanel =
                 if isFsharpTextEditor textEditor && panel.IsSome then
                     let doc = textEditor.document
                     let! res = LanguageService.documentation doc.uri (int pos.line) (int pos.character)
-                    res
-                    |> Option.bind mapContent
-                    |> Option.iter setContent
+                    res |> Option.bind mapContent |> Option.iter setContent
                 else
                     return ()
             }
@@ -220,9 +216,7 @@ module InfoPanel =
         let updateOnLink xmlSig assemblyName =
             promise {
                 let! res = LanguageService.documentationForSymbol xmlSig assemblyName
-                res
-                |> Option.bind mapContent
-                |> Option.iter setContent
+                res |> Option.bind mapContent |> Option.iter setContent
             }
 
     let mutable private timer = None

--- a/src/Components/LineLens.fs
+++ b/src/Components/LineLens.fs
@@ -196,8 +196,7 @@ module DecorationUpdate =
 
     let private getSignature (uri: Uri) (range: DTO.Range) =
         promise {
-            let! signaturesResult =
-                LanguageService.signatureData uri range.StartLine (range.StartColumn - 1)
+            let! signaturesResult = LanguageService.signatureData uri range.StartLine (range.StartColumn - 1)
 
             return signaturesResult |> Option.map (fun r -> range, formatSignature r.Data)
         }
@@ -223,7 +222,12 @@ module DecorationUpdate =
                 interesting
                 |> Array.map (getSignature uri)
                 |> Promise.allSettled
-                |> Promise.map (fun s -> s |> Array.choose (fun sv -> match sv.value with  | Some (Some v) -> Some v | _ -> None))
+                |> Promise.map (fun s ->
+                    s
+                    |> Array.choose (fun sv ->
+                        match sv.value with
+                        | Some(Some v) -> Some v
+                        | _ -> None))
 
             return signatures
         }

--- a/src/Components/PipelineHints.fs
+++ b/src/Components/PipelineHints.fs
@@ -169,6 +169,7 @@ module DecorationUpdate =
                 return Some info
             | None when document.version = version ->
                 let! hintsResults = LanguageService.pipelineHints uri
+
                 match hintsResults with
                 | None -> return None
                 | Some hintsResults ->

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -665,10 +665,12 @@ module SolutionExplorer =
     let newProject () =
         promise {
             let! templates = LanguageService.dotnetNewList ()
+
             let templates =
                 match templates with
                 | None -> []
                 | Some templates -> templates.Data
+
             let n =
                 templates
                 |> List.map (fun t ->

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -271,18 +271,6 @@ let getProjectsForTests
     let rec getFullName (ti: TestItem) =
         match ti.parent with
         | Some p ->
-            let parentModuleType =
-                if moduleTypes.ContainsKey p.id then
-                    Some moduleTypes[p.id]
-                else
-                    None
-
-            let tiModuleType =
-                if moduleTypes.ContainsKey ti.id then
-                    Some moduleTypes[ti.id]
-                else
-                    None
-
             match moduleTypes.TryGetValue p.id, moduleTypes.TryGetValue ti.id with
             | (true, pModuleType), (true, tModuleType) ->
                 let segment =

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -219,7 +219,7 @@ module DotnetTest =
 let rec mapTest
     (tc: TestController)
     (uri: Uri)
-    (moduleTypes: System.Collections.Generic.Dictionary<string, string>)
+    (moduleTypes: Collections.Generic.Dictionary<string, string>)
     (t: TestAdapterEntry)
     : TestItem =
     let ti = tc.createTestItem (uri.ToString() + " -- " + string t.id, t.name, uri)
@@ -243,7 +243,7 @@ let rec mapTest
 /// Get a flat list with all tests for each project
 let getProjectsForTests
     (tc: TestController)
-    (moduleTypes: System.Collections.Generic.Dictionary<string, string>)
+    (moduleTypes: Collections.Generic.Dictionary<string, string>)
     (req: TestRunRequest)
     : ProjectWithTests array =
     let testsWithProject =
@@ -376,7 +376,7 @@ let runTests
 
 let runHandler
     (tc: TestController)
-    (moduleTypes: System.Collections.Generic.Dictionary<string, string>)
+    (moduleTypes: Collections.Generic.Dictionary<string, string>)
     (req: TestRunRequest)
     (_ct: CancellationToken)
     : U2<Thenable<unit>, unit> =
@@ -436,7 +436,7 @@ let activate (context: ExtensionContext) =
     let testController =
         tests.createTestController ("fsharp-test-controller", "F# Test Controller")
 
-    let moduleTypes = System.Collections.Generic.Dictionary<string, string>()
+    let moduleTypes = Collections.Generic.Dictionary<string, string>()
 
     testController.createRunProfile (
         "Run F# Tests",

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -225,11 +225,12 @@ let rec mapTest
     (tc: TestController)
     (uri: Uri)
     (moduleTypes: Collections.Generic.Dictionary<string, string>)
+    (parentNameId: string)
     (t: TestAdapterEntry)
     : TestItem =
     let ti =
         tc.createTestItem (
-            uri.ToString() + " -- " + Convert.ToBase64String(Encoding.UTF8.GetBytes(t.name)),
+            $"{uri.ToString()} -- {parentNameId} -- {Convert.ToBase64String(Encoding.UTF8.GetBytes(t.name))}",
             t.name,
             uri
         )
@@ -245,7 +246,7 @@ let rec mapTest
     moduleTypes.Add(ti.id, t.moduleType)
 
     t.childs
-    |> Array.iter (fun n -> mapTest tc uri moduleTypes n |> ti.children.add)
+    |> Array.iter (fun n -> mapTest tc uri moduleTypes $"{parentNameId}.{t.name}" n |> ti.children.add)
 
     ti?``type`` <- t.``type``
     ti
@@ -452,7 +453,7 @@ let activate (context: ExtensionContext) =
 
         let res =
             res.tests
-            |> Array.map (mapTest testController (vscode.Uri.parse (res.file, true)) moduleTypes)
+            |> Array.map (mapTest testController (vscode.Uri.parse (res.file, true)) moduleTypes "")
 
         res
         |> Array.iter (fun testItem ->

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -268,8 +268,6 @@ let getProjectsForTests
             |> Option.bind (fun uri -> Project.tryFindLoadedProjectByFile uri.fsPath)
             |> Option.map (fun (project: Project) -> { TestItem = t; Project = project }))
 
-    logger.Debug("Module types", moduleTypes)
-
     let rec getFullName (ti: TestItem) =
         match ti.parent with
         | Some p ->

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -361,7 +361,8 @@ module DTO =
           childs: TestAdapterEntry[]
           id: int
           list: bool
-          ``type``: string }
+          ``type``: string
+          moduleType: string }
 
     type TestForFile =
         { file: string

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -95,9 +95,11 @@ module LanguageService =
 
     let mutable client: LanguageClient option = None
 
-    let inline checkNotificationAndCast<'t> (response: Types.PlainNotification): 't option =
-        if isNullOrUndefined response then None
-        else Some (ofJson<'t> response.content)
+    let inline checkNotificationAndCast<'t> (response: Types.PlainNotification) : 't option =
+        if isNullOrUndefined response then
+            None
+        else
+            Some(ofJson<'t> response.content)
 
     let selector: DocumentSelector =
         let fileSchemeFilter: DocumentFilter =
@@ -344,8 +346,7 @@ Consider:
                   Output = output
                   Name = name }
 
-            cl.sendRequest ("fsharp/dotnetnewrun", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsharp/dotnetnewrun", req) |> Promise.map ignore
 
     let dotnetAddProject (target: string) (reference: string) =
         match client with
@@ -355,8 +356,7 @@ Consider:
                 { Target = target
                   Reference = reference }
 
-            cl.sendRequest ("fsharp/dotnetaddproject", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsharp/dotnetaddproject", req) |> Promise.map ignore
 
     let dotnetRemoveProject (target: string) (reference: string) =
         match client with
@@ -366,8 +366,7 @@ Consider:
                 { Target = target
                   Reference = reference }
 
-            cl.sendRequest ("fsharp/dotnetremoveproject", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsharp/dotnetremoveproject", req) |> Promise.map ignore
 
     let dotnetAddSln (target: string) (reference: string) =
         match client with
@@ -377,8 +376,7 @@ Consider:
                 { Target = target
                   Reference = reference }
 
-            cl.sendRequest ("fsharp/dotnetaddsln", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsharp/dotnetaddsln", req) |> Promise.map ignore
 
     let fsprojMoveFileUp (fsproj: string) (file: string) =
         match client with
@@ -388,8 +386,7 @@ Consider:
                 { FsProj = fsproj
                   FileVirtualPath = file }
 
-            cl.sendRequest ("fsproj/moveFileUp", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsproj/moveFileUp", req) |> Promise.map ignore
 
     let fsprojMoveFileDown (fsproj: string) (file: string) =
         match client with
@@ -399,8 +396,7 @@ Consider:
                 { FsProj = fsproj
                   FileVirtualPath = file }
 
-            cl.sendRequest ("fsproj/moveFileDown", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsproj/moveFileDown", req) |> Promise.map ignore
 
     let fsprojAddFileAbove (fsproj: string) (file: string) (newFile: string) =
         match client with
@@ -411,8 +407,7 @@ Consider:
                   FileVirtualPath = file
                   NewFile = newFile }
 
-            cl.sendRequest ("fsproj/addFileAbove", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsproj/addFileAbove", req) |> Promise.map ignore
 
     let fsprojAddFileBelow (fsproj: string) (file: string) (newFile: string) =
         match client with
@@ -423,8 +418,7 @@ Consider:
                   FileVirtualPath = file
                   NewFile = newFile }
 
-            cl.sendRequest ("fsproj/addFileBelow", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsproj/addFileBelow", req) |> Promise.map ignore
 
     let fsprojAddFile (fsproj: string) (file: string) =
         match client with
@@ -434,8 +428,7 @@ Consider:
                 { FsProj = fsproj
                   FileVirtualPath = file }
 
-            cl.sendRequest ("fsproj/addFile", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsproj/addFile", req) |> Promise.map ignore
 
     let fsprojAddExistingFile (fsproj: string) (file: string) =
         match client with
@@ -445,8 +438,7 @@ Consider:
                 { FsProj = fsproj
                   FileVirtualPath = file }
 
-            cl.sendRequest ("fsproj/addExistingFile", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsproj/addExistingFile", req) |> Promise.map ignore
 
     let fsprojRemoveFile (fsproj: string) (file: string) =
         match client with
@@ -456,8 +448,7 @@ Consider:
                 { FsProj = fsproj
                   FileVirtualPath = file }
 
-            cl.sendRequest ("fsproj/removeFile", req)
-            |> Promise.map ignore
+            cl.sendRequest ("fsproj/removeFile", req) |> Promise.map ignore
 
     let parseError (err: obj) =
         let data =
@@ -650,19 +641,25 @@ Consider:
             let findBestTFM (availableTFMs: string seq) (tfm: string) =
                 let tfmToSemVer (t: string) =
                     t.Replace("netcoreapp", "").Replace("net", "").Split([| '.' |], 2)
-                    |> fun ver -> semver.parse(!! $"{ver[0]}.{ver[1]}.0")
+                    |> fun ver -> semver.parse (!! $"{ver[0]}.{ver[1]}.0")
+
                 let tfmMap =
                     availableTFMs
-                    |> Seq.choose (fun tfm -> match tfmToSemVer tfm with Some v -> Some(tfm, v) | None -> None)
+                    |> Seq.choose (fun tfm ->
+                        match tfmToSemVer tfm with
+                        | Some v -> Some(tfm, v)
+                        | None -> None)
                     |> Seq.sortBy (fun (_, v) -> v.major, v.minor)
+
                 printfn $"choosing from among %A{tfmMap}"
+
                 match tfmToSemVer tfm with
                 | None ->
                     printfn "unable to parse target tfm, using latest"
                     Seq.last availableTFMs
                 | Some ver ->
                     tfmMap
-                    |> Seq.skipWhile (fun (_, v) -> (semver.compare(!! v, !!ver)) = enum -1) // skip while fsac tfm is less than target tfm
+                    |> Seq.skipWhile (fun (_, v) -> (semver.compare (!!v, !!ver)) = enum -1) // skip while fsac tfm is less than target tfm
                     |> Seq.tryHead // get first fsac tfm that is greater than or equal to target tfm
                     |> Option.map fst
                     |> Option.defaultWith (fun () -> Seq.last availableTFMs)
@@ -670,11 +667,14 @@ Consider:
             let fsacPathForTfm (tfm: string) =
                 if String.IsNullOrEmpty fsacNetcorePath then
                     let binPath = node.path.join (VSCodeExtension.ionidePluginPath (), "bin")
+
                     let availableTFMs =
-                        node.fs.readdirSync(!! binPath)
-                        |> Seq.filter (fun p -> p.StartsWith "net")  // there are loose files in the binpath, ignore those
+                        node.fs.readdirSync (!!binPath)
+                        |> Seq.filter (fun p -> p.StartsWith "net") // there are loose files in the binpath, ignore those
                         |> Seq.map node.path.basename
+
                     printfn $"Available FSAC TFMs: %A{availableTFMs}"
+
                     if availableTFMs |> Seq.contains tfm then
                         printfn "TFM match found"
                         node.path.join (binPath, tfm, "fsautocomplete.dll")


### PR DESCRIPTION
Fixes #1756 

Using module type information from https://github.com/fsharp/FsAutoComplete/pull/1071, correctly handle the full name of tests where there is a module within a module, a type within a module or a module which shares the same name as a sibling type.

![test_explorer_nested_modules](https://user-images.githubusercontent.com/36001967/224477360-4e380309-a4b4-4cd6-ad50-eadacb3fda76.gif)

Unfortunately, `TestAdapterEntry` which holds the information about module type is not accessible at the point where the full name is constructed, and the VSCode type `TestItem` has no field where this information can be added (AFAIK). To workaround that, this PR uses an otherwise undesirable `ResizeArray` acting as a map of sorts to hold mutable state about module types and this is passed to various functions. Ideally, something like a Set would be used but I will double check if Fable supports `System.Collections.Generic.HashSet` (otherwise it might be worth doing some housekeeping to ensure this collection doesn't become a memory leak).