### PR TITLE
Suffix location matching (Match test locations where test name and code structure differ)

### DIFF
--- a/src/Components/LineLens/LineLens.fs
+++ b/src/Components/LineLens/LineLens.fs
@@ -101,7 +101,9 @@ module DecorationUpdate =
                     LanguageService.signatureData uri range.StartLine (range.StartColumn - 1)
                     |> Async.AwaitPromise
 
-                return signaturesResult |> Option.map (fun r -> range|>CodeRange.fromDTO, formatSignature r.Data)
+                return
+                    signaturesResult
+                    |> Option.map (fun r -> range |> CodeRange.fromDTO, formatSignature r.Data)
             with e ->
                 logger.Error("Error getting signature %o", e)
                 return None


### PR DESCRIPTION
### WHAT

#### More tests have locations
Improve matching of test explorer items to code locations.
Specifically, detect tests that are logically grouped by a testList, but not directly located under that same testList in the code.


Example 

Before, these tests didn't have features based on code location
![suffix-match-before](https://github.com/ionide/ionide-vscode-fsharp/assets/2847259/65375b89-c771-4391-9aa3-61dc485e98c5)

After
![suffix-match-after](https://github.com/ionide/ionide-vscode-fsharp/assets/2847259/4d30da4c-0e00-4b46-9736-0cc0ea4ee42e)

#### Mislocated tests don't pollute the explorer
Also prevent mislocated tests from showing in the test explorer.
The production version already prevented these on initial discovery, but they would still show up if the tests were renamed.
Now the incorrect test items shouldn't show at all.

For example, the [Not Directly in Parent](https://github.com/farlee2121/Ionide-Test-Explorer-RegressionTest/blob/80038c74f310278b2ab6898b4c177ab7ef86fb1e/tests/ExpectoTests/Expecto.fs#L138) test should be nested under `Composed test lists?` and `Composed test lists - 2` and is not a root level test.

Before
![top-level-clutter](https://github.com/ionide/ionide-vscode-fsharp/assets/2847259/62b9f2f3-cb8e-465b-8977-75c150077cda)

After
![top-level-clutter-solved](https://github.com/ionide/ionide-vscode-fsharp/assets/2847259/ec9c89a0-ddd2-4548-a2e1-6ec7fca81529)

### HOW
If an explorer test can't be located in code, check if any of the code test ids are a suffix of the explorer test id.


### Known Issues

1. It still has issues locating tests under parents that can't be matched. For example, if the parent test name contains a separator character like `+` or `.`.
2. Test located by this new approach do not get live updates, which could be confusing for users.

### Alternative Approaches

I hoped to solve this within the FSAC `testDetected` endpoint. 
This would have made it simple to support live explorer updates, and the code analysis results would have been more aligned with the logical structure of the tests.

The basic idea was to try resolving any referenced values within an expecto testList.
However, it doesn't look like this can be done with the untyped expression used for detecting tests.
Using the typed expressions seemed like a heavy update that could cause performance issues with how frequently this analysis is run.

I didn't measure the performance of using the typed expressions though. It may still be viable.
I also may have missed options for resolving symbols in the untyped AST.

### Performance

I tested this on large numbers of tests in several repos, since it runs every time the code updates.
I didn't observe any slowdowns, but I'm 100% confident this can't cause performance issues.

