### PR TITLE
Disable GCHeapCount for net6.0

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -551,16 +551,16 @@
         },
         "FSharp.fsac.gc.heapCount": {
           "default": 2,
-          "markdownDescription": "Limits the number of [heaps](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals#the-managed-heap) created by the garbage collector. Applies to server garbage collection only. See [Middle Ground between Server and Workstation GC](https://devblogs.microsoft.com/dotnet/middle-ground-between-server-and-workstation-gc/) for more details. This can allow FSAC to still benefit from Server garbage collection while still limiting the number of heaps. Requires restart.",
+          "markdownDescription": "Limits the number of [heaps](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals#the-managed-heap) created by the garbage collector. Applies to server garbage collection only. See [Middle Ground between Server and Workstation GC](https://devblogs.microsoft.com/dotnet/middle-ground-between-server-and-workstation-gc/) for more details. This can allow FSAC to still benefit from Server garbage collection while still limiting the number of heaps. [Only available on .NET 7 or higher](https://github.com/ionide/ionide-vscode-fsharp/issues/1899#issuecomment-1649009462). Requires restart.",
           "type": "integer",
           "required": [
             "FSharp.fsac.gc.server"
           ]
         },
-        "Fsharp.fsac.gc.noAffinitize": {
-          "default": true,
-          "type": "boolean",
-          "markdownDescription": "Specifies whether to [affinitize](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#affinitize) garbage collection threads with processors. To affinitize a GC thread means that it can only run on its specific CPU.. Applies to server garbage collection only. See [GCNoAffinitize](https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/gcnoaffinitize-element#remarks) for more details. Requires restart.",
+        "Fsharp.fsac.gc.noAffinitize" : {
+          "default" : true,
+          "type" : "boolean",
+          "markdownDescription": "Specifies whether to [affinitize](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#affinitize) garbage collection threads with processors. To affinitize a GC thread means that it can only run on its specific CPU.. Applies to server garbage collection only. See [GCNoAffinitize](https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/gcnoaffinitize-element#remarks) for more details. [Only available on .NET 7 or higher](https://github.com/ionide/ionide-vscode-fsharp/issues/1899#issuecomment-1649009462). Requires restart.",
           "required": [
             "FSharp.fsac.gc.server"
           ]
@@ -741,7 +741,7 @@
         },
         "FSharp.openTelemetry.enabled": {
           "default": false,
-          "description": "Enables OpenTelemetry exporter. See https://opentelemetry.io/docs/reference/specification/protocol/exporter/ for environment variables to configure for the exporter. Requires Restart.",
+          "markdownDescription": "Enables OpenTelemetry exporter. See [OpenTelemetry Protocol Exporter](https://opentelemetry.io/docs/reference/specification/protocol/exporter/) for environment variables to configure for the exporter. Requires Restart.",
           "type": "boolean"
         },
         "FSharp.pipelineHints.enabled": {

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -37,6 +37,10 @@ module Notifications =
     let testDetected = testDetectedEmitter.event
 
 module LanguageService =
+    open Fable.Import.LanguageServer.Client
+
+    let private logger =
+        ConsoleAndOutputChannelLogger(Some "LanguageService", Level.DEBUG, Some defaultOutputChannel, Some Level.DEBUG)
     module Types =
         open Fable.Import.VSCode.Vscode
         type PlainNotification = { content: string }
@@ -599,7 +603,37 @@ Consider:
         let clientOpts =
             let opts = createEmpty<Client.LanguageClientOptions>
 
+            let mutable initFails = 0
 
+            let initializationFailureHandler (error:  U3<ResponseError,Exception,obj option>) =
+                if initFails < 5 then
+                    logger.Error($"Initialization failed: %%", error)
+                    initFails <- initFails + 1
+                    true
+                else
+                    false
+
+
+            let restarts = new ResizeArray<_>()
+            let errorHandling = {
+
+                new ErrorHandler with
+                    member this.closed(): CloseAction =
+                        restarts.Add(1)
+                        if restarts |> Seq.length < 5 then
+                            CloseAction.Restart
+                        else
+
+                            logger.Error("Server closed")
+                            CloseAction.DoNotRestart
+                    member this.error(error: Exception, message: Message, count: float): ErrorAction =
+                        logger.Error($"Error from server: {error} {message} {count}")
+                        if count < 3.0 then
+                            ErrorAction.Continue
+                        else
+                            ErrorAction.Shutdown
+
+            }
 
             let initOpts = createObj [ "AutomaticWorkspaceInit" ==> false ]
 
@@ -611,7 +645,12 @@ Consider:
             // that's why we need to coerce it here.
             opts.documentSelector <- Some selector
             opts.synchronize <- Some synch
+            opts.errorHandler <- Some errorHandling
             opts.revealOutputChannelOn <- Some Client.RevealOutputChannelOn.Never
+            // Worth keeping around for debug purposes
+            // opts.traceOutputChannel <- Some defaultOutputChannel
+            // opts.outputChannel <- Some defaultOutputChannel
+            opts.initializationFailedHandler <- Some (!! initializationFailureHandler)
 
             opts.initializationOptions <- Some !^(Some initOpts)
             opts?markdown <- createObj [ "isTrusted" ==> true; "supportHtml" ==> true ]
@@ -810,7 +849,7 @@ Consider:
                               | pres when Seq.length pres > 0 -> "DOTNET_ROLL_FORWARD_TO_PRERELEASE", box 1
                               | _ -> () ]
 
-                        return args, envVariables, fsacPath
+                        return args, envVariables, fsacPath, sdkVersion
                 }
 
             /// Converts true to 1 and false to 0
