### PR TITLE
release notes and FSAC bump for 7.6.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### 7.6.0 - 14.06.2023
 
 * Updates FSAC to 0.60.0, which updates the compiler services to match .NET SDK 7.0.300, and includes a helpful XMLDoc generation codefix. Check out the [release notes](https://github.com/fsharp/FsAutoComplete/releases/tag/v0.60.0) for more details.
+* Includes fixes to the syntax highlighting from @jkillingsworth for constructor parens, the `new` keyword, access modifiers, arrow coloration, `:` in abstract member definitions, `()` in unit literals, and more!
 
 ### 7.5.4 - 07.05.2023
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 7.6.0 - 14.06.2023
+
+* Updates FSAC to 0.60.0, which updates the compiler services to match .NET SDK 7.0.300, and includes a helpful XMLDoc generation codefix. Check out the [release notes](https://github.com/fsharp/FsAutoComplete/releases/tag/v0.60.0) for more details.
+
 ### 7.5.4 - 07.05.2023
 
 * Fix debug settings to not override coreclr from omnisharp.

--- a/paket.lock
+++ b/paket.lock
@@ -242,4 +242,4 @@ STORAGE: PACKAGES
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    fsautocomplete (0.59.6)
+    fsautocomplete (0.60)

--- a/paket.lock
+++ b/paket.lock
@@ -38,7 +38,7 @@ NUGET
       FSharp.Core (>= 4.7.2)
 GIT
   remote: https://github.com/ionide/ionide-fsgrammar.git
-     (f7f89b4138b482beb81b12348e6bc170bb7693d4)
+     (71b1ead8c99715f6c994115ebab7ee4a14cf0c59)
 GITHUB
   remote: ionide/ionide-vscode-helpers
     src/Fable.Import.Showdown.fs (7da920c71e4f94240a55aabb555327ebef4b653d)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5b7176</samp>

Update FSAC dependency and release notes. This change improves the F# language services and adds a new codefix for documentation comments.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c5b7176</samp>

> _`ionide` updates_
> _FSAC brings new features_
> _autumn of bug fixes_

<!--
copilot:emoji
-->

:sparkles::bug::memo:

<!--
1.  :sparkles: This emoji is often used to indicate new features or enhancements, and in this case it reflects the new capabilities of the updated FSAC, such as improved type checking, signature help, and code formatting.
2. :bug: This emoji is commonly used to signify bug fixes or resolved issues, and in this case it corresponds to the various bug fixes that the FSAC update brings, such as fixing incorrect errors, crashes, and performance problems.
3. :memo: This emoji is typically used to denote documentation or comments, and in this case it relates to the codefix for generating XML documentation comments, which helps users write better and more consistent documentation for their F# code.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5b7176</samp>

*  Add a new section for version 7.6.0 in the release notes ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1885/files?diff=unified&w=0#diff-68d24fa81558aae3d8c59e2aa57a4fa719ea3b04d7fa14beff45f16f00858f50R1-R4))
