### PR TITLE
Make Adaptive server the default one

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -470,8 +470,8 @@
           "type": "string"
         },
         "FSharp.enableAdaptiveLspServer": {
-          "default": false,
-          "description": "EXPERIMENTAL. Enables Enable LSP Server based on FSharp.Data.Adaptive. This can improve stability. Requires restart.",
+          "default": true,
+          "description": "Enables Enable LSP Server based on FSharp.Data.Adaptive. This can improve stability. Requires restart.",
           "type": "boolean"
         },
         "FSharp.enableAnalyzers": {

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -625,7 +625,7 @@ Consider:
     let getOptions (c: ExtensionContext) : JS.Promise<Executable> =
         promise {
             let enableAdaptiveLspServer =
-                "FSharp.enableAdaptiveLspServer" |> Configuration.get false
+                "FSharp.enableAdaptiveLspServer" |> Configuration.get true
 
             let openTelemetryEnabled = "FSharp.openTelemetry.enabled" |> Configuration.get false
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28bd856</samp>

This pull request enables the new FSharp.Data.Adaptive language server by default for the ionide-vscode-fsharp extension. It updates the `package.json` file and the `LanguageService` module to reflect this change.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 28bd856</samp>

> _New language server_
> _`enableAdaptiveLspServer`_
> _Now the default choice_

<!--
copilot:emoji
-->

:sparkles::wrench::memo:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the new language server implementation based on FSharp.Data.Adaptive.
2.  :wrench: This emoji represents the adjustment of a configuration or setting, which is the change in the default value of the `FSharp.enableAdaptiveLspServer` option.
3.  :memo: This emoji represents the update of documentation or comments, which is the removal of the word "EXPERIMENTAL" from the description of the option.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 28bd856</samp>

* Enable the new language server based on FSharp.Data.Adaptive by default ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1865/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L473-R474), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1865/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL628-R628))
