### PR TITLE
make FSharp.fsac.netcoreDllPath more ergonomic to use with multiple-TFM FSAC builds

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -542,7 +542,7 @@
         },
         "FSharp.fsac.netCoreDllPath": {
           "default": "",
-          "description": "The path to the \u0027fsautocomplete.dll\u0027, useful for debugging a self-built fsac. Requires restart.",
+          "description": "The path to the \u0027fsautocomplete.dll\u0027, a directory containing TFM-specific versions of fsautocomplete.dll, or a directory containing fsautocomplete.dll. Useful for debugging a self-built FSAC. If a DLL is specified, uses it directly. If a directory is specified and it contains TFM-specific folders (net6.0, net7.0, etc) then that directory will be probed for the best TFM to use for the current runtime. This is useful when working with a local copy of FSAC, you can point directly to the bin/Debug or bin/Release folder and it'll Just Work. Finally, if a directory is specified and there are no TFM paths, then fsautocomplete.dll from that directory is used. Requires restart.",
           "scope": "machine-overridable",
           "type": "string"
         },

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -675,26 +675,39 @@ Consider:
                     |> Option.map fst
                     |> Option.defaultWith (fun () -> Seq.last availableTFMs)
 
-            let fsacPathForTfm (tfm: string) =
-                if String.IsNullOrEmpty fsacNetcorePath then
-                    let binPath = node.path.join (VSCodeExtension.ionidePluginPath (), "bin")
+            let probePathForTFMs (basePath: string) (tfm: string) =
+                let availableTFMs =
+                    node.fs.readdirSync (!!basePath)
+                    |> Seq.filter (fun p -> p.StartsWith "net") // there are loose files in the basePath, ignore those
+                    |> Seq.map node.path.basename
 
-                    let availableTFMs =
-                        node.fs.readdirSync (!!binPath)
-                        |> Seq.filter (fun p -> p.StartsWith "net") // there are loose files in the binpath, ignore those
-                        |> Seq.map node.path.basename
+                printfn $"Available FSAC TFMs: %A{availableTFMs}"
 
-                    printfn $"Available FSAC TFMs: %A{availableTFMs}"
-
-                    if availableTFMs |> Seq.contains tfm then
-                        printfn "TFM match found"
-                        node.path.join (binPath, tfm, "fsautocomplete.dll")
-                    else
-                        // find best-matching
-                        let tfm = findBestTFM availableTFMs tfm
-                        node.path.join (binPath, tfm, "fsautocomplete.dll")
+                if availableTFMs |> Seq.contains tfm then
+                    printfn "TFM match found"
+                    node.path.join (basePath, tfm, "fsautocomplete.dll")
                 else
-                    fsacNetcorePath
+                    // find best-matching
+                    let tfm = findBestTFM availableTFMs tfm
+                    node.path.join (basePath, tfm, "fsautocomplete.dll")
+
+            let fsacPathForTfm (tfm: string) =
+                match fsacNetcorePath with
+                | null | "" ->
+                    // user didn't specify a path, so use FSAC from our extension
+                    let binPath = node.path.join (VSCodeExtension.ionidePluginPath (), "bin")
+                    probePathForTFMs binPath tfm
+                | userSpecified ->
+                    if userSpecified.EndsWith ".dll" then userSpecified else
+                    // if dir has tfm folders, probe
+                    let filesAndFolders = node.fs.readdirSync (!!userSpecified)
+                    if filesAndFolders |> Seq.exists (fun f -> (node.path.basename f).StartsWith("net") && node.fs.statSync(!!f).isDirectory())
+                    then
+                        // tfm directories found, probe this directory like we would our own bin path
+                        probePathForTFMs userSpecified tfm
+                    else
+                        // no tfm paths, try to use `fsautocomplete.dll` from this directory
+                        node.path.join (userSpecified, "fsautocomplete.dll")
 
             let tfmForSdkVersion (v: SemVer) =
                 match int v.major, int v.minor with


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c1dabe</samp>

This pull request improves the configuration and documentation of the `FSharp.fsac.netCoreDllPath` setting and refactors the logic for finding the best `fsautocomplete.dll` for the current runtime. It updates the setting description and the extension version in `release/package.json` and extracts a new function `probePathForTFMs` in `src/Core/LanguageService.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5c1dabe</samp>

> _To find the best `fsautocomplete.dll`_
> _We refactored the code to make it swell_
> _We extracted a function_
> _To probe for the TFM junction_
> _And updated the `package.json` as well_

<!--
copilot:emoji
-->

🔧📝🚀

<!--
1.  🔧 for refactoring the logic for finding the best `fsautocomplete.dll`.
2.  📝 for updating the setting description and the extension version.
3.  🚀 for improving the configuration and documentation of the extension.
-->


### WHY
<!-- author to complete -->

Implements the algorithm described [here](https://github.com/fsharp/FsAutoComplete/issues/1086#issuecomment-1475472046) for locating FSAC using the `FSharp.fsac.netcoreDllPath` property. This should make it easier for folks to test with local FSAC instances, as they can just point to the `bin/Debug` or `bin/Release` folder of the FsAutoComplete project in a clone of fsharp/fsautocomplete, and we'll Just Work. This also enables seamless working of the net6.0 version of FSAC locally built when running against a repo that's using the 7.0 runtime, as some contributors have run into.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c1dabe</samp>

*  Refactor and extract the logic for finding the best `fsautocomplete.dll` for the current runtime into a separate function `probePathForTFMs` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1853/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL678-R710))
*  Use the `probePathForTFMs` function in the `fsacPathForTfm` function to handle the cases when the user specifies a custom path for the `FSharp.fsac.netCoreDllPath` setting or when the default path is used ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1853/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL678-R710))
*  Update the description of the `FSharp.fsac.netCoreDllPath` setting in `release/package.json` to reflect the new logic and the possible values for the setting ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1853/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L545-R545))
*  Bump the version of the extension from 7.5.2 to 7.5.3 in `release/package.json` to prepare for a new release that includes the changes in this pull request ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1853/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L1655-R1655))