### PR TITLE
Adds more garbage collection settings

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -532,7 +532,8 @@
         "FSharp.fsac.conserveMemory": {
           "default": false,
           "description": "Configures FsAutoComplete with settings intended to reduce memory consumption. Requires restart.",
-          "type": "boolean"
+          "type": "boolean",
+          "deprecationMessage": "This setting is deprecated. Use FSharp.fsac.gc.conserveMemory instead."
         },
         "FSharp.fsac.dotnetArgs": {
           "default": [],
@@ -541,6 +542,26 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "FSharp.fsac.gc.conserveMemory" : {
+          "default": 1,
+          "markdownDescription": "Configures the garbage collector to [conserve memory](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#conserve-memory) at the expense of more frequent garbage collections and possibly longer pause times. [Large Object Heap](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap) will be compacted automatically if it has too much fragmentation. Requires restart.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9
+        },
+        "FSharp.fsac.gc.heapCount" : {
+          "default": 2,
+          "markdownDescription": "Limits the number of [heaps](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals#the-managed-heap) created by the garbage collector. Applies to server garbage collection only. See [Middle Ground between Server and Workstation GC](https://devblogs.microsoft.com/dotnet/middle-ground-between-server-and-workstation-gc/) for more details. This can allow FSAC to still benefit from Server garbage collection while still limiting the number of heaps. Requires restart.",
+          "type": "integer",
+          "required": [
+            "FSharp.fsac.gc.server"
+          ]
+        },
+        "FSharp.fsac.gc.server": {
+          "default": true,
+          "markdownDescription": "Configures whether the application uses workstation garbage collection or server garbage collection. See [Workstation vs Server Garbage Collection](https://devblogs.microsoft.com/premier-developer/understanding-different-gc-modes-with-concurrency-visualizer/#workstation-gc-vs-server-gc) for more details. Workstation will use less memory but Server will have more throughput. Requires restart.",
+          "type": "boolean"
         },
         "FSharp.fsac.netCoreDllPath": {
           "default": "",

--- a/release/package.json
+++ b/release/package.json
@@ -544,8 +544,7 @@
           "type": "array"
         },
         "FSharp.fsac.gc.conserveMemory" : {
-          "default": 1,
-          "markdownDescription": "Configures the garbage collector to [conserve memory](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#conserve-memory) at the expense of more frequent garbage collections and possibly longer pause times. [Large Object Heap](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap) will be compacted automatically if it has too much fragmentation. Requires restart.",
+          "markdownDescription": "Configures the garbage collector to [conserve memory](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#conserve-memory) at the expense of more frequent garbage collections and possibly longer pause times. Acceptable values are 0-9. Any non-zero value will allow the [Large Object Heap](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap) to be compacted automatically if it has too much fragmentation. Requires restart.",
           "type": "integer",
           "minimum": 0,
           "maximum": 9

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -632,7 +632,11 @@ Consider:
             let enableProjectGraph =
                 "FSharp.enableMSBuildProjectGraph" |> Configuration.get false
 
-            let conserveMemory = "FSharp.fsac.conserveMemory" |> Configuration.get false
+            let gcConserveMemory = "FSharp.fsac.gc.conserveMemory" |> Configuration.get 1
+
+            let gcHeapCount = "FSharp.fsac.gc.heapCount" |> Configuration.get 2
+
+            let gcServer = "FSharp.fsac.gc.server" |> Configuration.get true
 
             let parallelReferenceResolution =
                 "FSharp.fsac.parallelReferenceResolution" |> Configuration.get false
@@ -788,8 +792,9 @@ Consider:
 
                     let fsacEnvVars =
                         [ yield! fsacEnvVars
-                          if conserveMemory then
-                              yield "DOTNET_GCConserveMemory", box "9"
+                          yield "DOTNET_GCHeapCount", box (gcHeapCount.ToString("X")) // Requires hexadecimal value
+                          yield "DOTNET_GCConserveMemory", box gcConserveMemory
+                          yield "DOTNET_GCServer", box gcServer
                           if parallelReferenceResolution then
                               yield "FCS_ParallelReferenceResolution", box "true" ]
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3992b2</samp>

This pull request adds new settings to control FSAC's garbage collection and deprecates `conserveMemory`. It updates `package.json` and `LanguageService.fs` to reflect these changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d3992b2</samp>

> _If you use FSAC for F# coding_
> _You might want to tweak its eroding_
> _Of memory and heap_
> _With settings more deep_
> _Than `conserveMemory`, now exploding_

<!--
copilot:emoji
-->

🗑️🚀🗃️

<!--
1.  🗑️ - This emoji represents garbage collection, and can be used for the new settings that allow the user to control how FSAC manages its memory usage.
2.  🚀 - This emoji represents performance, and can be used for the change that passes the environment variables to the .NET Core process, which may improve the responsiveness and stability of FSAC.
3.  🗃️ - This emoji represents deprecation, and can be used for the removal of the `conserveMemory` option, which is no longer relevant or supported by FSAC.
-->

### WHY

- Deprecated `FSharp.fsac.conserveMemory` and added `FSharp.fsac.gc.conserveMemory`. I think it's reasonable to allow people to configure this with whatever value they want. Defaulted it to on with the value of 1 so it will actual compact Large Object Heap but shouldn't be too aggressive. 
- Added `FSharp.fsac.gc.heapCount` with a default value of 2. This should allow us to still get some benefits of server GC while not having a heap per core which could look like we're using more memory than we should.
- Added `FSharp.fsac.gc.server` with default value of on. We do ship FSAC with this on but this allows people to turn it off if they really want to have a bit more control over their memory.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d3992b2</samp>

*  Add and update settings for FSAC garbage collector configuration ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1896/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L535-R536), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1896/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R546-R565), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1896/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL635-R640), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1896/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL791-R797))
  *  Deprecate `FSharp.fsac.conserveMemory` setting in `package.json` and show a message to use `FSharp.fsac.gc.conserveMemory` instead ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1896/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L535-R536))
  *  Add `FSharp.fsac.gc.conserveMemory`, `FSharp.fsac.gc.heapCount`, and `FSharp.fsac.gc.server` settings in `package.json` with default values, descriptions, and validation rules ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1896/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R546-R565))
  *  Replace `conserveMemory` option with `gcConserveMemory`, `gcHeapCount`, and `gcServer` options in `getOptions` function in `LanguageService` module in `src/Core/LanguageService.fs` and assign them the values from the settings ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1896/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL635-R640))
  *  Pass `DOTNET_GCHeapCount`, `DOTNET_GCConserveMemory`, and `DOTNET_GCServer` environment variables to FSAC process in `spawnNetCore` function in `LanguageService` module in `src/Core/LanguageService.fs` and format `DOTNET_GCHeapCount` as hexadecimal ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1896/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL791-R797))
*  Bump up extension version to `7.8.1` in `package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1896/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L1723-R1744))
