### PR TITLE
Add setting to turn off test discovery on workspace load

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -823,6 +823,11 @@
           "description": "Allow Ionide to prompt to use SdkScripts",
           "type": "boolean"
         },
+        "FSharp.TestExplorer.AutoDiscoverTestsOnLoad": {
+          "default": true,
+          "description": "Decides if the test explorer will automatically try discover tests when the workspace loads. You can still manually refresh the explorer to discover tests at any time",
+          "type": "boolean"
+        },
         "FSharp.trace.server": {
           "default": "off",
           "description": "Trace server messages at the LSP protocol level for diagnostics.",

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1506,10 +1506,14 @@ let activate (context: ExtensionContext) =
 
     testController.refreshHandler <- Some refreshHandler
 
+
+    let shouldAutoDiscoverTests =
+        Configuration.get true "FSharp.TestExplorer.AutoDiscoverTestsOnLoad"
+
     let mutable hasInitiatedDiscovery = false
 
     Project.workspaceLoaded.Invoke(fun () ->
-        if not hasInitiatedDiscovery then
+        if shouldAutoDiscoverTests && not hasInitiatedDiscovery then
             hasInitiatedDiscovery <- true
 
             let trxTests =


### PR DESCRIPTION
### WHAT
Add a configuration setting to turn off automatic test discovery on workspace load.

### WHY
@TheAngryByrd [was having issues](https://github.com/ionide/ionide-vscode-fsharp/pull/1874#issuecomment-1697941330) with slowness due to concurrent builds on certain project

