### PR TITLE
force roll forward when discovered .NET version is greater than FSAC TFM

### DIFF
--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -698,7 +698,7 @@ Consider:
                    stat.isDirectory ()
 
             /// locates the FSAC dll and TFM for that dll given a host TFM
-            let fsacPathForTfm (tfm: string): string * string =
+            let fsacPathForTfm (tfm: string) : string * string =
                 match fsacNetcorePath with
                 | null
                 | "" ->
@@ -707,7 +707,7 @@ Consider:
                     probePathForTFMs binPath tfm
                 | userSpecified ->
                     if userSpecified.EndsWith ".dll" then
-                        let tfm = node.path.basename(node.path.dirname userSpecified)
+                        let tfm = node.path.basename (node.path.dirname userSpecified)
                         tfm, userSpecified
                     else
                         // if dir has tfm folders, probe
@@ -722,7 +722,7 @@ Consider:
                             probePathForTFMs userSpecified tfm
                         else
                             // no tfm paths, try to use `fsautocomplete.dll` from this directory
-                            let tfm = node.path.basename(node.path.dirname userSpecified)
+                            let tfm = node.path.basename (node.path.dirname userSpecified)
                             tfm, node.path.join (userSpecified, "fsautocomplete.dll")
 
             let tfmForSdkVersion (v: SemVer) =
@@ -764,19 +764,16 @@ Consider:
                             |> Option.defaultValue false
 
                         let shouldApplyImplicitRollForward =
-                            not (hasUserFxVersion || hasUserRollForward)
-                            && sdkTfm <> fsacTfm // if the SDK doesn't match one of our FSAC TFMs, then we're in compat mode
+                            not (hasUserFxVersion || hasUserRollForward) && sdkTfm <> fsacTfm // if the SDK doesn't match one of our FSAC TFMs, then we're in compat mode
 
-                        let args =
-                            userDotnetArgs
+                        let args = userDotnetArgs
 
                         let envVariables =
                             [ if shouldApplyImplicitRollForward then
-                                "DOTNET_ROLL_FORWARD", box "LatestMajor"
+                                  "DOTNET_ROLL_FORWARD", box "LatestMajor"
                               match sdkVersion.prerelease with
                               | null -> ()
-                              | pres when pres.Count > 0 ->
-                                  "DOTNET_ROLL_FORWARD_TO_PRERELEASE", box "true"
+                              | pres when Seq.length pres > 0 -> "DOTNET_ROLL_FORWARD_TO_PRERELEASE", box 1
                               | _ -> () ]
 
                         return args, envVariables, fsacPath

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -207,7 +207,7 @@ Consider:
         }
 
     /// runs `dotnet --version` in the current rootPath to determine the resolved sdk version from the global.json file.
