### PR TITLE
Test debugging

### DIFF
--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -485,6 +485,9 @@ module DotnetCli =
                 Vscode.debug.startDebugging (Some folder, U2.Case2 launchRequest)
                 |> Promise.ofThenable
 
+            // NOTE: Have to wait or it'll continue before the debugger reaches the stop on entry point.
+            //       That'll leave the debugger in a confusing state where it shows it's attached but 
+            //       no breakpoints are hit and the breakpoints show as disabled
             do! Promise.sleep 2000
             Vscode.commands.executeCommand ("workbench.action.debug.continue") |> ignore
         }
@@ -524,6 +527,8 @@ module DotnetCli =
 
             let tryLaunchDebugger (consoleOutput: Node.Buffer.Buffer) =
                 if not isDebuggerStarted then
+                    // NOTE: the processId we need to attach to is not the one we started for `dotnet test`. 
+                    //       Dotnet test will return the correct process id if (and only if) we are in debug mode
                     match tryGetDebugProcessId (string consoleOutput) with
                     | None -> ()
                     | Some processId ->


### PR DESCRIPTION
### WHAT
Add ability to debug unit tests from the Ionide Test Explorer.

https://github.com/ionide/ionide-vscode-fsharp/assets/2847259/7a9bbff8-56a0-4edb-b480-0a7276d30a79

Debug is also available from the gutter decoration
![image](https://github.com/ionide/ionide-vscode-fsharp/assets/2847259/da54e452-4038-4a95-ac36-e00657c1282b)

### HOW
Add a new test run profile for debugging. 
When the debugging profile is selected, 
1. set the right environment variable for vstest to return the processId (and wait for a debugger to attach)
2. parse the processId out of the output
3. attach to that process with a vscode attach profile
4. `workbench.action.debug.continue` to get past the stop on entry that can be confusing 

I tested to make sure it works across frameworks (Expecto, XUnit, etc) and when multiple projects are run.