### PR TITLE
Adds sourcetext setting

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -548,6 +548,15 @@
           "scope": "machine-overridable",
           "type": "string"
         },
+        
+        "FSharp.fsac.sourceTextImplementation": {
+          "default": "NamedText",
+          "description": "EXPERIMENTAL. Enables the use of a new source text implementation. This may have better memory characteristics. Requires restart.",
+          "enum": [
+            "NamedText",
+            "RoslynSourceText"
+          ]
+        },
         "FSharp.fsac.parallelReferenceResolution": {
           "default": false,
           "description": "EXPERIMENTAL: Speed up analyzing of projects in parallel. Requires restart.",

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -645,6 +645,8 @@ Consider:
 
             let verbose = "FSharp.verboseLogging" |> Configuration.get false
 
+            let sourceText = "FSharp.fsac.sourceTextImplementation" |> Configuration.get "NamedText"
+
             /// given a set of tfms and a target tfm, find the first of the set that satisfies the target.
             /// if no target is found, use the 'latest' tfm
             /// e.g. [net6.0, net7.0] + net8.0 -> net7.0
@@ -839,6 +841,7 @@ Consider:
                           if fsacSilencedLogs <> null && fsacSilencedLogs.Length > 0 then
                               yield "--filter"
                               yield! fsacSilencedLogs
+                          yield $"--source-text-factory={sourceText}"
                           match c.storageUri with
                           | Some uri ->
                               let storageDir = uri.fsPath


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3bdb122</samp>

This pull request adds a new experimental feature to the extension that allows users to select a different source text implementation for the F# language server. It updates the `package.json` file and the `LanguageService` module to support this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3bdb122</samp>

> _The F# language server is great_
> _But sometimes it can be too late_
> _To update the text_
> _So they added a flex_
> _With a new option to change its state_

<!--
copilot:emoji
-->

:sparkles::wrench::page_facing_up:

<!--
1.  :sparkles: - This emoji is often used to indicate the addition of a new feature or enhancement, which is the case for the experimental option for the source text implementation.
2. :wrench: - This emoji is often used to indicate the adjustment of a configuration or setting, which is the case for the new configuration option for choosing the source text implementation.
3. :page_facing_up: - This emoji is often used to indicate the modification of a document or file, which is the case for the newline added at the end of the `package.json` file.
-->

### WHY

https://github.com/fsharp/FsAutoComplete/pull/1123

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3bdb122</samp>

*  Add a new configuration option for choosing the source text implementation of the F# language server ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1890/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R551-R559))
*  Pass the value of the new option to the language server process as a command line argument ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1890/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befR648-R649), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1890/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befR844))
*  Add a newline at the end of `package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1890/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L1662-R1671))
