### PR TITLE
Extract shared line lens and pipeline hint code

### DIFF
--- a/src/Components/LineLens.fs
+++ b/src/Components/LineLens.fs
@@ -146,6 +146,6 @@ let private lineLensDecorationUpdate: LineLens2.DecorationUpdate =
 
 
 let createLineLens () =
-    LineLens2.LineLens(LineLensDecorations.decorationType, lineLensDecorationUpdate, LineLensConfig.getConfig)
+    LineLens2.LineLens("LineLens",lineLensDecorationUpdate, LineLensConfig.getConfig)
 
 let Instance = createLineLens ()

--- a/src/Components/LineLens.fs
+++ b/src/Components/LineLens.fs
@@ -7,6 +7,7 @@ open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 open Fable.Core.JsInterop
 open DTO
+open LineLens2
 
 type Number = float
 
@@ -25,17 +26,13 @@ module LineLensConfig =
 
     let private parseEnabledMode (s: string) =
         match s.ToLowerInvariant() with
-        | "never" -> Never
-        | "always" -> Always
+        | "never" -> false
+        | "always" -> true
         | "replacecodelens"
-        | _ -> ReplaceCodeLens
+        | _ -> true
 
-    type LineLensConfig =
-        { enabled: EnabledMode; prefix: string }
 
-    let defaultConfig =
-        { enabled = ReplaceCodeLens
-          prefix = " //  " }
+    let defaultConfig = { enabled = true; prefix = " //  " }
 
     let private themeRegex = Regex("\s*theme\((.+)\)\s*")
 
@@ -48,104 +45,8 @@ module LineLensConfig =
         { enabled = cfg.get ("FSharp.lineLens.enabled", "replacecodelens") |> parseEnabledMode
           prefix = cfg.get ("FSharp.lineLens.prefix", defaultConfig.prefix) }
 
-    let isEnabled conf =
-        match conf.enabled with
-        | Always -> true
-        | ReplaceCodeLens -> true
-        | _ -> false
-
-module Documents =
-
-    type Cached =
-        {
-            /// vscode document version that was parsed
-            version: Number
-            /// Decorations
-            decorations: ResizeArray<DecorationOptions>
-            /// Text editors where the decorations are shown
-            textEditors: ResizeArray<TextEditor>
-        }
-
-    type DocumentInfo =
-        {
-            /// Full uri of the document
-            uri: Uri
-            /// Current decoration cache
-            cache: Cached option
-        }
-
-    type Documents = Dictionary<Uri, DocumentInfo>
-
-    let inline create () = Documents()
-
-    let inline tryGet uri (documents: Documents) = documents.TryGet uri
-
-    let inline getOrAdd uri (documents: Documents) =
-        match tryGet uri documents with
-        | Some x -> x
-        | None ->
-            let value = { uri = uri; cache = None }
-            documents.Add(uri, value)
-            value
-
-    let inline set uri value (documents: Documents) = documents.[uri] <- value
-
-    let update info (decorations: ResizeArray<DecorationOptions>) version (documents: Documents) =
-        let updated =
-            { info with
-                cache =
-                    Some
-                        { version = version
-                          decorations = decorations
-                          textEditors = ResizeArray() } }
-
-        documents |> set info.uri updated
-        updated
-
-    let inline tryGetCached uri (documents: Documents) =
-        documents
-        |> tryGet uri
-        |> Option.bind (fun info -> info.cache |> Option.map (fun c -> info, c))
-
-    let inline tryGetCachedAtVersion uri version (documents: Documents) =
-        documents
-        |> tryGet uri
-        |> Option.bind (fun info ->
-            match info.cache with
-            | Some cache when cache.version = version -> Some(info, cache)
-            | _ -> None)
-
-let mutable private config = LineLensConfig.defaultConfig
-
-module LineLensDecorations =
-
-    let create range text =
-        // What we add after the range
-        let attachment = createEmpty<ThemableDecorationAttachmentRenderOptions>
-        attachment.color <- Some(U2.Case2(vscode.ThemeColor.Create "fsharp.linelens"))
-        attachment.contentText <- Some text
-
-        // Theme for the range
-        let renderOptions = createEmpty<DecorationInstanceRenderOptions>
-        renderOptions.after <- Some attachment
-
-        let decoration = createEmpty<DecorationOptions>
-        decoration.range <- range
-        decoration.renderOptions <- Some renderOptions
-        decoration
-
-    let decorationType =
-        let opt = createEmpty<DecorationRenderOptions>
-        opt.isWholeLine <- Some true
-        opt
-
-type State =
-    { documents: Documents.Documents
-      decorationType: TextEditorDecorationType
-      disposables: ResizeArray<Disposable> }
 
 module DecorationUpdate =
-
     let formatSignature (sign: SignatureData) : string =
         let formatType =
             function
@@ -189,9 +90,8 @@ module DecorationUpdate =
             else
                 interestingNested |> Array.append [| syms.Declaration.BodyRange |])
 
-    let private lineRange (doc: TextDocument) (range: DTO.Range) =
-        let lineNumber = float range.StartLine - 1.
-        let textLine = doc.lineAt lineNumber
+    let private lineRange (doc: TextDocument) (range: Vscode.Range) =
+        let textLine = doc.lineAt range.start.line
         textLine.range
 
     let private getSignature (uri: Uri) (range: DTO.Range) =
@@ -200,11 +100,17 @@ module DecorationUpdate =
                 LanguageService.signatureData uri range.StartLine (range.StartColumn - 1)
                 |> Async.AwaitPromise
 
-            return signaturesResult |> Option.map (fun r -> range, formatSignature r.Data)
+            return
+                signaturesResult
+                |> Option.map (fun r -> range |> CodeRange.fromDTO, formatSignature r.Data)
         }
 
-    let private signatureToDecoration (doc: TextDocument) (range: DTO.Range, signature: string) =
-        LineLensDecorations.create (lineRange doc range) (config.prefix + signature)
+    let signatureToDecoration
+        (config: LineLens2.LineLensConfig)
+        (doc: TextDocument)
+        (range: Vscode.Range, signature: string)
+        =
+        LineLens2.LineLensDecorations.create "fsharp.linelens" (lineRange doc range) (config.prefix + signature)
 
     let private onePerLine (ranges: Range[]) =
         ranges
@@ -214,7 +120,7 @@ module DecorationUpdate =
     let private needUpdate (uri: Uri) (version: Number) { documents = documents } =
         (documents |> Documents.tryGetCachedAtVersion uri version).IsSome
 
-    let private declarationsResultToSignatures declarationsResult uri =
+    let declarationsResultToSignatures document declarationsResult uri =
         promise {
             let interesting = declarationsResult.Data |> interestingSymbolPositions
 
@@ -230,180 +136,16 @@ module DecorationUpdate =
             return signatures
         }
 
