### PR TITLE
Update SDK link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The library that powers project and script loading is [proj-info](https://github
 
 # Requirements
 
-* .NET 6.0/7.0 SDK - https://dotnet.microsoft.com/download/dotnet/5.0
+* .NET 6.0/7.0 SDK - https://dotnet.microsoft.com/download/dotnet/7.0
 
 * VS Code C# plugin - Ionide's debugging capabilities relies on the debugger provided by Omnisharp team. 
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1064264</samp>

Updated the required .NET SDK version in `README.md` to 7.0. This helps users install and use Ionide with the latest .NET release.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1064264</samp>

> _`Ionide` users_
> _update `.NET SDK` version_
> _autumn of progress_

<!--
copilot:emoji
-->

🆕🚀🔧

<!--
1.  🆕 - This emoji indicates that the .NET SDK version was updated to a new version, which is a significant change for users who want to use the latest tools and frameworks.
2.  🚀 - This emoji implies that the .NET SDK version was upgraded to a faster, more powerful, and more modern version, which is a positive change for users who want to improve their performance and productivity.
3.  🔧 - This emoji suggests that the .NET SDK version was changed to a different version, which is a technical change for users who need to adjust their settings and configurations.
-->

### WHY

README incorrectly points to .NET 5 SDK which is EOL. While .NET 6 is LTS, it seems reasonable to me to point people to the latest Standard Term Support (i.e. .NET 7) but I could be swayed either way.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1064264</samp>

* Update the .NET SDK version requirement to 7.0 ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1866/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26)) in `README.md` to match the latest .NET release
