### PR TITLE
Make LineLens.configChangedHandler update the config directly, instead of through a ref

### DIFF
--- a/src/Components/LineLens/LineLensShared.fs
+++ b/src/Components/LineLens/LineLensShared.fs
@@ -275,12 +275,12 @@ type LineLens
         state <- None
         logger.Debug "Uninstalled"
 
-    let configChangedHandler (config: LineLensConfig ref) decorationType =
+    let configChangedHandler decorationType =
         logger.Debug("Config Changed event")
 
-        let wasEnabled = (config.Value.enabled) && state <> None
-        config.Value <- getConfig ()
-        let isEnabled = config.Value.enabled
+        let wasEnabled = (config.enabled) && state <> None
+        config <- getConfig ()
+        let isEnabled = config.enabled
 
         if wasEnabled <> isEnabled then
             if isEnabled then install decorationType else uninstall ()
@@ -313,7 +313,8 @@ type LineLens
 
     member t.activate(context: ExtensionContext) =
         logger.Info "Activating"
-        let changeHandler = fun () -> configChangedHandler (ref config) decorationType
+
+        let changeHandler = fun () -> configChangedHandler decorationType
 
         workspace.onDidChangeConfiguration $ (changeHandler, (), context.subscriptions)
         |> ignore


### PR DESCRIPTION
### WHAT
Not sure if this is the right thing to do, but:

I was looking at #1924 about the missing leading space in the lens text.
Whilst testing, I tried changing the user setting for the lens prefix from ' //  ' to a custom value (e.g. ' **  ') and noticed that that wasn't picked up either.

It looks to me like the intent is for the 'default' value (the one changed in #1928) to be overwritten be a configuration specifed value that gets loaded in the ```configChangedHandler ``` call made from the ```activate``` event.
However - when I tried debugging it it looked like the updated ```prefix``` value wasn't peristed into the ```config``` member of ```LineLens``` - it looked to always be using the local default.

I'm not sure what's causing that to go wrong, *but* - I'm not sure why the config object is passed into ```configChangedHandler ``` by reference and from a bit of testing it seems that just making it update the ```config``` member directly causes the whole thing to correctly pick up a user specified prefix string.

So - here it is for any comments from anyone who knows more about how it's supposed to work.

### WHY
refs #1924 

### HOW
Update the ```config``` member of ```LineLens``` directly instead of through a reference.