-    /// Update the decorations stored for the document.
-    /// * If the info is already in cache, return that
-    /// * If it change during the process nothing is done and it return None, if a real change is done it return the new state
-    let updateDecorationsForDocument (document: TextDocument) (version: float) state =
-        promise {
-            let uri = document.uri
 
-            match state.documents |> Documents.tryGetCachedAtVersion uri version with
-            | Some(info, _) ->
-                logger.Debug("Found existing decorations in cache for '%s' @%d", uri, version)
-                return Some info
-            | None when document.version = version ->
-                let text = document.getText ()
-                let! declarationsResult = LanguageService.lineLenses uri
-
-                match declarationsResult with
-                | None -> return None
-                | Some declarationsResult ->
-
-                    if document.version = version then
-                        let! signatures = declarationsResultToSignatures declarationsResult uri
-                        let info = state.documents |> Documents.getOrAdd uri
-
-                        if
-                            document.version = version && info.cache.IsNone
-                            || info.cache.Value.version <> version
-                        then
-                            let decorations =
-                                signatures |> Seq.map (signatureToDecoration document) |> ResizeArray
-
-                            logger.Debug("New decorations generated for '%s' @%d", uri, version)
-
-                            return Some(state.documents |> Documents.update info decorations version)
-                        else
-                            return None
-                    else
-                        return None
-            | _ -> return None
-        }
-
-    /// Set the decorations for the editor, filtering lines where the user recently typed
-    let setDecorationsForEditor (textEditor: TextEditor) (info: Documents.DocumentInfo) state =
-        match info.cache with
-        | Some cache when not (cache.textEditors.Contains(textEditor)) ->
-            cache.textEditors.Add(textEditor)
-            logger.Debug("Setting decorations for '%s' @%d", info.uri, cache.version)
-            textEditor.setDecorations (state.decorationType, U2.Case2(cache.decorations))
-        | _ -> ()
-
-    /// Set the decorations for the editor if we have them for the current version of the document
-    let setDecorationsForEditorIfCurrentVersion (textEditor: TextEditor) state =
-        let uri = textEditor.document.uri
-        let version = textEditor.document.version
-
-        match Documents.tryGetCachedAtVersion uri version state.documents with
-        | None -> () // An event will arrive later when we have generated decorations
-        | Some(info, _) -> setDecorationsForEditor textEditor info state
-
-    let documentClosed (uri: Uri) state =
-        // We can/must drop all caches as versions are unique only while a document is open.
-        // If it's re-opened later versions will start at 1 again.
-        state.documents.Remove(uri) |> ignore
-
-let inline private isFsharpFile (doc: TextDocument) =
-    match doc with
-    | Document.FSharp when doc.uri.scheme = "file" -> true
-    | Document.FSharpScript when doc.uri.scheme = "file" -> true
-    | _ -> false
-
-let mutable private state: State option = None
-
-let private textEditorsChangedHandler (textEditors: ResizeArray<TextEditor>) =
-    match state with
-    | Some state ->
-        for textEditor in textEditors do
-            if isFsharpFile textEditor.document then
-                DecorationUpdate.setDecorationsForEditorIfCurrentVersion textEditor state
-    | None -> ()
-
-let removeDocument (uri: Uri) =
-    match state with
-    | Some state ->
-        let documentExistInCache =
-            state.documents
-            // Try to find the document in the cache
-            // We use the path as the search value because parsed URI are not unified by VSCode
-            |> Seq.tryFind (fun element -> element.Key.path = uri.path)
-
-        match documentExistInCache with
-        | Some(KeyValue(uri, _)) ->
-            DecorationUpdate.documentClosed uri state
-
-            window.visibleTextEditors
-            // Find the text editor related to the document in cache
-            |> Seq.tryFind (fun textEditor -> textEditor.document.uri = uri)
-            // If the text editor is found, remove the decorations
-            |> Option.iter (fun textEditor -> textEditor.setDecorations (state.decorationType, U2.Case1(ResizeArray())))
-
-        | None -> ()
-
-    | None -> ()
-
-let private documentParsedHandler (event: Notifications.DocumentParsedEvent) =
-    match state with
-    | None -> ()
-    | Some state ->
-        promise {
-            let! updatedInfo = DecorationUpdate.updateDecorationsForDocument event.document event.version state
-
-            match updatedInfo with
-            | Some info ->
-                // Update all text editors where this document is shown (potentially more than one)
-                window.visibleTextEditors
-                |> Seq.filter (fun editor -> editor.document = event.document)
-                |> Seq.iter (fun editor -> DecorationUpdate.setDecorationsForEditor editor info state)
-            | _ -> ()
-        }
-        |> logger.ErrorOnFailed "Updating after parse failed"
-
-let private closedTextDocumentHandler (textDocument: TextDocument) =
-    state |> Option.iter (DecorationUpdate.documentClosed textDocument.uri)
-
-let install () =
-    logger.Debug "Installing"
-
-    let decorationType =
-        window.createTextEditorDecorationType (LineLensDecorations.decorationType)
-
-    let disposables = ResizeArray<Disposable>()
-
-    disposables.Add(window.onDidChangeVisibleTextEditors.Invoke(unbox textEditorsChangedHandler))
-    disposables.Add(Notifications.onDocumentParsed.Invoke(unbox documentParsedHandler))
-    disposables.Add(workspace.onDidCloseTextDocument.Invoke(unbox closedTextDocumentHandler))
-
-    let newState =
-        { decorationType = decorationType
-          disposables = disposables
-          documents = Documents.create () }
-
-    state <- Some newState
-
-    logger.Debug "Installed"
-
-let uninstall () =
-    logger.Debug "Uninstalling"
-
-    match state with
-    | None -> ()
-    | Some state ->
-        for disposable in state.disposables do
-            disposable.dispose () |> ignore
-
-        state.decorationType.dispose ()
-
-    state <- None
-    logger.Debug "Uninstalled"
-
-let configChangedHandler () =
-    logger.Debug("Config Changed event")
-
-    let wasEnabled = (LineLensConfig.isEnabled config) && state <> None
-    config <- LineLensConfig.getConfig ()
-    let isEnabled = LineLensConfig.isEnabled config
-
-    if wasEnabled <> isEnabled then
-        if isEnabled then install () else uninstall ()
+let private lineLensDecorationUpdate: LineLens2.DecorationUpdate =
+    LineLens2.DecorationUpdate.updateDecorationsForDocument
+        LanguageService.lineLenses
+        DecorationUpdate.declarationsResultToSignatures
+        DecorationUpdate.signatureToDecoration
 
 
-let activate (context: ExtensionContext) =
-    logger.Info "Activating"
 
-    workspace.onDidChangeConfiguration
-    $ (configChangedHandler, (), context.subscriptions)
-    |> ignore
+let createLineLens () =
+    LineLens2.LineLens(LineLensDecorations.decorationType, lineLensDecorationUpdate, LineLensConfig.getConfig)
 