@@ -819,18 +858,26 @@ Consider:
 
             let spawnNetCore dotnet : JS.Promise<Executable> =
                 promise {
-                    let! (fsacDotnetArgs, fsacEnvVars, fsacPath) = discoverDotnetArgs ()
-
+                    let! (fsacDotnetArgs, fsacEnvVars, fsacPath, sdkVersion) = discoverDotnetArgs ()
+                    // Only set DOTNET_GCHeapCount if we're on .NET 7 or higher
+                    // .NET 6 has some issues with this env var on linux
+                    // https://github.com/ionide/ionide-vscode-fsharp/issues/1899
+                    let versionSupportingEnvVars = (semver.parse (Some (U2.Case1 "7.0.0"))).Value
+                    let isNet7orHigher = semver.cmp(U2.Case2 sdkVersion, Operator.GTE, U2.Case2 versionSupportingEnvVars)
                     let fsacEnvVars =
                         [ yield! fsacEnvVars
-                          yield "DOTNET_GCHeapCount", box (gcHeapCount.ToString("X")) // Requires hexadecimal value https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#heap-count
+                          if isNet7orHigher then
+                            // it doesn't really make sense to set GCNoAffinitize without setting GCHeapCount
+                            yield "DOTNET_GCNoAffinitize", box (boolToInt gcNoAffinitize) // https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#affinitize
+                            yield "DOTNET_GCHeapCount", box (gcHeapCount.ToString("X")) // Requires hexadecimal value https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#heap-count
+
                           yield "DOTNET_GCConserveMemory", box gcConserveMemory //https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#conserve-memory
                           yield "DOTNET_GCServer", box (boolToInt gcServer) // https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#workstation-vs-server
-                          yield "DOTNET_GCNoAffinitize", box (boolToInt gcNoAffinitize) // https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#affinitize
+
                           if parallelReferenceResolution then
                               yield "FCS_ParallelReferenceResolution", box "true" ]
 
-                    printfn $"""FSAC (NETCORE): '%s{fsacPath}'"""
+                    logger.Debug $"""FSAC (NETCORE): '%s{fsacPath}'"""
 
                     let exeOpts = createEmpty<ExecutableOptions>
 
@@ -929,12 +976,17 @@ Consider:
 
     let start (c: ExtensionContext) =
         promise {
-            let! startOpts = getOptions c
-            let cl = createClient startOpts
-            registerCustomNotifications cl
-            let started = cl.start ()
-            c.subscriptions.Add(started |> box |> unbox)
-            return ()
+            try
+                let! startOpts = getOptions c
+                logger.Debug ("F# language server options: %%",startOpts)
+                let cl = createClient startOpts
+                registerCustomNotifications cl
+                let started = cl.start ()
+                c.subscriptions.Add(started |> box |> unbox)
+                return ()
+            with e ->
+                logger.Error("Error starting F# language server: %%", e)
+                return raise e
         }
 
     let stop () =

--- a/src/Core/Logging.fs
+++ b/src/Core/Logging.fs
@@ -64,15 +64,15 @@ module Logging =
         let formattedMessage = Util.format (template, args)
 
         let formattedLogLine =
-            String.Format("[{0:HH:mm:ss} {1,-5}] {2}", DateTime.Now, string level, formattedMessage)
+            String.Format("[{0:HH:mm:ss} {1,-5}] [{2}] {3}", DateTime.Now, string level, source, formattedMessage)
 
         out.appendLine (formattedLogLine)
 
-    let private writeToFile level template args =
+    let private writeToFile level source template  args =
         let formattedMessage = Util.format (template, args)
 
         let formattedLogLine =
-            String.Format("[{0:HH:mm:ss} {1,-5}] {2}\n", DateTime.Now, string level, formattedMessage)
+            String.Format("[{0:HH:mm:ss} {1,-5}] [{2}] {3}\n", DateTime.Now, string level, source, formattedMessage)
         // Only store the 200 last logs
         if ionideLogsMemory.Length >= 200 then
             ionideLogsMemory <- ionideLogsMemory.Tail @ [ formattedLogLine ]
@@ -94,7 +94,7 @@ module Logging =
         if source = Some "IONIDE-FSAC" then
             try
                 if string args.[0] <> "parse" then
-                    writeToFile level template args
+                    writeToFile level source template  args
             with _ ->
                 () // Do nothing
 
@@ -165,3 +165,6 @@ module Logging =
         /// https://nodejs.org/api/util.html#util_util_format_format
         member this.ErrorOnFailed text (p: JS.Promise<_>) =
             p |> Promise.catchEnd (fun err -> this.Error(text + ": %O", err))
+
+
+    let defaultOutputChannel = window.createOutputChannel "Ionide"

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -10,6 +10,9 @@ open Ionide.VSCode.Helpers
 open Ionide.VSCode.FSharp
 open Node.ChildProcess
 
+let private logger =
+    ConsoleAndOutputChannelLogger(Some "Main", Level.DEBUG, Some defaultOutputChannel, Some Level.DEBUG)
+
 type Api =
     { ProjectLoadedEvent: Event<DTO.Project>
       BuildProject: DTO.Project -> JS.Promise<string>
@@ -27,15 +30,15 @@ let activate (context: ExtensionContext) : JS.Promise<Api> =
             try
                 activationFn ctx
             with ex ->
-                printfn $"Error while activating feature '{label}': {ex}"
+                logger.Error $"Error while activating feature '{label}': {ex}"
                 Unchecked.defaultof<_>
 
     LanguageService.start context
-    |> Promise.catch (fun e -> printfn $"Error activating FSAC: %A{e}") // prevent unhandled rejected promises
+    |> Promise.catch (fun e -> logger.Error $"Error activating FSAC: %A{e}") // prevent unhandled rejected promises
     |> Promise.onSuccess (fun _ ->
         let progressOpts = createEmpty<ProgressOptions>
         progressOpts.location <- U2.Case1 ProgressLocation.Window
-
+        logger.Debug "Activating features"
         window.withProgress (
             progressOpts,
             (fun p ctok ->
@@ -46,7 +49,7 @@ let activate (context: ExtensionContext) : JS.Promise<Api> =
                 p.report pm
 
                 Project.activate context
-                |> Promise.catch (fun e -> printfn $"Error loading projects: %A{e}")
+                |> Promise.catch (fun e -> logger.Error $"Error loading projects: %A{e}")
                 |> Promise.onSuccess (fun _ -> tryActivate "quickinfoproject" QuickInfoProject.activate context)
                 |> Promise.bind (fun _ ->
                     if showExplorer then
@@ -56,7 +59,7 @@ let activate (context: ExtensionContext) : JS.Promise<Api> =
                         Promise.lift None)
                 |> Promise.bind (fun _ -> tryActivate "analyzers" LanguageService.loadAnalyzers ())
                 |> Promise.catch (fun e ->
-                    printfn $"Error loading all projects: %A{e}"
+                    logger.Error $"Error loading all projects: %A{e}"
 
                     let pm =
                         {| message = Some "Error loading projects"
@@ -119,7 +122,7 @@ let activate (context: ExtensionContext) : JS.Promise<Api> =
           GetProjectLauncher = Project.getLauncher
           DebugProject = Debugger.debugProject })
     |> Promise.catch (fun e ->
-        printfn $"Error activating features: %A{e}"
+        logger.Error $"Error activating features: %A{e}"
         Unchecked.defaultof<_>)
 
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ff76a3</samp>

This pull request improves the documentation, error handling, logging, and environment configuration of the Ionide F# extension. It updates some settings in `release/package.json`, adds custom handlers and a logger for the language server in `src/Core/LanguageService.fs`, enhances the logging module in `src/Core/Logging.fs`, and uses the custom logger in `src/fsharp.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5ff76a3</samp>

> _`Ionide.VSCode`_
> _Logging and error handling_
> _Autumn of refactor_

<!--
copilot:emoji
-->

📝🐛📊

<!--
1.  📝 - This emoji represents documentation and formatting changes, as it is often used to indicate writing or editing.
2.  🐛 - This emoji represents bug fixes and error handling improvements, as it is often used to indicate finding or fixing a problem.
3.  📊 - This emoji represents logging and output enhancements, as it is often used to indicate data or statistics.
-->

### WHY

Closes #1899.  For reasons discussed in that issue, we're disabling `GCHeapCount` and `GCNoAffinitize` settings for net6.0 since it seems to have issues at least on linux but possibly more.  I don't want to get to deep into detecting exactly what issue so we're blanket not supporting it for 6.0.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ff76a3</samp>

*  Add custom error handling and logging logic for the language server ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befR40-R43),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL602-R637),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL614-R652),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL813-R851),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL822-R879),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL932-R988))
  * Create a `logger` variable in the `Notifications` module to log messages to the "LanguageService" output channel ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befR40-R43))
  * Define variables and functions to handle initialization failures, restarts, and errors in the `private` function in the `LanguageService` module ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL602-R637))
  * Set the custom error handler, initialization failed handler, trace output channel, and output channel for the language client in the `opts` object in the `LanguageService` module ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL614-R652))
  * Add a `sdkVersion` variable to the return value of the `discoverDotnetArgs` function in the `getOptions` function in the `LanguageService` module, to store the .NET SDK version used to run the language server ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL813-R851))
  * Use the `sdkVersion` variable to conditionally set the `DOTNET_GCHeapCount` and `DOTNET_GCNoAffinitize` environment variables for the language server process, to avoid issues on lower versions or Linux ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL822-R879))
  * Add a try-catch block around the `getOptions` function call in the `start` function in the `LanguageService` module, and log the options and any errors using the `logger` variable ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL932-R988))
