### PR TITLE
Fix regression of AutoDiscoverTestsOnLoad behavior

### DIFF
--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1628,10 +1628,13 @@ let activate (context: ExtensionContext) =
 
     testController.refreshHandler <- Some refreshHandler
 
+    let shouldAutoDiscoverTests =
+        Configuration.get true "FSharp.TestExplorer.AutoDiscoverTestsOnLoad"
+
     let mutable hasInitiatedDiscovery = false
 
     Project.workspaceLoaded.Invoke(fun () ->
-        if not hasInitiatedDiscovery then
+        if shouldAutoDiscoverTests && not hasInitiatedDiscovery then
             hasInitiatedDiscovery <- true
 
             let trxTests =


### PR DESCRIPTION
#1919 behavior was [unintentionally removed](https://github.com/ionide/ionide-vscode-fsharp/commit/61c4d71ef5b255a77aa368548530380174d39ac4#r127656246).  Perhaps clobbered in a merge?
This restores the missing conditional.

Thanks @stroborobo for pointing it out