-    let runtimeVersion () =
+    let sdkVersion () =
         promise {
             let! dotnet = tryFindDotnet ()
 
@@ -683,11 +683,11 @@ Consider:
 
                 if availableTFMs |> Seq.contains tfm then
                     printfn "TFM match found"
-                    node.path.join (basePath, tfm, "fsautocomplete.dll")
+                    tfm, node.path.join (basePath, tfm, "fsautocomplete.dll")
                 else
                     // find best-matching
                     let tfm = findBestTFM availableTFMs tfm
-                    node.path.join (basePath, tfm, "fsautocomplete.dll")
+                    tfm, node.path.join (basePath, tfm, "fsautocomplete.dll")
 
             let isNetFolder (folder: string) =
                 printfn $"checking folder %s{folder}"
@@ -697,7 +697,8 @@ Consider:
                 && let stat = node.fs.statSync (!!folder) in
                    stat.isDirectory ()
 
-            let fsacPathForTfm (tfm: string) =
+            /// locates the FSAC dll and TFM for that dll given a host TFM
+            let fsacPathForTfm (tfm: string): string * string =
                 match fsacNetcorePath with
                 | null
                 | "" ->
@@ -706,7 +707,8 @@ Consider:
                     probePathForTFMs binPath tfm
                 | userSpecified ->
                     if userSpecified.EndsWith ".dll" then
-                        userSpecified
+                        let tfm = node.path.basename(node.path.dirname userSpecified)
+                        tfm, userSpecified
                     else
                         // if dir has tfm folders, probe
                         let filesAndFolders =
@@ -720,7 +722,8 @@ Consider:
                             probePathForTFMs userSpecified tfm
                         else
                             // no tfm paths, try to use `fsautocomplete.dll` from this directory
-                            node.path.join (userSpecified, "fsautocomplete.dll")
+                            let tfm = node.path.basename(node.path.dirname userSpecified)
+                            tfm, node.path.join (userSpecified, "fsautocomplete.dll")
 
             let tfmForSdkVersion (v: SemVer) =
                 match int v.major, int v.minor with
@@ -732,64 +735,51 @@ Consider:
 
             let discoverDotnetArgs () =
                 promise {
-                    let! (rollForwardArgs, necessaryEnvVariables, fsacPath) =
-                        promise {
-                            let! sdkVersionAtRootPath = runtimeVersion ()
 
-                            match sdkVersionAtRootPath with
-                            | Error e ->
-                                printfn $"FSAC (NETCORE): {e}"
-                                return [], [], ""
-                            | Ok v ->
-                                printfn "Parsed SDK version at root path: %s" v.raw
-                                let tfm = tfmForSdkVersion v
-                                printfn "Parsed SDK version to tfm: %s" tfm
-                                let fsacPath = fsacPathForTfm tfm
-                                printfn "Parsed TFM to fsac path: %s" fsacPath
-                                return [], [], fsacPath
-                        // if v.major >= 6.0 then
-                        //     // when we run on a sdk higher than 6.x (aka what FSAC is currently built/targeted for),
-                        //     // we have to tell the runtime to allow it to actually run on that runtime (instead of presenting 6.x as 5.x)
-                        //     // in order for msbuild resolution to work
-                        //     let args = [ "--roll-forward"; "LatestMajor" ]
+                    let! sdkVersionAtRootPath = sdkVersion ()
 
-                        //     let envs =
-                        //         if v.prerelease <> null || v.prerelease.Count > 0 then
-                        //             [ "DOTNET_ROLL_FORWARD_TO_PRERELEASE", box 1 ]
-                        //         else
-                        //             []
+                    match sdkVersionAtRootPath with
+                    | Error e ->
+                        printfn $"Error finding dotnet version: {e}"
+                        return failwith "Error finding dotnet version, do you have dotnet installed and on the PATH?"
+                    | Ok sdkVersion ->
+                        printfn "Parsed SDK version at root path: %s" sdkVersion.raw
+                        let sdkTfm = tfmForSdkVersion sdkVersion
+                        printfn "Parsed SDK version to tfm: %s" sdkTfm
+                        let fsacTfm, fsacPath = fsacPathForTfm sdkTfm
+                        printfn "Parsed TFM to fsac path: %s" fsacPath
 
-                        //     return args, envs, fsacPath
-                        // else
-                        //     return [], [], fsacPath
-                        }
+                        let userDotnetArgs = "FSharp.fsac.dotnetArgs" |> Configuration.get [||]
 
-                    let userDotnetArgs = "FSharp.fsac.dotnetArgs" |> Configuration.get [||]
+                        let hasUserRollForward =
+                            userDotnetArgs
+                            |> Array.tryFindIndex (fun a -> a = "--roll-forward")
+                            |> Option.map (fun _ -> true)
+                            |> Option.defaultValue false
 
-                    let hasUserRollForward =
-                        userDotnetArgs
-                        |> Array.tryFindIndex (fun a -> a = "--roll-forward")
-                        |> Option.map (fun _ -> true)
-                        |> Option.defaultValue false
+                        let hasUserFxVersion =
+                            userDotnetArgs
+                            |> Array.tryFindIndex (fun a -> a = "--fx-version")
+                            |> Option.map (fun _ -> true)
+                            |> Option.defaultValue false
 
-                    let hasUserFxVersion =
-                        userDotnetArgs
-                        |> Array.tryFindIndex (fun a -> a = "--fx-version")
-                        |> Option.map (fun _ -> true)
-                        |> Option.defaultValue false
+                        let shouldApplyImplicitRollForward =
+                            not (hasUserFxVersion || hasUserRollForward)
+                            && sdkTfm <> fsacTfm // if the SDK doesn't match one of our FSAC TFMs, then we're in compat mode
 
-                    let shouldApplyImplicitRollForward = not (hasUserFxVersion || hasUserRollForward)
+                        let args =
+                            userDotnetArgs
 
-                    let args =
-                        [ if shouldApplyImplicitRollForward then
-                              yield! rollForwardArgs
-                          yield! userDotnetArgs ]
+                        let envVariables =
+                            [ if shouldApplyImplicitRollForward then
+                                "DOTNET_ROLL_FORWARD", box "LatestMajor"
+                              match sdkVersion.prerelease with
+                              | null -> ()
+                              | pres when pres.Count > 0 ->
+                                  "DOTNET_ROLL_FORWARD_TO_PRERELEASE", box "true"
+                              | _ -> () ]
 
-                    let envVariables =
-                        [ if shouldApplyImplicitRollForward then
-                              yield! necessaryEnvVariables ]
-
-                    return args, envVariables, fsacPath
+                        return args, envVariables, fsacPath
                 }
 
             let spawnNetCore dotnet : JS.Promise<Executable> =
@@ -803,7 +793,7 @@ Consider:
                           if parallelReferenceResolution then
                               yield "FCS_ParallelReferenceResolution", box "true" ]
 
