### PR TITLE
Update release package.json

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -70,7 +70,7 @@
         "defaults": {
           "dark": "#FFCC00",
           "highContrast": "#FFFF00",
-          "light": "#FFCC00"
+          "light": "#7c6400"
         },
         "description": "Text colors for warnings shown in the status bar",
         "id": "fsharp.statusBarWarnings"


### PR DESCRIPTION


### WHAT
Update the text color for warnings shown in the status bar when using a light theme. 

### WHY
Previously it used #ffcc00, which looks fine with a dark theme, but is very difficult to read when you have a light theme. This pr changes the warning text color for a light theme to #7c6400.

### HOW
Previously it looked like this when using a light theme:

![2023-06-06_10-45](https://github.com/ionide/ionide-vscode-fsharp/assets/6868833/41357f58-9b11-44e9-b30f-06eaf5bdb808)

With this change it now looks like this when using a light theme:

![2023-06-06_10-48](https://github.com/ionide/ionide-vscode-fsharp/assets/6868833/de57c6b0-95cc-4b02-b2e6-9372d40ff710)
