### PR TITLE
Adds FSharp.fsac.cachedTypeCheckCount

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -683,6 +683,9 @@
           ],
           "description": "The set of System.Diagnostics.Activity names to watch.",
           "type": "array",
+          "items": {
+            "type": "string"
+          },
           "required": [
             "FSharp.notifications.trace"
           ]

--- a/release/package.json
+++ b/release/package.json
@@ -511,6 +511,11 @@
           "description": "Appends the \u0027--attachdebugger\u0027 argument to fsac, this will allow you to attach a debugger.",
           "type": "boolean"
         },
+        "FSharp.fsac.cachedTypeCheckCount":  {
+          "default": 200,
+          "description": "The MemoryCacheOptions.SizeLimit for caching typechecks.",
+          "type": "integer"
+        },
         "FSharp.fsac.conserveMemory": {
           "default": false,
           "description": "Configures FsAutoComplete with settings intended to reduce memory consumption. Requires restart.",


### PR DESCRIPTION
Corresponding PR: https://github.com/fsharp/FsAutoComplete/pull/1077

<img width="401" alt="image" src="https://user-images.githubusercontent.com/1490044/224882879-c1f18fbf-8cb7-4133-8444-397a1161d6ca.png">
<img width="331" alt="image" src="https://user-images.githubusercontent.com/1490044/224882959-00c4b6e2-f48a-4a77-ab67-fe4d502ae91d.png">

Also fixed up `FSharp.notifications.traceNamespaces` to have a UI and because I'm lazy I didn't make another PR :).

<img width="350" alt="image" src="https://user-images.githubusercontent.com/1490044/224885379-845e8684-7b83-4cb9-831a-7d3217190e9f.png">

