### PR TITLE
Adds exclusion config for analyzers

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -758,6 +758,20 @@
           "description": "Enables detection of cases when names of functions and values can be simplified",
           "type": "boolean"
         },
+        "FSharp.simplifyNameAnalyzerExclusions": {
+          "default": [
+            ".*\\.g\\.fs",
+            ".*\\.cg\\.fs"
+          ],
+          "description": "A set of regex patterns to exclude from the simplify name analyzer",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "required": [
+            "FSharp.simplifyNameAnalyzer"
+          ]
+        },
         "FSharp.smartIndent": {
           "default": false,
           "description": "Enables smart indent feature",
@@ -799,6 +813,20 @@
           "description": "Enables detection of unused declarations",
           "type": "boolean"
         },
+        "FSharp.unusedDeclarationsAnalyzerExclusions": {
+          "default": [
+            ".*\\.g\\.fs",
+            ".*\\.cg\\.fs"
+          ],
+          "description": "A set of regex patterns to exclude from the unused declarations analyzer",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "required": [
+            "FSharp.unusedDeclarationsAnalyzer"
+          ]
+        },
         "FSharp.addPrivateAccessModifier": {
           "default": false,
           "description": "Enables a codefix that adds a private access modifier",
@@ -808,6 +836,21 @@
           "default": true,
           "description": "Enables detection of unused opens",
           "type": "boolean"
+        },
+        
+        "FSharp.unusedOpensAnalyzerExclusions": {
+          "default": [
+            ".*\\.g\\.fs",
+            ".*\\.cg\\.fs"
+          ],
+          "description": "A set of regex patterns to exclude from the unused opens analyzer",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "required": [
+            "FSharp.unusedOpensAnalyzer"
+          ]
         },
         "FSharp.verboseLogging": {
           "default": false,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e707e0</samp>

Add configuration options to exclude files from analyzers. Update `./release/package.json` formatting.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5e707e0</samp>

> _If you use the FSharp extension_
> _You might want some more customization_
> _To exclude some files_
> _From the analyzers' eyes_
> _You can use regex for exclusion_

<!--
copilot:emoji
-->

:sparkles::wrench::page_facing_up:

<!--
1.  :sparkles: - This emoji represents the addition of new features or functionality, which is the case for the new configuration options.
2.  :wrench: - This emoji represents the improvement or adjustment of existing features or functionality, which is the case for the regex-based exclusion logic.
3.  :page_facing_up: - This emoji represents the addition or modification of documentation, which is the case for the updated `./release/package.json` file.
-->

### WHY

[Corresponding PR on FSAC](https://github.com/fsharp/FsAutoComplete/pull/1120)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e707e0</samp>

*  Add configuration options to exclude files from analyzers ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1887/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R761-R774), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1887/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R816-R829), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1887/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R840-R854))
* Add newline at the end of `package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1887/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L1662-R1705))
