### PR TITLE
Support new type return by 'fsharp/documentation' and add support for "Open documentation" link from the tooltips

### DIFF
--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -63,10 +63,10 @@ module DTO =
           Functions: string list
           Interfaces: string list
           Attributes: string list
-          Types: string list
+          DeclaredTypes: string list
           Signature: string
           Comment: string
-          Footer: string }
+          FooterLines: string list }
 
     type Error =
         {

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -248,7 +248,7 @@ Consider:
                   Position = { Line = line; Character = col } }
 
             cl.sendRequest ("fsharp/documentation", req)
-            |> Promise.map checkNotificationAndCast<Result<DocumentationDescription[][]>>
+            |> Promise.map checkNotificationAndCast<Result<DocumentationDescription>>
 
     let documentationForSymbol xmlSig assembly =
         match client with
@@ -259,7 +259,7 @@ Consider:
                   XmlSig = xmlSig }
 
             cl.sendRequest ("fsharp/documentationSymbol", req)
-            |> Promise.map checkNotificationAndCast<Result<DocumentationDescription[][]>>
+            |> Promise.map checkNotificationAndCast<Result<DocumentationDescription>>
 
     let signature (uri: Uri) line col =
         match client with
@@ -614,7 +614,10 @@ Consider:
             opts.revealOutputChannelOn <- Some Client.RevealOutputChannelOn.Never
 
             opts.initializationOptions <- Some !^(Some initOpts)
-            opts?markdown <- createObj [ "isTrusted" ==> true ]
+            opts?markdown <- createObj [
+                "isTrusted" ==> true
+                "supportHtml" ==> true
+            ]
 
             opts
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42537c4</samp>

This pull request enhances the documentation feature of the extension by using a new type for documentation responses, enabling HTML rendering in the info panel, and simplifying the logic and rendering of the panel. The changes affect the `LanguageService`, `DTO`, and `InfoPanel` modules in the `src` folder.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 42537c4</samp>

> _Sing, O Muse, of the valiant coder who refined the docs feature_
> _With skillful changes to the `DTO` and the `LanguageService` modules_
> _He stripped the `Data` field and made the `Footer` into `FooterLines`_
> _Like Hephaestus who forged the shield of Achilles with cunning art_

<!--
copilot:emoji
-->

📝🛠️🌐

<!--
1.  📝 - This emoji represents documentation or writing, and can be used to indicate the changes to the `DocumentationDescription` type and the rendering of the info panel.
2.  🛠️ - This emoji represents tools or fixing, and can be used to indicate the improvements to the logic and functionality of the info panel, as well as the reuse of existing functions.
3.  🌐 - This emoji represents the web or HTML, and can be used to indicate the changes to the language service to enable HTML rendering in the documentation panel.
-->

### WHY

This PR adds support for https://github.com/fsharp/FsAutoComplete/pull/1099

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42537c4</samp>

*  Simplify the `Panel.mapContent` function to use the new `DocumentationDescription` type and avoid duplicate logic ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1861/files?diff=unified&w=0#diff-1df05fa3bf1a54a9d9c4c617daca68036b6ef28de04a3db5ec3f300498268cfbL77-R77), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1861/files?diff=unified&w=0#diff-1df05fa3bf1a54a9d9c4c617daca68036b6ef28de04a3db5ec3f300498268cfbL88-R96))
*  Rename the `Types` field of the `DocumentationDescription` type to `DeclaredTypes` for clarity ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1861/files?diff=unified&w=0#diff-1df05fa3bf1a54a9d9c4c617daca68036b6ef28de04a3db5ec3f300498268cfbL141-R132), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1861/files?diff=unified&w=0#diff-f9255d255821b133fb806c5612f7a51ae6b1f7ef59ca1c0bfee5d76fcab1da99L66-R69))
*  Update the `LanguageService.documentation` and `LanguageService.documentationForSymbol` functions to use the new `DocumentationDescription` type and cast the response accordingly ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1861/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL251-R251), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1861/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL262-R262))
*  Add the `supportHtml` option to the markdown settings in the `LanguageService.private` function to enable HTML rendering in the documentation panel ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1861/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL617-R620))
*  Check if the panel exists before updating it with the documentation link in the `Panel.showDocumentation` function ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1861/files?diff=unified&w=0#diff-1df05fa3bf1a54a9d9c4c617daca68036b6ef28de04a3db5ec3f300498268cfbL274-R275))
