### PR TITLE
add addPrivateAccessModifier to configuration part of package.json

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -797,6 +797,11 @@
           "description": "Enables detection of unused declarations",
           "type": "boolean"
         },
+        "FSharp.addPrivateAccessModifier": {
+          "default": false,
+          "description": "Enables a codefix that adds a private access modifier",
+          "type": "boolean"
+        },
         "FSharp.unusedOpensAnalyzer": {
           "default": true,
           "description": "Enables detection of unused opens",


### PR DESCRIPTION
Counterpart to https://github.com/fsharp/FsAutoComplete/pull/1089
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 11c5024</samp>

Add a new extension setting `FSharp.codeFix.addPrivateModifier` to enable or disable a codefix for adding private access modifiers to F# declarations. This is part of a pull request that improves the codefix feature and fixes some bugs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 11c5024</samp>

> _`FSharp` extension_
> _Adds a new codefix option_
> _Private in autumn_

<!--
copilot:emoji
-->

:sparkles::wrench::gear:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the codefix for adding private modifiers.
2.  :wrench: This emoji represents the fixing of some issues or bugs, which are related to the codefix or the F# language service.
3.  :gear: This emoji represents the configuration or settings of the extension, which are affected by the new option.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 11c5024</samp>

* Add a new configuration option `FSharp.codeFix.addPrivateModifier` to enable or disable a codefix that adds a private access modifier to F# declarations ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1858/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R800-R804))