* Add links to issue comments that explain the limitations of some settings in `release/package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L554-R554),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L563-R563))
  * Add a link to an issue comment for the `FSharp.fsac.gc.heapCount` setting, which is only available on .NET 7 or higher ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L554-R554))
  * Add a similar link for the `FSharp.fsac.gc.noAffinitize` setting, which is also only available on .NET 7 or higher ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L563-R563))
* Use markdown syntax for the description of the `FSharp.openTelemetry.enabled` setting in `release/package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L744-R744))
  * Change the `description` property to `markdownDescription` for the `FSharp.openTelemetry.enabled` setting, to make the link to the OpenTelemetry Protocol Exporter more visible and clickable ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L744-R744))
* Add a newline at the end of `release/package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L1751-R1751))
  * Add a newline character at the end of `release/package.json`, to follow the common convention and avoid potential issues with some tools or parsers ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L1751-R1751))
* Add a `source` parameter to the `writeToConsole` and `writeToFile` functions in the `Logging` module ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-4226eab928dba3716019d86425bcd53587c3e4b9e2f27c365ff260094ef37996L67-R75),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-4226eab928dba3716019d86425bcd53587c3e4b9e2f27c365ff260094ef37996L97-R97))
  * Add a `source` parameter to the `writeToConsole` function in the `Logging` module, which indicates the source of the log message, and include it in the `formattedLogLine` variable ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-4226eab928dba3716019d86425bcd53587c3e4b9e2f27c365ff260094ef37996L67-R75))
  * Pass the `source` parameter to the `writeToFile` function call in the `writeToConsole` function in the `Logging` module, to pass the source information to the file logging as well ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-4226eab928dba3716019d86425bcd53587c3e4b9e2f27c365ff260094ef37996L97-R97))
* Add a default output channel for logging messages to the VS Code output panel in the `Logging` module ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-4226eab928dba3716019d86425bcd53587c3e4b9e2f27c365ff260094ef37996R168-R170))
  * Add a `defaultOutputChannel` variable to the `Logging` module, which is an instance of the `OutputChannel` class created with the name "Ionide" ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-4226eab928dba3716019d86425bcd53587c3e4b9e2f27c365ff260094ef37996R168-R170))
* Replace the `printfn` function calls with the custom logger calls in the `Ionide.VSCode.FSharp` module ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2R13-R15),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L30-R41),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L49-R52),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L59-R62),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L122-R125))
  * Create a `logger` variable in the `Ionide.VSCode.FSharp` module, which is an instance of the `ConsoleAndOutputChannelLogger` class ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2R13-R15))
  * Replace the `printfn` function calls with the `logger` variable calls in the `tryActivate` function, the `Project.activate` function call, and the `Promise.catch` function calls in the `activate` function in the `Ionide.VSCode.FSharp` module, to use the custom logger instead of the standard output for logging errors ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L30-R41),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L49-R52),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L59-R62),[link](https://github.com/ionide/ionide-vscode-fsharp/pull/1900/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2L122-R125))
