### PR TITLE
fix debug launch

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 7.5.4 - 07.05.2023
+
+* Fix debug settings to not override coreclr from omnisharp.
+* Update Ionide TextMate grammar to pick up some fixes (Thanks @jkillingsworth!)
+
 ### 7.5.3 - 21.04.2023
 
 * Update to FSAC 0.59.6 to get all the delightful new features and fixes. You can check the release notes for [0.59.6](https://github.com/fsharp/FsAutoComplete/releases/tag/v0.59.5).

--- a/release/package.json
+++ b/release/package.json
@@ -826,12 +826,6 @@
       "title": "F#",
       "type": "object"
     },
-    "debuggers": [
-      {
-        "label": "Ionide LaunchSettings",
-        "type": "coreclr"
-      }
-    ],
     "grammars": [
       {
         "language": "fsharp",

--- a/release/package.json
+++ b/release/package.json
@@ -6,7 +6,9 @@
   },
   "activationEvents": [
     "onCommand:workbench.action.tasks.runTask",
+    "onDebugInitialConfigurations:coreclr",
     "onDebugDynamicConfigurations:coreclr",
+    "onDebugResolve:coreclr",
     "workspaceContains:**/*.fs",
     "workspaceContains:**/*.fsproj",
     "workspaceContains:**/*.fsx",

--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -337,14 +337,14 @@ module Debugger =
             override x.provideDebugConfigurations(folder: option<WorkspaceFolder>, token: option<CancellationToken>) =
                 let generate () =
                     promise {
-                        logger.Info $"Evaluating launch settings configurations for workspace '%A{folder}'"
+                        logger.Info("Evaluating launch settings configurations for %O", folder)
                         let projects = Project.getLoaded ()
                         let! msbuildTasks = tasks.fetchTasks (msbuildTasksFilter)
 
                         let tasks =
                             projects
-                            |> Seq.collect (fun (p: Project) ->
-                                seq {
+                            |> List.collect (fun (p: Project) ->
+                                [
                                     let projectFile = node.path.basename p.Project
 
                                     let buildTaskForProject =
@@ -360,16 +360,14 @@ module Debugger =
                                     match defaultConfigForProject (p, buildTaskForProject) with
                                     | Some p -> yield p
                                     | None -> ()
-                                })
+                                ])
 
                         return ResizeArray tasks
                     }
 
-                generate ()
-                |> Promise.map Some
-                |> Promise.toThenable
-                |> U2.Case2
-                |> ProviderResult.Some
+                generate () // this bix/unbox is a hack because JS types
+                |> box
+                |> unbox
 
             override x.resolveDebugConfiguration
                 (
@@ -377,7 +375,7 @@ module Debugger =
                     debugConfiguration: DebugConfiguration,
                     token: option<CancellationToken>
                 ) =
-                logger.Info $"Evaluating launch settings configurations for workspace2 '{folder}'"
+                logger.Info("Resolving launch settings configuration %O for %O", debugConfiguration, folder)
                 ProviderResult.Some(U2.Case1 debugConfiguration)
 
             override x.resolveDebugConfigurationWithSubstitutedVariables
@@ -386,7 +384,7 @@ module Debugger =
                     debugConfiguration: DebugConfiguration,
                     token: option<CancellationToken>
                 ) =
-                logger.Info $"Evaluating launch settings configurations for workspace3 '{folder}'"
+                logger.Info("Resolving subsituted launch settings configuration %O for %O", debugConfiguration, folder)
                 ProviderResult.Some(U2.Case1 debugConfiguration) }
 
     let activate (c: ExtensionContext) =


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b62aaa</samp>

This pull request enhances the debugging experience for F# projects in the ionide-vscode-fsharp extension. It updates the activation and debugging logic to use the `coreclr` debugger type, fixes some bugs related to the debug settings and the syntax highlighting, and improves the logging and type compatibility of the `Debugger` module. It also updates the `RELEASE_NOTES.md` file to document these changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8b62aaa</samp>

> _We are the F# warriors, we debug with coreclr_
> _We activate and launch our code, we resolve our variables_
> _We log and box and unbox, we format with node.js_
> _We fix the bugs and highlight the syntax, we write the release notes_

<!--
copilot:emoji
-->

🐛🚀📝

<!--
1.  🐛 for bug fixes
2.  🚀 for performance improvements
3.  📝 for documentation updates
-->

### WHY
Instead of declaring that Ionide knew how to handle 'coreclr' launch types, all we really needed to do was have our debug adapter launch when 'coreclr' launch types are being queried. This fixes the breaking behavior for users.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b62aaa</samp>

*  Add activation events for coreclr debugger in `package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1871/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L9-R11))
*  Remove unused debuggers section from `package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1871/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L829-L834))
*  Update logging statements in `Debugger.fs` to use node.js console formatting syntax ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1871/files?diff=unified&w=0#diff-5cd78ecc280ba189382f47bebe9e3eff8a6c6e86439fdf867f4be407b9ef728fL340-R340), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1871/files?diff=unified&w=0#diff-5cd78ecc280ba189382f47bebe9e3eff8a6c6e86439fdf867f4be407b9ef728fL380-R378), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1871/files?diff=unified&w=0#diff-5cd78ecc280ba189382f47bebe9e3eff8a6c6e86439fdf867f4be407b9ef728fL389-R387))
*  Replace Seq.collect with List.collect in `Debugger.fs` for performance and readability ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1871/files?diff=unified&w=0#diff-5cd78ecc280ba189382f47bebe9e3eff8a6c6e86439fdf867f4be407b9ef728fL346-R347))
*  Apply hack to convert promise to thenable in `Debugger.fs` to workaround type mismatch issue ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1871/files?diff=unified&w=0#diff-5cd78ecc280ba189382f47bebe9e3eff8a6c6e86439fdf867f4be407b9ef728fL363-R370))
*  Add release notes for version 7.5.4 in `RELEASE_NOTES.md` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1871/files?diff=unified&w=0#diff-68d24fa81558aae3d8c59e2aa57a4fa719ea3b04d7fa14beff45f16f00858f50R1-R5))

![telplin-debug](https://user-images.githubusercontent.com/573979/236723422-65a2b9e7-166d-43d7-bb1a-258cd4c0ee84.gif)