-    configChangedHandler ()
-    ()
+let Instance = createLineLens ()

--- a/src/Components/LineLens/LineLens.fs
+++ b/src/Components/LineLens/LineLens.fs
@@ -101,7 +101,7 @@ module DecorationUpdate =
                     LanguageService.signatureData uri range.StartLine (range.StartColumn - 1)
                     |> Async.AwaitPromise
 
-                return signaturesResult |> Option.map (fun r -> range, formatSignature r.Data)
+                return signaturesResult |> Option.map (fun r -> range|>CodeRange.fromDTO, formatSignature r.Data)
             with e ->
                 logger.Error("Error getting signature %o", e)
                 return None

--- a/src/Components/LineLens/LineLens.fs
+++ b/src/Components/LineLens/LineLens.fs
@@ -7,7 +7,7 @@ open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 open Fable.Core.JsInterop
 open DTO
-open LineLens2
+open LineLensShared
 
 type Number = float
 
@@ -106,11 +106,11 @@ module DecorationUpdate =
         }
 
     let signatureToDecoration
-        (config: LineLens2.LineLensConfig)
+        (config: LineLensShared.LineLensConfig)
         (doc: TextDocument)
         (range: Vscode.Range, signature: string)
         =
-        LineLens2.LineLensDecorations.create "fsharp.linelens" (lineRange doc range) (config.prefix + signature)
+        LineLensShared.LineLensDecorations.create "fsharp.linelens" (lineRange doc range) (config.prefix + signature)
 
     let private onePerLine (ranges: Range[]) =
         ranges
@@ -137,8 +137,8 @@ module DecorationUpdate =
         }
 
 
-let private lineLensDecorationUpdate: LineLens2.DecorationUpdate =
-    LineLens2.DecorationUpdate.updateDecorationsForDocument
+let private lineLensDecorationUpdate: LineLensShared.DecorationUpdate =
+    LineLensShared.DecorationUpdate.updateDecorationsForDocument
         LanguageService.lineLenses
         DecorationUpdate.declarationsResultToSignatures
         DecorationUpdate.signatureToDecoration
@@ -146,6 +146,6 @@ let private lineLensDecorationUpdate: LineLens2.DecorationUpdate =
 
 
 let createLineLens () =
-    LineLens2.LineLens("LineLens",lineLensDecorationUpdate, LineLensConfig.getConfig)
+    LineLensShared.LineLens("LineLens", lineLensDecorationUpdate, LineLensConfig.getConfig)
 
 let Instance = createLineLens ()

--- a/src/Components/LineLens/LineLensShared.fs
+++ b/src/Components/LineLens/LineLensShared.fs
@@ -1,4 +1,4 @@
-module Ionide.VSCode.FSharp.LineLens2
+module Ionide.VSCode.FSharp.LineLensShared
 
 open System.Collections.Generic
 open Fable.Core
@@ -7,6 +7,7 @@ open Fable.Import.VSCode.Vscode
 open Fable.Core.JsInterop
 open Fable.Core.JS
 open Logging
+
 type Number = float
 
 
@@ -101,7 +102,12 @@ type LineLensState =
       disposables: ResizeArray<Disposable> }
 
 type DecorationUpdate =
-    ConsoleAndOutputChannelLogger->LineLensConfig -> (TextDocument) -> (float) -> LineLensState -> Promise<option<Documents.DocumentInfo>>
+    ConsoleAndOutputChannelLogger
+        -> LineLensConfig
+        -> (TextDocument)
+        -> (float)
+        -> LineLensState
+        -> Promise<option<Documents.DocumentInfo>>
 
 module DecorationUpdate =
     /// Update the decorations stored for the document.
