### PR TITLE
Fix source maps for extension debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,7 @@
 			"sourceMaps": true,
 			"outFiles": [
 				"${workspaceFolder}/release/*.js",
+				"${workspaceFolder}/out/**/*.js",
 				"!**/node_modules/**"
 			],
 		},
@@ -34,6 +35,7 @@
 			"trace": true,
 			"outFiles": [
 				"${workspaceFolder}/release/*.js",
+				"${workspaceFolder}/out/**/*.js",
 				"!**/node_modules/**"
 			],
 		},
@@ -53,6 +55,7 @@
 			"trace": true,
 			"outFiles": [
 				"${workspaceFolder}/release/*.js",
+				"${workspaceFolder}/out/**/*.js",
 				"!**/node_modules/**"
 			],
 		},
@@ -65,7 +68,12 @@
 			],
 			"stopOnEntry": false,
 			"request": "launch",
-			"sourceMaps": true
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceFolder}/release/*.js",
+				"${workspaceFolder}/out/**/*.js",
+				"!**/node_modules/**"
+			],
 		},
 	]
 }


### PR DESCRIPTION
## Motivation

I've been looking at some contributions, but was having a hard time locating errors because stack traces were relative to the js output and breakpoints weren't mapping.

This PR fixes source maps to get breakpoints working. Unfortunately, it does not also fix stack trace links.

## What changed

I noticed that `/release/fsharp.js.map` had incorrect relative paths to js files in the /out folder (probably because of copy during build).
So I added the out folder to the launch.json setting for discovering source files.

```jsonc
"outFiles": [
  "${workspaceFolder}/release/*.js",
  "${workspaceFolder}/out/**/*.js", // <-- this here
  "!**/node_modules/**"
],
```

## Tradeoffs / Gotchas

This fix gets breakpoints working for all four launch configurations, but "Build (watch) and Launch Extension" and "Launch Only" backed by watch will not adjust to changes in the source file. The debugger will still stop at the breakpoint, but the code shown versus the code actually executed appears to be out of sync if the file has been modified.

