### PR TITLE
A little cleanup in src/Components

### DIFF
--- a/src/Components/Diagnostics.fs
+++ b/src/Components/Diagnostics.fs
@@ -53,7 +53,7 @@ Error: %A
 
 ### Steps to reproduce
 
-<!-- Add here the step to reproduce you problem. Example: -->
+<!-- Add here the steps to reproduce you problem. Example: -->
 <!-- 1. Open an F# file -->
 <!-- 2. Ctrl + P > "F# Add Reference" -->
             """

--- a/src/Components/Gitignore.fs
+++ b/src/Components/Gitignore.fs
@@ -1,4 +1,4 @@
-/// Prompt users to add VSCode lines to their gitignore if the config is set
+// Prompt users to add VSCode lines to their gitignore if the config is set
 namespace Ionide.VSCode.FSharp
 
 module Gitignore =

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -1024,20 +1024,13 @@ module SolutionExplorer =
         NodeReveal.activate context rootChanged.event treeView
 
         let wsProvider =
-            let viewLoading path = "<b>Status:</b> loading.."
+            let viewLoading = "<b>Status:</b> loading.."
 
-            let viewLanguageNotSupported path = "<b>Status:</b> language not supported"
+            let viewLanguageNotSupported = "<b>Status:</b> language not supported"
 
             let viewParsed (proj: Project) =
                 match getProjectModel proj with
-                | (Project(_,
-                           _,
-                           _,
-                           files,
-                           ProjectReferencesList(_, projRefs, _),
-                           PackageReferenceList(_, refs, _),
-                           _,
-                           project)) ->
+                | (Project(_, _, _, _, _, PackageReferenceList(_, refs, _), _, project)) ->
                     let files = project.Files
 
                     let projRefs = project.ProjectReferences |> Array.map (fun n -> n.ProjectFileName)
@@ -1112,7 +1105,7 @@ module SolutionExplorer =
                     |> String.concat "<br />"
                 | _ -> "Failed to generate status report..."
 
-            let viewFailed path error =
+            let viewFailed error =
                 let sdkErrorRegex =
                     Regex(
                         "A compatible SDK version for global\.json version: \[([\d.]+)\].*was not found.*",
@@ -1154,12 +1147,11 @@ module SolutionExplorer =
 
                             match Project.tryFindInWorkspace path with
                             | None -> sprintf "Project '%s' not found" path
-                            | Some(Project.ProjectLoadingState.Loading path) -> viewLoading path
+                            | Some(Project.ProjectLoadingState.Loading _path) -> viewLoading
                             | Some(Project.ProjectLoadingState.Loaded proj) -> viewParsed proj
-                            | Some(Project.ProjectLoadingState.NotRestored(path, error)) -> viewFailed path error
-                            | Some(Project.ProjectLoadingState.Failed(path, error)) -> viewFailed path error
-                            | Some(Project.ProjectLoadingState.LanguageNotSupported path) ->
-                                viewLanguageNotSupported path
+                            | Some(Project.ProjectLoadingState.NotRestored(_path, error)) -> viewFailed error
+                            | Some(Project.ProjectLoadingState.Failed(_path, error)) -> viewFailed error
+                            | Some(Project.ProjectLoadingState.LanguageNotSupported _path) -> viewLanguageNotSupported
                         | _ -> sprintf "Requested uri: %s" (uri.toString ())
 
                     U2.Case1 message |> Some }
@@ -1181,12 +1173,12 @@ module SolutionExplorer =
             | ProjectFailedToLoad(_, path, name, _) -> ShowStatus.CreateOrShow(path, name)
             | ProjectNotRestored(_, path, name, _) -> ShowStatus.CreateOrShow(path, name)
             | Model.ProjectLoading(_, path, name) -> ShowStatus.CreateOrShow(path, name)
-            | Model.Project(_, path, name, _, _, _, _, proj) -> ShowStatus.CreateOrShow(path, name)
+            | Model.Project(_, path, name, _, _, _, _, _proj) -> ShowStatus.CreateOrShow(path, name)
             | _ -> ()
 
         let runDebug m =
             match m with
-            | Model.Project(_, path, name, _, _, _, _, proj) -> proj |> Debugger.buildAndDebug
+            | Model.Project(_, _path, _name, _, _, _, _, proj) -> proj |> Debugger.buildAndDebug
             | _ -> Promise.empty
 
         let setLaunchSettingsCommand m =


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d76ef05</samp>

This pull request improves the code quality and consistency of some components in the `ionide-vscode-fsharp` extension. It simplifies some patterns, removes unused variables, fixes a typo, and changes a comment style.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d76ef05</samp>

> _`Diagnostics` fixed_
> _Comments and patterns refined_
> _Code like autumn leaves_

<!--
copilot:emoji
-->

📝💅🧹

<!--
1.  📝 for fixing a typo in the comment template.
2.  💅 for changing the comment style in the module `Diagnostics`.
3.  🧹 for simplifying and cleaning up the code in the SolutionExplorer component.
-->

### WHY
A little cleanup in src/Components like removing unused parameters, prefixing with `_` etc.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d76ef05</samp>

*  Fix typo in comment template for reporting issues ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1921/files?diff=unified&w=0#diff-7f1790499ad70294744a478a20d358e431605c2d45ae46184bfef0d3773ae5f3L56-R56))
*  Change comment style from triple slash to double slash in module `Diagnostics` to follow F# style guide ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1921/files?diff=unified&w=0#diff-8b7dd94b340750755c44ce5d4aa57e0b2e42f37be85d1d40e16c002c1b69e049L1-R1))
*  Simplify pattern matching on project model and loading state in `SolutionExplorer.fs` by removing unused variables and arguments ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1921/files?diff=unified&w=0#diff-13ae03b738fb9bcc3ffeb34994ecc2d80e815e98079c87f8e9c0c42fadd2a9d9L1027-R1033), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1921/files?diff=unified&w=0#diff-13ae03b738fb9bcc3ffeb34994ecc2d80e815e98079c87f8e9c0c42fadd2a9d9L1115-R1108), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1921/files?diff=unified&w=0#diff-13ae03b738fb9bcc3ffeb34994ecc2d80e815e98079c87f8e9c0c42fadd2a9d9L1157-R1154), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1921/files?diff=unified&w=0#diff-13ae03b738fb9bcc3ffeb34994ecc2d80e815e98079c87f8e9c0c42fadd2a9d9L1184-R1181))
