### PR TITLE
Add keybinding to fsharp.explorer.renameFile in F# Solution Explorer

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -949,6 +949,11 @@
     ],
     "keybindings": [
       {
+        "command": "fsharp.explorer.renameFile",
+        "key": "F2",
+        "when": "viewItem == ionide.projectExplorer.file"
+      },
+      {
         "command": "fsi.SendLine",
         "key": "alt\u002B/",
         "mac": "alt\u002B/",


### PR DESCRIPTION
### WHAT
copilot:summary

copilot:poem

copilot:emoji

### WHY
I thought this would be a quick one, but apparently I'm missing some background story here why this doesn't work with such a simple change. Does anyone know why?

### HOW
copilot:walkthrough
