### PR TITLE
Add a leading space to the default prefix in LineLens.config

### DIFF
--- a/src/Components/LineLens/LineLensShared.fs
+++ b/src/Components/LineLens/LineLensShared.fs
@@ -186,7 +186,7 @@ type LineLens
     let decorationType =
         decorationType |> Option.defaultValue LineLensDecorations.decorationType
 
-    let mutable config = { enabled = true; prefix = "// " }
+    let mutable config = { enabled = true; prefix = " // " }
     let mutable state: LineLensState option = None
 
     /// Set the decorations for the editor, filtering lines where the user recently typed


### PR DESCRIPTION
### WHAT
Add a leading space to the default prefix string in the shared line lens code.

### WHY
refs #1924 

Note that this only updates the default value and doesn't fix the actual issue, it just seemed reasonable to me for this default to have a leading space to match the one at https://github.com/ionide/ionide-vscode-fsharp/blob/61c4d71ef5b255a77aa368548530380174d39ac4/src/Components/LineLens/LineLens.fs#L35C53-L35C53

I'll do a test PR shortly for another possible change related to the issue

### HOW
It's just a space in the prefix string.
