### PR TITLE
Crazy idea to help F# folks getting started - break C# dependency

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -155,43 +155,53 @@
       },
       {
         "command": "MSBuild.buildCurrent",
-        "title": "MSBuild: Build current project"
+        "title": "MSBuild: Build current project",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.buildSelected",
-        "title": "MSBuild: Build project"
+        "title": "MSBuild: Build project",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.rebuildCurrent",
-        "title": "MSBuild: Rebuild current project"
+        "title": "MSBuild: Rebuild current project",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.rebuildSelected",
-        "title": "MSBuild: Rebuild project"
+        "title": "MSBuild: Rebuild project",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.cleanCurrent",
-        "title": "MSBuild: Clean current project"
+        "title": "MSBuild: Clean current project",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.cleanSelected",
-        "title": "MSBuild: Clean project"
+        "title": "MSBuild: Clean project",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.restoreSelected",
-        "title": "MSBuild: Restore project"
+        "title": "MSBuild: Restore project",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.buildCurrentSolution",
-        "title": "MSBuild: Build current solution"
+        "title": "MSBuild: Build current solution",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.rebuildCurrentSolution",
-        "title": "MSBuild: Rebuild current solution"
+        "title": "MSBuild: Rebuild current solution",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.cleanCurrentSolution",
-        "title": "MSBuild: Clean current solution"
+        "title": "MSBuild: Clean current solution",
+        "when": "fsharp.debuggerAvailable"
       },
       {
         "command": "fsharp.explorer.moveUp",
@@ -968,12 +978,12 @@
       {
         "command": "MSBuild.buildCurrent",
         "key": "ctrl\u002Balt\u002Bb",
-        "when": "fsharp.project.any \u0026\u0026 editorFocus \u0026\u0026 editorLangId == \u0027fsharp\u0027"
+        "when": "fsharp.project.any \u0026\u0026 editorFocus \u0026\u0026 editorLangId == \u0027fsharp\u0027 && fsharp.debuggerAvailable"
       },
       {
         "command": "MSBuild.buildCurrentSolution",
         "key": "ctrl\u002Balt\u002Bshift\u002Bb",
-        "when": "fsharp.project.any"
+        "when": "fsharp.project.any && fsharp.debuggerAvailable"
       },
       {
         "command": "fsharp.openInfoPanel",
@@ -1165,15 +1175,15 @@
         },
         {
           "command": "MSBuild.buildCurrent",
-          "when": "fsharp.project.any \u0026\u0026 editorLangId == \u0027fsharp\u0027"
+          "when": "fsharp.project.any \u0026\u0026 editorLangId == \u0027fsharp\u0027 && fsharp.debuggerAvailable"
         },
         {
           "command": "MSBuild.rebuildCurrent",
-          "when": "fsharp.project.any \u0026\u0026 editorLangId == \u0027fsharp\u0027"
+          "when": "fsharp.project.any \u0026\u0026 editorLangId == \u0027fsharp\u0027 && fsharp.debuggerAvailable"
         },
         {
           "command": "MSBuild.cleanCurrent",
-          "when": "fsharp.project.any \u0026\u0026 editorLangId == \u0027fsharp\u0027"
+          "when": "fsharp.project.any \u0026\u0026 editorLangId == \u0027fsharp\u0027 && fsharp.debuggerAvailable"
         },
         {
           "command": "fsharp.clearCache",
@@ -1181,43 +1191,43 @@
         },
         {
           "command": "MSBuild.buildSelected",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "MSBuild.rebuildSelected",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "MSBuild.cleanSelected",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "MSBuild.restoreSelected",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "MSBuild.buildCurrentSolution",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "MSBuild.rebuildCurrentSolution",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "MSBuild.cleanCurrentSolution",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "fsharp.runDefaultProject",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "fsharp.debugDefaultProject",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "fsharp.chooseDefaultProject",
-          "when": "fsharp.project.any"
+          "when": "fsharp.project.any && fsharp.debuggerAvailable"
         },
         {
           "command": "fsharp.NewProject",
@@ -1261,12 +1271,12 @@
         {
           "command": "fsharp.debugDefaultProject",
           "group": "fsharp",
-          "when": "fsharp.project.any \u0026\u0026 config.FSharp.enableTouchBar"
+          "when": "fsharp.project.any \u0026\u0026 config.FSharp.enableTouchBar && fsharp.debuggerAvailable"
         },
         {
           "command": "fsharp.runDefaultProject",
           "group": "fsharp",
-          "when": "fsharp.project.any \u0026\u0026 config.FSharp.enableTouchBar"
+          "when": "fsharp.project.any \u0026\u0026 config.FSharp.enableTouchBar && fsharp.debuggerAvailable"
         },
         {
           "command": "fsharp.NewProject",
@@ -1536,12 +1546,12 @@
         {
           "command": "fsharp.explorer.project.debug",
           "group": "1_run@2",
-          "when": "viewItem == ionide.projectExplorer.projectExe"
+          "when": "viewItem == ionide.projectExplorer.projectExe && fsharp.debuggerAvailable"
         },
         {
           "command": "fsharp.explorer.project.debug",
           "group": "inline@2",
-          "when": "viewItem == ionide.projectExplorer.projectExe"
+          "when": "viewItem == ionide.projectExplorer.projectExe && fsharp.debuggerAvailable"
         },
         {
           "command": "fsharp.explorer.project.setDefault",
@@ -1733,9 +1743,7 @@
   "engines": {
     "vscode": "^0.10.0"
   },
-  "extensionDependencies": [
-    "ms-dotnettools.csharp"
-  ],
+  "extensionDependencies": [],
   "homepage": "http://ionide.io",
   "icon": "images/logo.png",
   "license": "MIT",

--- a/src/Components/CSharpExtensionSupport.fs
+++ b/src/Components/CSharpExtensionSupport.fs
@@ -1,0 +1,34 @@
+namespace Ionide.VSCode.FSharp
+
+open Fable.Import.VSCode.Vscode
+
+module CSharpExtension =
+
+    let private msCSharpExtensionName = "ms-vscode.csharp"
+    let private openvsixCSharpExtensionName = "ms-vscode.csharp"
+
+    let mutable private hasLookedForCSharp = false
+    let mutable private hasCSharp = false
+    let mutable private csharpExtension: Extension<obj> = null
+    let private csharpAvailableContext: bool -> unit =
+        let fn = Context.cachedSetter "fsharp.debuggerAvailable"
+        fun value ->
+            hasCSharp <- value
+            fn value
+
+    let isCSharpAvailable () = hasCSharp
+
+    let tryFindCSharpExtension() =
+        if hasLookedForCSharp
+        then hasCSharp
+        else
+            match extensions.getExtension msCSharpExtensionName with
+            | None ->
+                csharpAvailableContext false
+            | Some e ->
+                csharpExtension <- e
+                csharpAvailableContext true
+            hasLookedForCSharp <- true
+            hasCSharp
+
+    let warnAboutMissingCSharpExtension() = ()

--- a/src/Components/CSharpExtensionSupport.fs
+++ b/src/Components/CSharpExtensionSupport.fs
@@ -7,9 +7,13 @@ module CSharpExtension =
     let private msCSharpExtensionName = "ms-vscode.csharp"
     let private openvsixCSharpExtensionName = "ms-vscode.csharp"
 
+    let private resolvedCSharpExtensionName = msCSharpExtensionName
+
     let mutable private hasLookedForCSharp = false
     let mutable private hasCSharp = false
     let mutable private csharpExtension: Extension<obj> = null
+    let mutable private hasWarned = false
+
     let private csharpAvailableContext: bool -> unit =
         let fn = Context.cachedSetter "fsharp.debuggerAvailable"
         fun value ->
@@ -19,16 +23,19 @@ module CSharpExtension =
     let isCSharpAvailable () = hasCSharp
 
     let tryFindCSharpExtension() =
-        if hasLookedForCSharp
-        then hasCSharp
-        else
-            match extensions.getExtension msCSharpExtensionName with
+        if not hasLookedForCSharp
+        then
+            match extensions.getExtension resolvedCSharpExtensionName with
             | None ->
                 csharpAvailableContext false
             | Some e ->
                 csharpExtension <- e
                 csharpAvailableContext true
             hasLookedForCSharp <- true
-            hasCSharp
+        hasCSharp
 
-    let warnAboutMissingCSharpExtension() = ()
+    let warnAboutMissingCSharpExtension() =
+        if not hasWarned then
+            window.showWarningMessage($"The {resolvedCSharpExtensionName} extension isn't installed, so debugging and some build tools will not be available. Consider installing the {resolvedCSharpExtensionName} extension to enable those features.")
+            |> ignore
+            hasWarned <- true

--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -386,23 +386,27 @@ module Debugger =
                 ProviderResult.Some(U2.Case1 debugConfiguration) }
 
     let activate (c: ExtensionContext) =
-        commands.registerCommand ("fsharp.runDefaultProject", (buildAndRunDefault) |> objfy2)
-        |> c.Subscribe
 
-        commands.registerCommand ("fsharp.debugDefaultProject", (buildAndDebugDefault) |> objfy2)
-        |> c.Subscribe
+        match CSharpExtension.tryFindCSharpExtension() with
+        | false -> CSharpExtension.warnAboutMissingCSharpExtension()
+        | true ->
+            commands.registerCommand ("fsharp.runDefaultProject", (buildAndRunDefault) |> objfy2)
+            |> c.Subscribe
 
-        commands.registerCommand ("fsharp.chooseDefaultProject", (chooseDefaultProject) |> objfy2)
-        |> c.Subscribe
+            commands.registerCommand ("fsharp.debugDefaultProject", (buildAndDebugDefault) |> objfy2)
+            |> c.Subscribe
 
-        logger.Info "registering debug provider"
+            commands.registerCommand ("fsharp.chooseDefaultProject", (chooseDefaultProject) |> objfy2)
+            |> c.Subscribe
 
-        debug.registerDebugConfigurationProvider (
-            "coreclr",
-            launchSettingProvider,
-            DebugConfigurationProviderTriggerKind.Dynamic
-        )
-        |> c.Subscribe
+            logger.Info "registering debug provider"
 
-        context <- Some c
-        startup <- c.workspaceState.get<Project> "defaultProject"
+            debug.registerDebugConfigurationProvider (
+                "coreclr",
+                launchSettingProvider,
+                DebugConfigurationProviderTriggerKind.Dynamic
+            )
+            |> c.Subscribe
+
+            context <- Some c
+            startup <- c.workspaceState.get<Project> "defaultProject"

--- a/src/Ionide.FSharp.fsproj
+++ b/src/Ionide.FSharp.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="Core/LanguageService.fs" />
     <Compile Include="Core/Project.fs" />
     <Compile Include="Core/FsProjEdit.fs" />
+    <Compile Include="Components/CSharpExtensionSupport.fs" />
     <Compile Include="Components/Diagnostics.fs" />
     <Compile Include="Components/Gitignore.fs" />
     <Compile Include="Components/LanguageConfiguration.fs" />


### PR DESCRIPTION
### WHAT
copilot:summary

copilot:poem

copilot:emoji

### WHY

Ok, so we have a nonzero amount of folks that just want to get going with F#, and right now our hard dependency on the C# extension can introduce a source of instability. What if we could detect the presence of the C# extension at run time and light up debug/launch tasks support if it is found, while notifying the user that those features will not be available until they install that extension?

Basic plan of attack:
* make a new Context value for debugger support
* set that value by probing for the C# extension
* change debugger/msbuild activation to only register commands if C# is present
* use the context value to act as part of the `when` condition for lots of the commands we declare in package.json

TODO:
* [ ] manual testing
* [ ] figure out how the user dialog when no C# extension is available should look
* [ ] figure out how to detect the extensions' runtime context and swap between the openVSIX gallery C# extension and the VSCode marketplace C# extension
* [ ] respond to new extension installations over the lifetime of the Ionide extension

### HOW
copilot:walkthrough
