### PR TITLE
Add netcoredbg

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ The LSP that powers language features is [FSAutoComplete](https://github.com/fsh
 
 The library that powers project and script loading is [proj-info](https://github.com/ionide/proj-info)
 
+You find a version of this plugin pre-packaged with the FOSS debugger from Samsung [here](https://open-vsx.org/extension/Ionide/Ionide-fsharp)
+
 # Requirements
 
 * .NET 6.0/7.0 SDK - https://dotnet.microsoft.com/download/dotnet/7.0
 
-* VS Code C# plugin - Ionide's debugging capabilities relies on the debugger provided by Omnisharp team. 
+* VS Code C# plugin - Ionide's debugging capabilities rely on either the [Omnisharp](https://github.com/OmniSharp/omnisharp-vscode) debugger or [netcoredbg](https://github.com/muhammadsammy/free-omnisharp-vscode).
 
 ## Features
 


### PR DESCRIPTION
This also fixes the incorrect statement about Omnisharp being used for this page: https://open-vsx.org/extension/Ionide/Ionide-fsharp

(Since they are synced/use the same build pipeline)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b6ddfe</samp>

This pull request updates the `README.md` file to add a link to the open-vsx version of the plugin that uses the netcoredbg debugger and to fix a grammatical error. The goal is to provide users with more information and options for debugging F# code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6b6ddfe</samp>

> _`open-vsx` link_
> _debug with netcoredbg_
> _fall leaves are falling_

<!--
copilot:emoji
-->

🔗🐞📝

<!--
1.  🔗 - This emoji represents the addition of a link to another resource or website. It can be used to indicate that the change provides more information or options for the users.
2. 🐞 - This emoji represents debugging or fixing bugs. It can be used to indicate that the change improves the debugging capabilities or experience for the users.
3. 📝 - This emoji represents editing or writing documentation. It can be used to indicate that the change improves the grammar, style, or clarity of the documentation.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b6ddfe</samp>

* Add a link to the open-vsx version of the plugin that uses the netcoredbg debugger instead of the Omnisharp one ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1872/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R30))
* Fix a grammatical error in the sentence about the debugging capabilities ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1872/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R30))