@@ -111,7 +117,7 @@ module DecorationUpdate =
         (fetchHintsData: Uri -> Promise<option<'a>>)
         (hintsToSignature: TextDocument -> 'a -> Uri -> Promise<(Range * string) array>)
         (signatureToDecoration: LineLensConfig -> TextDocument -> (Range * string) -> DecorationOptions)
-        (logger:ConsoleAndOutputChannelLogger)
+        (logger: ConsoleAndOutputChannelLogger)
         config
         (document: TextDocument)
         (version: float)
@@ -166,16 +172,25 @@ let inline private isFsharpFile (doc: TextDocument) =
 /// The bulk of the logic is the decorationUpdate function you provide
 /// Normally this should be constructed using the `DecorationUpdate.updateDecorationsForDocument` function
 /// which provides caching and filtering of the decorations
-type LineLens(name,  decorationUpdate: DecorationUpdate, getConfig: unit -> LineLensConfig, ?decorationType:DecorationRenderOptions) =
+type LineLens
+    (
+        name,
+        decorationUpdate: DecorationUpdate,
+        getConfig: unit -> LineLensConfig,
+        ?decorationType: DecorationRenderOptions
+    ) =
 
     let logger =
         ConsoleAndOutputChannelLogger(Some $"LineLensRenderer-{name}", Level.DEBUG, None, Some Level.DEBUG)
-    let decorationType=decorationType|>Option.defaultValue LineLensDecorations.decorationType
+
+    let decorationType =
+        decorationType |> Option.defaultValue LineLensDecorations.decorationType
+
     let mutable config = { enabled = true; prefix = "// " }
     let mutable state: LineLensState option = None
 
     /// Set the decorations for the editor, filtering lines where the user recently typed
-    let setDecorationsForEditor  (textEditor: TextEditor) (info: Documents.DocumentInfo) state =
+    let setDecorationsForEditor (textEditor: TextEditor) (info: Documents.DocumentInfo) state =
         match info.cache with
         | Some cache when not (cache.textEditors.Contains(textEditor)) ->
             cache.textEditors.Add(textEditor)

--- a/src/Components/LineLens/PipelineHints.fs
+++ b/src/Components/LineLens/PipelineHints.fs
@@ -6,7 +6,7 @@ open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 open Fable.Core.JsInterop
 open DTO
-open LineLens2
+open LineLensShared
 
 type Number = float
 
@@ -64,10 +64,10 @@ module PipelineDecorationUpdate =
             return signatures
         }
 
-    let signatureToDecoration (config: LineLens2.LineLensConfig) doc (r, s) =
-        LineLens2.LineLensDecorations.create "fsharp.pipelineHints" r (config.prefix + s)
+    let signatureToDecoration (config: LineLensShared.LineLensConfig) doc (r, s) =
+        LineLensShared.LineLensDecorations.create "fsharp.pipelineHints" r (config.prefix + s)
 
-let private pipelineHintsDecorationUpdate: LineLens2.DecorationUpdate =
+let private pipelineHintsDecorationUpdate: LineLensShared.DecorationUpdate =
     DecorationUpdate.updateDecorationsForDocument
         LanguageService.pipelineHints
         PipelineDecorationUpdate.declarationsResultToSignatures
@@ -76,6 +76,6 @@ let private pipelineHintsDecorationUpdate: LineLens2.DecorationUpdate =
 
 
 let createPipeLineHints () =
-    LineLens2.LineLens("PipelineHints", pipelineHintsDecorationUpdate, PipelineHintsConfig.getConfig)
+    LineLensShared.LineLens("PipelineHints", pipelineHintsDecorationUpdate, PipelineHintsConfig.getConfig)
 
 let Instance = createPipeLineHints ()

--- a/src/Components/LineLens2.fs
+++ b/src/Components/LineLens2.fs
@@ -161,6 +161,7 @@ module DecorationUpdate =
         | Some cache when not (cache.textEditors.Contains(textEditor)) ->
             cache.textEditors.Add(textEditor)
             logger.Debug("Setting decorations for '%s' @%d", info.uri, cache.version)
+            logger.Debug("Decorations: %O", cache.decorations)
             textEditor.setDecorations (state.decorationType, U2.Case2(cache.decorations))
         | _ -> ()
 
@@ -191,7 +192,7 @@ let inline private isFsharpFile (doc: TextDocument) =
 /// Normally this should be constructed using the `DecorationUpdate.updateDecorationsForDocument` function
 /// which provides caching and filtering of the decorations
 type LineLens(decorationType, decorationUpdate: DecorationUpdate, getConfig: unit -> LineLensConfig) =
-    let mutable config = { enabled = false; prefix = "// " }
+    let mutable config = { enabled = true; prefix = "// " }
     let mutable state: LineLensState option = None
 
     let textEditorsChangedHandler (textEditors: ResizeArray<TextEditor>) =
@@ -202,7 +203,7 @@ type LineLens(decorationType, decorationUpdate: DecorationUpdate, getConfig: uni
                     DecorationUpdate.setDecorationsForEditorIfCurrentVersion textEditor state
         | None -> ()
 
-    let documentParsedHandler updateDecorationsForDocument (event: Notifications.DocumentParsedEvent) =
+    let documentParsedHandler (event: Notifications.DocumentParsedEvent) =
         match state with
         | None -> ()
         | Some state ->

--- a/src/Components/LineLens2.fs
+++ b/src/Components/LineLens2.fs
@@ -1,0 +1,303 @@
+module Ionide.VSCode.FSharp.LineLens2
+
+open System.Collections.Generic
+open Fable.Core
+open Fable.Import.VSCode
+open Fable.Import.VSCode.Vscode
+open Fable.Core.JsInterop
+open Fable.Core.JS
+
+type Number = float
+
+let private logger =
+    ConsoleAndOutputChannelLogger(Some "LineLens2", Level.DEBUG, None, Some Level.DEBUG)
+
+module Documents =
+
+    type Cached =
+        {
+            /// vscode document version that was parsed
+            version: Number
+            /// Decorations
+            decorations: ResizeArray<DecorationOptions>
+            /// Text editors where the decorations are shown
+            textEditors: ResizeArray<TextEditor>
+        }
+
+    type DocumentInfo =
+        {
+            /// Full uri of the document
+            uri: Uri
+            /// Current decoration cache
+            cache: Cached option
+        }
+
+    type Documents = Dictionary<Uri, DocumentInfo>
+
+    let inline create () = Documents()
+
+    let inline tryGet uri (documents: Documents) = documents.TryGet uri
+
+    let inline getOrAdd uri (documents: Documents) =
+        match tryGet uri documents with
+        | Some x -> x
+        | None ->
+            let value = { uri = uri; cache = None }
+            documents.Add(uri, value)
+            value
+
+    let inline set uri value (documents: Documents) = documents.[uri] <- value
+
+    let update info (decorations: ResizeArray<DecorationOptions>) version (documents: Documents) =
+        let updated =
+            { info with
+                cache =
+                    Some
+                        { version = version
+                          decorations = decorations
+                          textEditors = ResizeArray() } }
+
+        documents |> set info.uri updated
+        updated
+
+    let inline tryGetCached uri (documents: Documents) =
+        documents
+        |> tryGet uri
+        |> Option.bind (fun info -> info.cache |> Option.map (fun c -> info, c))
+
+    let inline tryGetCachedAtVersion uri version (documents: Documents) =
+        documents
+        |> tryGet uri
+        |> Option.bind (fun info ->
+            match info.cache with
+            | Some cache when cache.version = version -> Some(info, cache)
+            | _ -> None)
+
+module LineLensDecorations =
+
+    let create theme range text =
+        // What we add after the range
+        let attachment = createEmpty<ThemableDecorationAttachmentRenderOptions>
+        attachment.color <- Some(U2.Case2(vscode.ThemeColor.Create theme))
+        attachment.contentText <- Some text
+
+        // Theme for the range
+        let renderOptions = createEmpty<DecorationInstanceRenderOptions>
+        renderOptions.after <- Some attachment
+
+        let decoration = createEmpty<DecorationOptions>
+        decoration.range <- range
+        decoration.renderOptions <- Some renderOptions
+        decoration
+
+    let decorationType =
+        let opt = createEmpty<DecorationRenderOptions>
+        opt.isWholeLine <- Some true
+        opt
+
+type LineLensConfig = { enabled: bool; prefix: string }
+
+type LineLensState =
+    { documents: Documents.Documents
+      decorationType: TextEditorDecorationType
+      disposables: ResizeArray<Disposable> }
+
+type DecorationUpdate =
+    LineLensConfig -> (TextDocument) -> (float) -> LineLensState -> Promise<option<Documents.DocumentInfo>>
+
+module DecorationUpdate =
+
+    /// Update the decorations stored for the document.
+    /// * If the info is already in cache, return that
+    /// * If it change during the process nothing is done and it return None, if a real change is done it return the new state
+    let updateDecorationsForDocument<'a>
+        (fetchHintsData: Uri -> Promise<option<'a>>)
+        (hintsToSignature: TextDocument -> 'a -> Uri -> Promise<(Range * string) array>)
+        (signatureToDecoration: LineLensConfig -> TextDocument -> (Range * string) -> DecorationOptions)
+        config
+        (document: TextDocument)
+        (version: float)
+        state
+        =
+        promise {
+            let uri = document.uri
+
+            match state.documents |> Documents.tryGetCachedAtVersion uri version with
+            | Some(info, _) ->
+                logger.Debug("Found existing decorations in cache for '%s' @%d", uri, version)
+                return Some info
+            | None when document.version = version ->
+                logger.Debug("getting new decorations for '%s' @%d", uri, version)
+                let! hintsResults = fetchHintsData uri
+
+                match hintsResults with
+                | None -> return None
+                | Some hintsResults ->
+                    if document.version = version then
+
+                        let! signatures = hintsToSignature document hintsResults uri
+                        let info = state.documents |> Documents.getOrAdd uri
+
+                        if
+                            document.version = version && info.cache.IsNone
+                            || info.cache.Value.version <> version
+                        then
+                            let decorations =
+                                signatures |> Seq.map (signatureToDecoration config document) |> ResizeArray
+
+                            logger.Debug("New decorations generated for '%s' @%d", uri, version)
+
+                            return Some(state.documents |> Documents.update info decorations version)
+                        else
+                            return None
+                    else
+                        return None
+            | _ -> return None
+        }
+
+    /// Set the decorations for the editor, filtering lines where the user recently typed
+    let setDecorationsForEditor (textEditor: TextEditor) (info: Documents.DocumentInfo) state =
+        match info.cache with
+        | Some cache when not (cache.textEditors.Contains(textEditor)) ->
+            cache.textEditors.Add(textEditor)
+            logger.Debug("Setting decorations for '%s' @%d", info.uri, cache.version)
+            textEditor.setDecorations (state.decorationType, U2.Case2(cache.decorations))
+        | _ -> ()
+
+    /// Set the decorations for the editor if we have them for the current version of the document
+    let setDecorationsForEditorIfCurrentVersion (textEditor: TextEditor) state =
+        let uri = textEditor.document.uri
+        let version = textEditor.document.version
+
+        match Documents.tryGetCachedAtVersion uri version state.documents with
+        | None -> () // An event will arrive later when we have generated decorations
+        | Some(info, _) -> setDecorationsForEditor textEditor info state
+
+    let documentClosed (uri: Uri) state =
+        // We can/must drop all caches as versions are unique only while a document is open.
+        // If it's re-opened later versions will start at 1 again.
+        state.documents.Remove(uri) |> ignore
+
+let inline private isFsharpFile (doc: TextDocument) =
+    match doc with
+    | Document.FSharp when doc.uri.scheme = "file" -> true
+    | Document.FSharpScript when doc.uri.scheme = "file" -> true
+    | _ -> false
+
+
+///A generic type for a Decoration that is displayed at the end of a line
+/// This is used in LineLens and PipelineHints
+/// The bulk of the logic is the decorationUpdate function you provide
+/// Normally this should be constructed using the `DecorationUpdate.updateDecorationsForDocument` function
+/// which provides caching and filtering of the decorations
+type LineLens(decorationType, decorationUpdate: DecorationUpdate, getConfig: unit -> LineLensConfig) =
+    let mutable config = { enabled = false; prefix = "// " }
+    let mutable state: LineLensState option = None
+
+    let textEditorsChangedHandler (textEditors: ResizeArray<TextEditor>) =
+        match state with
+        | Some state ->
+            for textEditor in textEditors do
+                if isFsharpFile textEditor.document then
+                    DecorationUpdate.setDecorationsForEditorIfCurrentVersion textEditor state
+        | None -> ()
+
+    let documentParsedHandler updateDecorationsForDocument (event: Notifications.DocumentParsedEvent) =
+        match state with
+        | None -> ()
+        | Some state ->
+            promise {
+                let! updatedInfo = decorationUpdate config event.document event.version state
+
+                match updatedInfo with
+                | Some info ->
+                    // Update all text editors where this document is shown (potentially more than one)
+                    window.visibleTextEditors
+                    |> Seq.filter (fun editor -> editor.document = event.document)
+                    |> Seq.iter (fun editor -> DecorationUpdate.setDecorationsForEditor editor info state)
+                | _ -> ()
+            }
+            |> logger.ErrorOnFailed "Updating after parse failed"
+
+    let closedTextDocumentHandler (textDocument: TextDocument) =
+        state |> Option.iter (DecorationUpdate.documentClosed textDocument.uri)
+
+    let install decorationType =
+        logger.Debug "Installing"
+
+        let decorationType = window.createTextEditorDecorationType (decorationType)
+
+        let disposables = ResizeArray<Disposable>()
+
+        disposables.Add(window.onDidChangeVisibleTextEditors.Invoke(unbox textEditorsChangedHandler))
+        disposables.Add(Notifications.onDocumentParsed.Invoke(unbox documentParsedHandler))
+        disposables.Add(workspace.onDidCloseTextDocument.Invoke(unbox closedTextDocumentHandler))
+
+        let newState =
+            { decorationType = decorationType
+              disposables = disposables
+              documents = Documents.create () }
+
+        state <- Some newState
+
+        logger.Debug "Installed"
+
+    let uninstall () =
+        logger.Debug "Uninstalling"
+
+        match state with
+        | None -> ()
+        | Some state ->
+            for disposable in state.disposables do
+                disposable.dispose () |> ignore
+
+            state.decorationType.dispose ()
+
+        state <- None
+        logger.Debug "Uninstalled"
+
+    let configChangedHandler (config: LineLensConfig ref) decorationType =
+        logger.Debug("Config Changed event")
+
+        let wasEnabled = (config.Value.enabled) && state <> None
+        config.Value <- getConfig ()
+        let isEnabled = config.Value.enabled
+
+        if wasEnabled <> isEnabled then
+            if isEnabled then install decorationType else uninstall ()
+
+    member t.removeDocument(uri: Uri) =
+        match state with
+        | Some state ->
+            let documentExistInCache =
+                state.documents
+                // Try to find the document in the cache
+                // We use the path as the search value because parsed URI are not unified by VSCode
+                |> Seq.tryFind (fun element -> element.Key.path = uri.path)
+
+            match documentExistInCache with
+            | Some(KeyValue(uri, _)) ->
+                DecorationUpdate.documentClosed uri state
+
+                window.visibleTextEditors
+                // Find the text editor related to the document in cache
+                |> Seq.tryFind (fun textEditor -> textEditor.document.uri = uri)
+                // If the text editor is found, remove the decorations
+                |> Option.iter (fun textEditor ->
+                    textEditor.setDecorations (state.decorationType, U2.Case1(ResizeArray())))
+
+            | None -> ()
+
+        | None -> ()
+
+
+
+    member t.activate(context: ExtensionContext) =
+        logger.Info "Activating"
+        let changeHandler = fun () -> configChangedHandler (ref config) decorationType
+
+        workspace.onDidChangeConfiguration $ (changeHandler, (), context.subscriptions)
+        |> ignore
+
+        changeHandler ()
+        ()

--- a/src/Components/PipelineHints.fs
+++ b/src/Components/PipelineHints.fs
@@ -65,7 +65,7 @@ module PipelineDecorationUpdate =
         }
 
     let signatureToDecoration (config: LineLens2.LineLensConfig) doc (r, s) =
-        LineLens2.LineLensDecorations.create "" r (config.prefix + s)
+        LineLens2.LineLensDecorations.create "fsharp.pipelineHints" r (config.prefix + s)
 
 let private pipelineHintsDecorationUpdate: LineLens2.DecorationUpdate =
     DecorationUpdate.updateDecorationsForDocument

--- a/src/Components/PipelineHints.fs
+++ b/src/Components/PipelineHints.fs
@@ -76,6 +76,6 @@ let private pipelineHintsDecorationUpdate: LineLens2.DecorationUpdate =
 
 
 let createPipeLineHints () =
-    LineLens2.LineLens(LineLensDecorations.decorationType, pipelineHintsDecorationUpdate, PipelineHintsConfig.getConfig)
+    LineLens2.LineLens("PipelineHints", pipelineHintsDecorationUpdate, PipelineHintsConfig.getConfig)
 
 let Instance = createPipeLineHints ()

--- a/src/Components/PipelineHints.fs
+++ b/src/Components/PipelineHints.fs
@@ -6,6 +6,7 @@ open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 open Fable.Core.JsInterop
 open DTO
+open LineLens2
 
 type Number = float
 
@@ -14,9 +15,6 @@ let private logger =
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module PipelineHintsConfig =
-
-    type PipelineHintsConfig = { enabled: bool; prefix: string }
-
     let defaultConfig = { enabled = false; prefix = " //  " }
 
     let getConfig () =
@@ -31,97 +29,7 @@ module PipelineHintsConfig =
           prefix = cfg.get ("FSharp.pipelineHints.prefix", defaultConfig.prefix) }
 
 
-module Documents =
-
-    type Cached =
-        {
-            /// vscode document version that was parsed
-            version: Number
-            /// Decorations
-            decorations: ResizeArray<DecorationOptions>
-            /// Text editors where the decorations are shown
-            textEditors: ResizeArray<TextEditor>
-        }
-
-    type DocumentInfo =
-        {
-            /// Full uri of the document
-            uri: Uri
-            /// Current decoration cache
-            cache: Cached option
-        }
-
-    type Documents = Dictionary<Uri, DocumentInfo>
-
-    let inline create () = Documents()
-
-    let inline tryGet uri (documents: Documents) = documents.TryGet uri
-
-    let inline getOrAdd uri (documents: Documents) =
-        match tryGet uri documents with
-        | Some x -> x
-        | None ->
-            let value = { uri = uri; cache = None }
-            documents.Add(uri, value)
-            value
-
-    let inline set uri value (documents: Documents) = documents.[uri] <- value
-
-    let update info (decorations: ResizeArray<DecorationOptions>) version (documents: Documents) =
-        let updated =
-            { info with
-                cache =
-                    Some
-                        { version = version
-                          decorations = decorations
-                          textEditors = ResizeArray() } }
-
-        documents |> set info.uri updated
-        updated
-
-    let inline tryGetCached uri (documents: Documents) =
-        documents
-        |> tryGet uri
-        |> Option.bind (fun info -> info.cache |> Option.map (fun c -> info, c))
-
-    let inline tryGetCachedAtVersion uri version (documents: Documents) =
-        documents
-        |> tryGet uri
-        |> Option.bind (fun info ->
-            match info.cache with
-            | Some cache when cache.version = version -> Some(info, cache)
-            | _ -> None)
-
-let mutable private config = PipelineHintsConfig.defaultConfig
-
-module PipelineHintsDecorations =
-
-    let create range text =
-        // What we add after the range
-        let attachment = createEmpty<ThemableDecorationAttachmentRenderOptions>
-        attachment.color <- Some(U2.Case2(vscode.ThemeColor.Create "fsharp.pipelineHints"))
-        attachment.contentText <- Some text
-
-        // Theme for the range
-        let renderOptions = createEmpty<DecorationInstanceRenderOptions>
-        renderOptions.after <- Some attachment
-
-        let decoration = createEmpty<DecorationOptions>
-        decoration.range <- range
-        decoration.renderOptions <- Some renderOptions
-        decoration
-
-    let decorationType =
-        let opt = createEmpty<DecorationRenderOptions>
-        opt.isWholeLine <- Some true
-        opt
-
-type State =
-    { documents: Documents.Documents
-      decorationType: TextEditorDecorationType
-      disposables: ResizeArray<Disposable> }
-
-module DecorationUpdate =
+module PipelineDecorationUpdate =
 
     let interestingSymbolPositions
         (doc: TextDocument)
@@ -148,7 +56,7 @@ module DecorationUpdate =
         | None -> [| getSignature 1 (range, tts) |]
 
 
-    let private declarationsResultToSignatures (doc: TextDocument) (declarationsResult: DTO.PipelineHintsResult) uri =
+    let declarationsResultToSignatures (doc: TextDocument) (declarationsResult: DTO.PipelineHintsResult) uri =
         promise {
             let interesting = declarationsResult.Data |> interestingSymbolPositions doc
 
@@ -156,181 +64,18 @@ module DecorationUpdate =
             return signatures
         }
 
-    /// Update the decorations stored for the document.
-    /// * If the info is already in cache, return that
-    /// * If it change during the process nothing is done and it return None, if a real change is done it return the new state
-    let updateDecorationsForDocument (document: TextDocument) (version: float) state =
-        promise {
-            let uri = document.uri
+    let signatureToDecoration (config: LineLens2.LineLensConfig) doc (r, s) =
+        LineLens2.LineLensDecorations.create "" r (config.prefix + s)
 
-            match state.documents |> Documents.tryGetCachedAtVersion uri version with
-            | Some(info, _) ->
-                logger.Debug("Found existing decorations in cache for '%s' @%d", uri, version)
-                return Some info
-            | None when document.version = version ->
-                let! hintsResults = LanguageService.pipelineHints uri
-
-                match hintsResults with
-                | None -> return None
-                | Some hintsResults ->
-                    if document.version = version then
-
-                        let! signatures = declarationsResultToSignatures document hintsResults uri
-                        let info = state.documents |> Documents.getOrAdd uri
-
-                        if
-                            document.version = version && info.cache.IsNone
-                            || info.cache.Value.version <> version
-                        then
-                            let decorations =
-                                signatures
-                                |> Seq.map (fun (r, s) -> PipelineHintsDecorations.create r (config.prefix + s))
-                                |> ResizeArray
-
-                            logger.Debug("New decorations generated for '%s' @%d", uri, version)
-
-                            return Some(state.documents |> Documents.update info decorations version)
-                        else
-                            return None
-                    else
-                        return None
-            | _ -> return None
-        }
-
-    /// Set the decorations for the editor, filtering lines where the user recently typed
-    let setDecorationsForEditor (textEditor: TextEditor) (info: Documents.DocumentInfo) state =
-        match info.cache with
-        | Some cache when not (cache.textEditors.Contains(textEditor)) ->
-            cache.textEditors.Add(textEditor)
-            logger.Debug("Setting decorations for '%s' @%d", info.uri, cache.version)
-            textEditor.setDecorations (state.decorationType, U2.Case2(cache.decorations))
-        | _ -> ()
-
-    /// Set the decorations for the editor if we have them for the current version of the document
-    let setDecorationsForEditorIfCurrentVersion (textEditor: TextEditor) state =
-        let uri = textEditor.document.uri
-        let version = textEditor.document.version
-
-        match Documents.tryGetCachedAtVersion uri version state.documents with
-        | None -> () // An event will arrive later when we have generated decorations
-        | Some(info, _) -> setDecorationsForEditor textEditor info state
-
-    let documentClosed (uri: Uri) state =
-        // We can/must drop all caches as versions are unique only while a document is open.
-        // If it's re-opened later versions will start at 1 again.
-        state.documents.Remove(uri) |> ignore
-
-let inline private isFsharpFile (doc: TextDocument) =
-    match doc with
-    | Document.FSharp when doc.uri.scheme = "file" -> true
-    | Document.FSharpScript when doc.uri.scheme = "file" -> true
-    | _ -> false
-
-let mutable private state: State option = None
-
-let private textEditorsChangedHandler (textEditors: ResizeArray<TextEditor>) =
-    match state with
-    | Some state ->
-        for textEditor in textEditors do
-            if isFsharpFile textEditor.document then
-                DecorationUpdate.setDecorationsForEditorIfCurrentVersion textEditor state
-    | None -> ()
-
-let removeDocument (uri: Uri) =
-    match state with
-    | Some state ->
-        let documentExistInCache =
-            state.documents
-            // Try to find the document in the cache
-            // We use the path as the search value because parsed URI are not unified by VSCode
-            |> Seq.tryFind (fun element -> element.Key.path = uri.path)
-
-        match documentExistInCache with
-        | Some(KeyValue(uri, _)) ->
-            DecorationUpdate.documentClosed uri state
-
-            window.visibleTextEditors
-            // Find the text editor related to the document in cache
-            |> Seq.tryFind (fun textEditor -> textEditor.document.uri = uri)
-            // If the text editor is found, remove the decorations
-            |> Option.iter (fun textEditor -> textEditor.setDecorations (state.decorationType, U2.Case1(ResizeArray())))
-
-        | None -> ()
-
-    | None -> ()
-
-let private documentParsedHandler (event: Notifications.DocumentParsedEvent) =
-    match state with
-    | None -> ()
-    | Some state ->
-        promise {
-            let! updatedInfo = DecorationUpdate.updateDecorationsForDocument event.document event.version state
-
-            match updatedInfo with
-            | Some info ->
-                // Update all text editors where this document is shown (potentially more than one)
-                window.visibleTextEditors
-                |> Seq.filter (fun editor -> editor.document = event.document)
-                |> Seq.iter (fun editor -> DecorationUpdate.setDecorationsForEditor editor info state)
-            | _ -> ()
-        }
-        |> logger.ErrorOnFailed "Updating after parse failed"
-
-let private closedTextDocumentHandler (textDocument: TextDocument) =
-    state |> Option.iter (DecorationUpdate.documentClosed textDocument.uri)
-
-let install () =
-    logger.Debug "Installing"
-
-    let decorationType =
-        window.createTextEditorDecorationType (PipelineHintsDecorations.decorationType)
-
-    let disposables = ResizeArray<Disposable>()
-
-    disposables.Add(window.onDidChangeVisibleTextEditors.Invoke(unbox textEditorsChangedHandler))
-    disposables.Add(Notifications.onDocumentParsed.Invoke(unbox documentParsedHandler))
-    disposables.Add(workspace.onDidCloseTextDocument.Invoke(unbox closedTextDocumentHandler))
-
-    let newState =
-        { decorationType = decorationType
-          disposables = disposables
-          documents = Documents.create () }
-
-    state <- Some newState
-
-    logger.Debug "Installed"
-
-let uninstall () =
-    logger.Debug "Uninstalling"
-
-    match state with
-    | None -> ()
-    | Some state ->
-        for disposable in state.disposables do
-            disposable.dispose () |> ignore
-
-        state.decorationType.dispose ()
-
-    state <- None
-    logger.Debug "Uninstalled"
-
-let configChangedHandler () =
-    logger.Debug("Config Changed event")
-
-    let wasEnabled = (config.enabled) && state <> None
-    config <- PipelineHintsConfig.getConfig ()
-    let isEnabled = config.enabled
-
-    if wasEnabled <> isEnabled then
-        if isEnabled then install () else uninstall ()
+let private pipelineHintsDecorationUpdate: LineLens2.DecorationUpdate =
+    DecorationUpdate.updateDecorationsForDocument
+        LanguageService.pipelineHints
+        PipelineDecorationUpdate.declarationsResultToSignatures
+        PipelineDecorationUpdate.signatureToDecoration
 
 
-let activate (context: ExtensionContext) =
-    logger.Info "Activating"
 
-    workspace.onDidChangeConfiguration
-    $ (configChangedHandler, (), context.subscriptions)
-    |> ignore
+let createPipeLineHints () =
+    LineLens2.LineLens(LineLensDecorations.decorationType, pipelineHintsDecorationUpdate, PipelineHintsConfig.getConfig)
 
-    configChangedHandler ()
-    ()
+let Instance = createPipeLineHints ()

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -785,8 +785,8 @@ module SolutionExplorer =
         let normalizedPath = filePath.Replace("\\", "/")
         let fileUri = vscode.Uri.parse $"file:///%s{normalizedPath}"
 
-        LineLens.removeDocument fileUri
-        PipelineHints.removeDocument fileUri
+        LineLens.Instance.removeDocument fileUri
+        PipelineHints.Instance.removeDocument fileUri
 
     let activate (context: ExtensionContext) =
         let emiter = vscode.EventEmitter.Create<_>()

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -37,8 +37,8 @@
     <Compile Include="Components/Webview.fs" />
     <Compile Include="Components/Fsi.fs" />
     <Compile Include="Components/ScriptRunner.fs" />
-    <Compile Include="Components/LineLens2.fs" />
-    <Compile Include="Components/LineLens.fs" />
+    <Compile Include="Components/LineLens/LineLensShared.fs" />
+    <Compile Include="Components/LineLens/LineLens.fs" />
     <Compile Include="Components/QuickInfo.fs" />
     <Compile Include="Components/QuickInfoProject.fs" />
     <Compile Include="Components/MSBuild.fs" />
@@ -47,7 +47,7 @@
     <Compile Include="Components/HtmlConverter.fs" />
     <Compile Include="Components/InfoPanel.fs" />
     <Compile Include="Components/CodeLensHelpers.fs" />
-    <Compile Include="Components/PipelineHints.fs" />
+    <Compile Include="Components/LineLens/PipelineHints.fs" />
     <Compile Include="Components/SolutionExplorer.fs" />
     <Compile Include="Components/TestExplorer.fs" />
     <Compile Include="Components/InlayHints.fs" />

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -37,6 +37,7 @@
     <Compile Include="Components/Webview.fs" />
     <Compile Include="Components/Fsi.fs" />
     <Compile Include="Components/ScriptRunner.fs" />
+    <Compile Include="Components/LineLens2.fs" />
     <Compile Include="Components/LineLens.fs" />
     <Compile Include="Components/QuickInfo.fs" />
     <Compile Include="Components/QuickInfoProject.fs" />

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -72,7 +72,7 @@ let activate (context: ExtensionContext) : JS.Promise<Api> =
 
         tryActivate "fsprojedit" FsProjEdit.activate context
         tryActivate "diagnostics" Diagnostics.activate context
-        tryActivate "linelens" LineLens.activate context
+        tryActivate "linelens" LineLens.Instance.activate context
         tryActivate "quickinfo" QuickInfo.activate context
         tryActivate "help" Help.activate context
         tryActivate "msbuild" MSBuild.activate context
@@ -86,7 +86,7 @@ let activate (context: ExtensionContext) : JS.Promise<Api> =
         tryActivate "infopanel" InfoPanel.activate context
         tryActivate "codelens" CodeLensHelpers.activate context
         tryActivate "gitignore" Gitignore.activate context
-        tryActivate "pipelinehints" PipelineHints.activate context
+        tryActivate "pipelinehints" PipelineHints.Instance.activate context
         tryActivate "testExplorer" TestExplorer.activate context
         tryActivate "inlayhints" InlayHints.activate context
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eed7bb7</samp>

This pull request refactors the code for the LineLens and PipelineHints features, which show the signatures and types of F# expressions at the end of the lines. The code is moved from a single file `Components/LineLens.fs` to three separate files `Components/LineLens/LineLensShared.fs`, `Components/LineLens/LineLens.fs`, and `Components/LineLens/PipelineHints.fs`, to improve the organization and readability of the code. The code also uses a new `LineLens` type and `Instance` values to expose the features as singletons, and updates the references to the features in other modules and the project file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eed7bb7</samp>

> _Sing, O Muse, of the skillful refactorer who moved the code_
> _Of LineLens and PipelineHints, the helpful features divine,_
> _To separate files, with shared types and functions, for clarity and ease_
> _And updated the references, the project, and the activation, with care and grace_

<!--
copilot:emoji
-->

📁🔧🚀

<!--
1.  📁 - This emoji represents the creation of new files and modules for better organization and readability of the code.
2.  🔧 - This emoji represents the modification of existing functions and project files to adapt to the new organization and dependencies of the code.
3.  🚀 - This emoji represents the improvement of the features of LineLens and PipelineHints by reusing some common types and functions and encapsulating the logic in a generic type.
-->

### WHY
The line lens and Pipeline hint code has significant duplication. I have attempted to share as much code as possible. This was initially motivated by investigating how difficult it would be to port this feature to the ocaml vscode extension

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eed7bb7</samp>

*  Move the code for LineLens and PipelineHints features to separate files and modules for better organization and readability ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-1b61f4c4cffc4a09c37a7f8f70e16971e29dea3c1a8de9a9e8177bc8ffda4e40R1-R151), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-ec3ce02539a0733ff5606b4a6628e9bad7a047496d3cbb33e128b5334b414103R1-R322), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-dbab5b128338ebe31e4a7f519fa49fb3c35e53a8ef76615c0f78afe15ada4da6R1-R81), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-7ce008558fde77b6ae155d9dd49fd4049f622448fc7704e98f8f7bea68977682))
  * Create a new module `LineLensShared.fs` that contains common types and functions for managing the decorations that show the signatures and types at the end of the lines ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-ec3ce02539a0733ff5606b4a6628e9bad7a047496d3cbb33e128b5334b414103R1-R322))
  * Create a new module `LineLens.fs` that contains the code for the LineLens feature, which shows the signature of functions and values at the end of the line, and uses the `LineLensShared.fs` module ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-1b61f4c4cffc4a09c37a7f8f70e16971e29dea3c1a8de9a9e8177bc8ffda4e40R1-R151))
  * Create a new module `PipelineHints.fs` that contains the code for the PipelineHints feature, which shows the type of expressions in pipelines at the end of the line, and uses the `LineLensShared.fs` module ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-dbab5b128338ebe31e4a7f519fa49fb3c35e53a8ef76615c0f78afe15ada4da6R1-R81))
  * Delete the old module `Components/LineLens.fs` that contained the code for both features ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-7ce008558fde77b6ae155d9dd49fd4049f622448fc7704e98f8f7bea68977682))
  * Create `Instance` values that expose the `LineLens` type as a singleton for each feature, and use them to access the features from other modules ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-1b61f4c4cffc4a09c37a7f8f70e16971e29dea3c1a8de9a9e8177bc8ffda4e40R1-R151), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-dbab5b128338ebe31e4a7f519fa49fb3c35e53a8ef76615c0f78afe15ada4da6R1-R81))
