### PR TITLE
Adds GCNoAffinitize setting

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -557,6 +557,14 @@
             "FSharp.fsac.gc.server"
           ]
         },
+        "Fsharp.fsac.gc.noAffinitize" : {
+          "default" : true,
+          "type" : "boolean",
+          "markdownDescription": "Specifies whether to [affinitize](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#affinitize) garbage collection threads with processors. To affinitize a GC thread means that it can only run on its specific CPU.. Applies to server garbage collection only. See [GCNoAffinitize](https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/gcnoaffinitize-element#remarks) for more details. Requires restart.",
+          "required": [
+            "FSharp.fsac.gc.server"
+          ]
+        },
         "FSharp.fsac.gc.server": {
           "default": true,
           "markdownDescription": "Configures whether the application uses workstation garbage collection or server garbage collection. See [Workstation vs Server Garbage Collection](https://devblogs.microsoft.com/premier-developer/understanding-different-gc-modes-with-concurrency-visualizer/#workstation-gc-vs-server-gc) for more details. Workstation will use less memory but Server will have more throughput. Requires restart.",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a44e66</samp>

This pull request introduces a new option to configure the garbage collector affinity for the F# language server (FSAC) when using .NET Core. This can help improve performance for some workloads. The option is exposed in the VS Code settings and documented in the `package.json` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6a44e66</samp>

> _`FSAC` process_
> _tunes garbage collector_
> _autumn performance_

<!--
copilot:emoji
-->

🚀🗑️📝

<!--
1.  🚀 - This emoji could represent the performance improvement that some users might see from using the new option, as well as the fact that it is a new feature for the extension.
2.  🗑️ - This emoji could represent the garbage collector and the fact that the change affects how it allocates and frees memory for the FSAC process.
3.  📝 - This emoji could represent the documentation and description that were added for the new option and the existing ones, as well as the fact that the change modifies the `package.json` file.
-->

### WHY

From Discord: 

> reflectronic
> 
> it's probably best to set DOTNET_GCNoAffinitize=1 if you are using low heap counts. otherwise the GC is going to be pinned to the first 2 CPU cores, which gets awkward if you have many instances of the language server open


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a44e66</samp>

*  Add a new configuration option `FSharp.fsac.dotnetCore.gcNoAffinitize` for the F# language server to control whether to affinitize garbage collection threads with processors ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1898/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R560-R567))
*  Update the `package.json` file to include a description and a dependency for the new option ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1898/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R560-R567))
*  Read the value of the new option from the VS Code settings and assign it to a local variable `gcNoAffinitize` in the `getOptions` function of the `LanguageService` module ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1898/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befR666-R667))
*  Add a helper function `boolToInt` that converts a boolean value to an integer value of either 1 or 0 in the same module ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1898/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befR816-R819))
*  Modify the environment variables for the FSAC process when using .NET Core to include the new variable `DOTNET_GCNoAffinitize` and use the `boolToInt` function for `DOTNET_GCServer` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1898/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL820-R829))
*  Add comments with links to the documentation for the garbage collector settings in the `src/Core/LanguageService.fs` file ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1898/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL820-R829))
