### PR TITLE
Don't type test against interfaces

### DIFF
--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -420,8 +420,7 @@ module Fsi =
             let! profile =
                 match provider.provideTerminalProfile (ctok) with
                 | None -> promise.Return None
-                | Some(U2.Case1 options) -> promise.Return(Some options)
-                | Some(U2.Case2 work) -> Promise.ofThenable work
+                | Some work -> work |> Promise.ofMaybeThenable Some
 
             let profile =
                 match profile with
@@ -431,10 +430,7 @@ module Fsi =
 
                     failwith "unable to spawn FSI"
 
-            let terminal =
-                match profile.options with
-                | U2.Case1 opts -> window.createTerminal opts
-                | U2.Case2 opts -> window.createTerminal opts
+            let terminal = window.createTerminal !!profile.options
 
             // Wait for the new terminal to be ready
             let! newTerminal =

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -442,8 +442,10 @@ module SolutionExplorer =
                 ti.id <-
                     let label (ti: TreeItem) =
                         match ti.label with
-                        | Some(U2.Case1 l) -> l
-                        | Some(U2.Case2 l) -> l.label
+                        | Some(l) ->
+                            match box l with
+                            | :? string as l -> l
+                            | l -> (l :?> TreeItemLabel).label
                         | None -> ""
 
                     match element with

--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -284,6 +284,14 @@ module Promise =
     let ofThenable (t: Thenable<'t>) : JS.Promise<'t> = unbox (box t)
     let toThenable (p: JS.Promise<'t>) : Thenable<'t> = unbox (box p)
 
+    [<Emit("typeof ($0 || {}).then === 'function'")>]
+    let isThenable (x: obj) : bool = jsNative
+
+    let ofMaybeThenable (ifValue: 'T1 -> 'T2) (t: U2<'T1, Thenable<'T2>>) : JS.Promise<'T2> =
+        match box t with
+        | t when isThenable t -> unbox t |> ofThenable
+        | t -> unbox t |> ifValue |> Promise.lift
+
     let onSuccess = Promise.tap
 
     // source: https://github.com/ionide/ionide-vscode-helpers/blob/5e4c28c79ed565497cd481fac2f22ee2d8d28406/src/Helpers.fs#L92


### PR DESCRIPTION
See this comment: https://github.com/fable-compiler/Fable/issues/3443#issuecomment-1549617520

Fable converts pattern matching with erased unions (like `U2`) to type testing, but this doesn't work all the time. For example, it's not possible to type test against interfaces because they are not actually declared in the final JS code. Ideally we should use `Choice` instead of an erased union in those cases but here the values come from VS Code so I've replaced the pattern matching with other solutions to prevent the compilation warnings and ensure expected behavior.