### PR TITLE
Latest vscode-helpers

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -13,10 +13,10 @@ nuget Thoth.Json 7.0
 
 git https://github.com/ionide/ionide-fsgrammar.git master
 
-github ionide/ionide-vscode-helpers:7da920c71e4f94240a55aabb555327ebef4b653d src/Fable.Import.VSCode.fs
-github ionide/ionide-vscode-helpers:7da920c71e4f94240a55aabb555327ebef4b653d src/Helpers.fs
-github ionide/ionide-vscode-helpers:7da920c71e4f94240a55aabb555327ebef4b653d src/Fable.Import.Showdown.fs
-github ionide/ionide-vscode-helpers:7da920c71e4f94240a55aabb555327ebef4b653d src/Fable.Import.VSCode.LanguageServer.fs
+github ionide/ionide-vscode-helpers:8e81bc03f11f07b8e0811b3d4598eadc78f32f2f src/Fable.Import.VSCode.fs
+github ionide/ionide-vscode-helpers:8e81bc03f11f07b8e0811b3d4598eadc78f32f2f src/Helpers.fs
+github ionide/ionide-vscode-helpers:8e81bc03f11f07b8e0811b3d4598eadc78f32f2f src/Fable.Import.Showdown.fs
+github ionide/ionide-vscode-helpers:8e81bc03f11f07b8e0811b3d4598eadc78f32f2f src/Fable.Import.VSCode.LanguageServer.fs
 
 group fsac
   source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -41,10 +41,10 @@ GIT
      (71b1ead8c99715f6c994115ebab7ee4a14cf0c59)
 GITHUB
   remote: ionide/ionide-vscode-helpers
-    src/Fable.Import.Showdown.fs (7da920c71e4f94240a55aabb555327ebef4b653d)
-    src/Fable.Import.VSCode.fs (7da920c71e4f94240a55aabb555327ebef4b653d)
-    src/Fable.Import.VSCode.LanguageServer.fs (7da920c71e4f94240a55aabb555327ebef4b653d)
-    src/Helpers.fs (7da920c71e4f94240a55aabb555327ebef4b653d)
+    src/Fable.Import.Showdown.fs (8e81bc03f11f07b8e0811b3d4598eadc78f32f2f)
+    src/Fable.Import.VSCode.fs (8e81bc03f11f07b8e0811b3d4598eadc78f32f2f)
+    src/Fable.Import.VSCode.LanguageServer.fs (8e81bc03f11f07b8e0811b3d4598eadc78f32f2f)
+    src/Helpers.fs (8e81bc03f11f07b8e0811b3d4598eadc78f32f2f)
 GROUP build
 STORAGE: NONE
 RESTRICTION: == net7.0

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -596,7 +596,8 @@ Consider:
         promise { return Environment.configFsiSdkFilePath () }
 
     let private createClient (opts: Executable) =
-        let options = createObj [ "run" ==> opts; "debug" ==> opts ] |> unbox<ServerOptions>
+
+        let options: ServerOptions = U5.Case2 {| run = opts; debug = opts |}
 
         let fileDeletedWatcher =
             workspace.createFileSystemWatcher (U2.Case1 "**/*.{fs,fsx}", true, true, false)
@@ -990,8 +991,7 @@ Consider:
                 logger.Debug("F# language server options: %%", startOpts)
                 let cl = createClient startOpts
                 registerCustomNotifications cl
-                let started = cl.start ()
-                c.subscriptions.Add(started |> box |> unbox)
+                do! cl.start ()
                 return ()
             with e ->
                 logger.Error("Error starting F# language server: %%", e)


### PR DESCRIPTION


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f67792</samp>

This pull request refactors the `LanguageService.fs` module to use better F# practices and optimize memory usage, and updates the ionide-vscode-helpers dependency to a newer version.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f67792</samp>

> _`ServerOptions` cut_
> _Simpler, safer F# code_
> _Autumn of bug fixes_

<!--
copilot:emoji
-->

🆙🧹🚀

<!--
1.  🆙 for updating the dependencies
2.  🧹 for simplifying and cleaning up the code
3.  🚀 for improving the performance and efficiency of the language service
-->

### WHY

Latest upstream helpers from https://github.com/ionide/ionide-vscode-helpers/pull/50

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f67792</samp>

*  Simplify the creation of `ServerOptions` by using a union case with a record instead of a dynamic object ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1904/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL599-R601))
* Refactor the `start` function to use the `do!` keyword and avoid manual disposal of the `started` promise ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1904/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befL993-R994))
* Update the dependencies on the ionide-vscode-helpers repository to a newer commit hash ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1904/files?diff=unified&w=0#diff-377fe73bf860b37e7d9a8ca5be27762668b3a08aac581b435d4c31b737d905cdL16-R19))