-                    printfn $"FSAC (NETCORE): '%s{fsacPath}'"
+                    printfn $"""FSAC (NETCORE): '%s{fsacPath}'"""
 
                     let exeOpts = createEmpty<ExecutableOptions>
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e108e17</samp>

This pull request enhances the compatibility and reliability of the F# language service by improving the fsautocomplete.dll launching logic. It uses the TFMs of the dotnet SDK and the fsautocomplete.dll to determine the best roll-forward policy and arguments. It also refactors and cleans up some code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e108e17</samp>

> _`fsautocomplete`_
> _finds and launches better now_
> _with new `sdkVersion`_

<!--
copilot:emoji
-->

🛠️🚀🆕

<!--
1.  🛠️ - This emoji represents the improvement of the logic and the simplification of the code, as well as the fixing of some printing issues.
2. 🚀 - This emoji represents the enhancement of the performance and reliability of the F# language service, by launching the fsautocomplete.dll with the correct dotnet SDK and arguments.
3. 🆕 - This emoji represents the addition of new features, such as returning and comparing the TFMs of the dotnet SDK and the fsautocomplete.dll, and applying the appropriate roll-forward policy and arguments.
-->

### WHY
When running against a .NET 8 SDK, we _can_ use the net7.0 binaries, but we _must_ roll forward to the more recent Runtime. This is because without this roll forward, if the system has 7.0 runtimes installed the .NET host will prefer using those binaries.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e108e17</samp>

*  Rename `runtimeVersion` to `sdkVersion` to better reflect its purpose ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1889/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL210-R210))
*  Modify `probePathForTFMs` to return TFM and path to `fsautocomplete.dll` for each TFM ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1889/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL686-R690))
*  Annotate `fsacPathForTfm` with type signature of `string * string` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1889/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL700-R701))
*  Extract TFM from user-specified `fsautocomplete.dll` path if it ends with ".dll" ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1889/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL709-R711))
*  Extract TFM from user-specified directory path if it does not have TFM folders ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1889/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL723-R726))
*  Refactor `discoverDotnetArgs` to simplify logic of finding SDK version, FSAC TFM and path, and roll-forward arguments and environment variables ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1889/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL735-R782))
*  Use triple-quoted string literal for printing `fsautocomplete.dll` path in `spawnNetCore` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1889/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL806-R796))