* Update the project file to compile the new files and modules and remove the old file ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-9609f7e561702edf7075a23210e8a85dfce7d72c17cd3aa75507dcc1e99cfe07L1-R55))
  * Add the new files `Components/LineLens/LineLensShared.fs`, `Components/LineLens/LineLens.fs`, and `Components/LineLens/PipelineHints.fs` to the list of compiled files ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-9609f7e561702edf7075a23210e8a85dfce7d72c17cd3aa75507dcc1e99cfe07L1-R55))
  * Remove the old file `Components/LineLens.fs` from the list of compiled files ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-9609f7e561702edf7075a23210e8a85dfce7d72c17cd3aa75507dcc1e99cfe07L1-R55))
  * Update the order of the files to respect the dependencies between the modules ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-9609f7e561702edf7075a23210e8a85dfce7d72c17cd3aa75507dcc1e99cfe07L1-R55))
* Update the function `activate` in `src/fsharp.fs` to use the `Instance` values of `LineLens` and `PipelineHints` instead of the old module names ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L75-R75), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L89-R89))
  * Replace the references to `LineLens.activate` and `LineLens.deactivate` with `LineLens.Instance.activate` and `LineLens.Instance.deactivate` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L75-R75))
  * Replace the references to `PipelineHints.activate` and `PipelineHints.deactivate` with `PipelineHints.Instance.activate` and `PipelineHints.Instance.deactivate` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L89-R89))
* Update the function `private` in `src/Components/SolutionExplorer.fs` to use the `Instance` values of `LineLens` and `PipelineHints` instead of the old module names ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-13ae03b738fb9bcc3ffeb34994ecc2d80e815e98079c87f8e9c0c42fadd2a9d9L788-R789))
  * Replace the references to `LineLens.removeDecorations` and `PipelineHints.removeDecorations` with `LineLens.Instance.removeDecorations` and `PipelineHints.Instance.removeDecorations` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1895/files?diff=unified&w=0#diff-13ae03b738fb9bcc3ffeb34994ecc2d80e815e98079c87f8e9c0c42fadd2a9d9L788-R789))
