### PR TITLE
Show package names only once

### DIFF
--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -1043,7 +1043,9 @@ module SolutionExplorer =
                     let projRefs = project.ProjectReferences |> Array.map (fun n -> n.ProjectFileName)
 
                     let packageRefs =
-                        project.PackageReferences |> Array.map (fun n -> n.Name + " " + n.Version)
+                        project.PackageReferences
+                        |> Array.distinctBy (fun n -> n.Name)
+                        |> Array.map (fun n -> n.Name + " " + n.Version)
 
                     let refs =
                         refs


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b03d263</samp>

Fixed a bug in the solution explorer that caused duplicate package references to appear. Modified `packageRefs` in `src/Components/SolutionExplorer.fs` to filter out duplicates by name.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b03d263</samp>

> _`packageRefs` fixed_
> _No more duplicates shown in_
> _Solution explorer_

<!--
copilot:emoji
-->

🐛🗑️🗃️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to the `packageRefs` value. It indicates that the previous behavior was incorrect or undesirable and that the change resolved the issue.
2.  🗑️ - This emoji represents removing something, which is what the change did to the duplicate package references by name. It indicates that the change cleaned up or simplified the code or data by getting rid of unnecessary or redundant elements.
3.  🗃️ - This emoji represents a file cabinet or a database, which is a possible metaphor for the solution explorer or the package references. It indicates that the change affected the organization, structure, or display of the data or files in the project or solution.
-->

### WHY
Because there are multiple .dll files in the FSharp.Compiler.Service package, proj-info has two entries in the PackageReferences, which is fine. But here, we only want to show the package names.
![image](https://github.com/ionide/ionide-vscode-fsharp/assets/3221269/276ee6dc-4f5f-423b-9ae3-409487e7ad59)


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b03d263</samp>

* Fix bug of duplicate package references in solution explorer by removing them before mapping to string ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1920/files?diff=unified&w=0#diff-13ae03b738fb9bcc3ffeb34994ecc2d80e815e98079c87f8e9c0c42fadd2a9d9L1046-R1048))
