### PR TITLE
Add "Rename file" to the solution explorer

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -208,6 +208,10 @@
         "title": "Move file down"
       },
       {
+        "command": "fsharp.explorer.renameFile",
+        "title": "Rename file"
+      },
+      {
         "command": "fsharp.explorer.removeFile",
         "title": "Remove file"
       },
@@ -922,6 +926,10 @@
           "when": "false"
         },
         {
+          "command": "fsharp.explorer.renameFile",
+          "when": "false"
+        },
+        {
           "command": "fsharp.explorer.removeFile",
           "when": "false"
         },
@@ -1200,8 +1208,13 @@
           "when": "viewItem == ionide.projectExplorer.file"
         },
         {
+          "command": "fsharp.explorer.renameFile",
+          "group": "2_action@1",
+          "when": "viewItem == ionide.projectExplorer.file"
+        },
+        {
           "command": "fsharp.explorer.removeFile",
-          "group": "1_navigation@4",
+          "group": "2_action@2",
           "when": "viewItem == ionide.projectExplorer.file"
         },
         {

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -889,7 +889,10 @@ module SolutionExplorer =
                                     return null
                                 }
                             )
-                            |> unbox
+                            |> Promise.catchEnd (fun error ->
+                                window.showErrorMessage error.Message
+                                |> ignore
+                            )
                         | _ -> undefined
                     | _ ->
                         undefined

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -630,6 +630,14 @@ module SolutionExplorer =
 
         opts.validateInput <-
             fun userInput ->
+                // Add .fs extension if not present
+                // This is to mirror the logic from the command as we don't force
+                // user to provide the extension and auto add it if needed
+                // Maxime Mangel:
+                // I am not sure if this is the best way to do it because an fsproj
+                // can have other file extensions than .fs
+                let userInput = handleUntitled userInput
+
                 let fileExist =
                     existingFiles
                     |> List.tryFind (fun file ->

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -425,3 +425,8 @@ module DTO =
             { FsProj: string
               FileVirtualPath: string
               NewFile: string }
+
+        type DotnetRenameFileRequest =
+            { FsProj: string
+              OldFileVirtualPath: string
+              NewFileName: string }

--- a/src/Core/FsProjEdit.fs
+++ b/src/Core/FsProjEdit.fs
@@ -14,6 +14,9 @@ module FsProjEdit =
     let moveFileDownPath project file =
         LanguageService.fsprojMoveFileDown project file
 
+    let renameFile project file newFileName =
+        LanguageService.fsprojRenameFile project file newFileName
+
     let removeFilePath project file =
         LanguageService.fsprojRemoveFile project file
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -448,6 +448,18 @@ Consider:
             cl.sendRequest ("fsproj/addExistingFile", req)
             |> Promise.map ignore
 
+    let fsprojRenameFile (fsproj: string) (file: string) (newFile: string) =
+        match client with
+        | None -> Promise.empty
+        | Some cl ->
+            let req: FsProj.DotnetRenameFileRequest =
+                { FsProj = fsproj
+                  OldFileVirtualPath = file
+                  NewFileName = newFile }
+
+            cl.sendRequest ("fsproj/renameFile", req)
+            |> Promise.map ignore
+
     let fsprojRemoveFile (fsproj: string) (file: string) =
         match client with
         | None -> Promise.empty


### PR DESCRIPTION
This PR needs https://github.com/fsharp/FsAutoComplete/pull/1075

This PR adds:

- Rename file to the contextual menu of the solution explorer
- Create a new group in contextual menu of a file which contains "actions on the file"
    - Rename file
    - Remove file
    
    I did that because I found that otherwise it was a bit too clamp.
- Make the file name detection mirror the logic of the commands

    If the user provide a file name without a F# extension, the commands add the `.fs` extension automatically. The validation of the user input now follow the same logic.

    Is it the correct way of doing it? Fsproj are not limited to `.fs` / F# files, so perhaps we should respect what the user provided.


https://user-images.githubusercontent.com/4760796/224574795-d553e4ed-ef24-4cc7-aed1-d8fd1064846d.mov


