### PR TITLE
Explicitly report error to the user when one of the following command fails (addFile, addExistingFile, addFileAbove, addFileBelow)

### DIFF
--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -872,7 +872,10 @@ module SolutionExplorer =
                                     let file' = handleUntitled file
                                     FsProjEdit.addFileAbove proj virtPath file'
                                 | None -> Promise.empty)
-                            |> unbox
+                            |> Promise.catchEnd (fun error ->
+                                window.showErrorMessage error.Message
+                                |> ignore
+                            )
                         | _ -> undefined
                     | _ ->
                         undefined
@@ -898,7 +901,10 @@ module SolutionExplorer =
                                     let file' = handleUntitled file
                                     FsProjEdit.addFileBelow proj virtPath file'
                                 | None -> Promise.empty)
-                            |> unbox
+                            |> Promise.catchEnd (fun error ->
+                                window.showErrorMessage error.Message
+                                |> ignore
+                            )
                         | _ -> undefined
                     | _ -> undefined
 
@@ -918,8 +924,12 @@ module SolutionExplorer =
                         | Some file ->
                             let file' = handleUntitled file
                             FsProjEdit.addFile proj file'
-                        | None -> Promise.empty)
-                    |> unbox
+                        | None -> Promise.empty
+                    )
+                    |> Promise.catchEnd (fun error ->
+                        window.showErrorMessage error.Message
+                        |> ignore
+                    )
                 | _ -> undefined)
         )
         |> context.Subscribe
@@ -950,7 +960,10 @@ module SolutionExplorer =
                             else
                                 Promise.empty
                         | None -> Promise.empty)
-                    |> unbox
+                    |> Promise.catchEnd (fun error ->
+                        window.showErrorMessage error.Message
+                        |> ignore
+                    )
                 | _ -> undefined)
         )
         |> context.Subscribe


### PR DESCRIPTION
This PR is related to https://github.com/fsharp/FsAutoComplete/pull/1076 but doesn't need it in order to be merged.

This PR improve the reported error in VSCode if the LSP server detected a problem when running the commands (addFile, addExistingFile, addFileAbove, addFileBelow) and that problem was not detected up front by Ionide.

**Old error**

https://user-images.githubusercontent.com/4760796/224756564-e5cceb3e-1036-4646-8644-4ffc8d46ea66.mp4

**New error**

https://user-images.githubusercontent.com/4760796/224756591-eeac4ac5-e3a3-4e6d-8edb-d65fad05a5e6.mp4



