### PR TITLE
Provide default fileNesting patterns

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -38,6 +38,13 @@
         "language": "fsharp"
       }
     ],
+    "configurationDefaults": {
+      "explorer.fileNesting.patterns": {
+        "*.fs": "${basename}.fsi, ${basename}.fs.js, ${basename}.fs.js.map",
+        "*.fsl": "${basename}.fsi, ${basename}.fs",
+        "*.fsy": "${basename}.fsi, ${basename}.fs"
+      }
+    },
     "colors": [
       {
         "defaults": {


### PR DESCRIPTION
Fix #1724

Adding the configuration like done in this PR seems to be enough to have nesting pattern added for F#.

This configuration is merged with the default configuration from VSCode:

<img width="535" alt="image" src="https://user-images.githubusercontent.com/4760796/224512297-358cd6c1-309b-43e9-ab13-be07d3c8f7de.png">

The picture above is the result of doing `Fable.Core.JS.console.log (Configuration.getUnsafe "explorer.fileNesting.patterns")` when loading Ionide.

However, the drawback I see is that if the user don't want the nested feature for F# files and he try to set its configuration then the default value completed doesn't contain the default configuration from VSCode but only the ones from Ionide.

https://user-images.githubusercontent.com/4760796/224512424-f4d35e79-99eb-406f-892a-ba2e894b604f.mov

Personally, I think this is problem in VSCode and not in Ionide.

If we want, to preserve the defaults configuration then, we would need to do something similar to **Suggest gitignore**:

- Ask the user if he wants F# nesting patterns. 
- If yes
    - Retrieve the current nesting patterns settings
    - Merge with F# nesting patterns and save in the workspace settings
- If no, discard or save user choice to not suggest again


