### PR TITLE
Bug xunit theory

### DIFF
--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1628,10 +1628,13 @@ let activate (context: ExtensionContext) =
 
     testController.refreshHandler <- Some refreshHandler
 
+    let shouldAutoDiscoverTests =
+        Configuration.get true "FSharp.TestExplorer.AutoDiscoverTestsOnLoad"
+
     let mutable hasInitiatedDiscovery = false
 
     Project.workspaceLoaded.Invoke(fun () ->
-        if not hasInitiatedDiscovery then
+        if shouldAutoDiscoverTests && not hasInitiatedDiscovery then
             hasInitiatedDiscovery <- true
 
             let trxTests =


### PR DESCRIPTION
### WHAT
#1935 
Parameterized tests were never finishing for xUnit and MSTest.
This gets them completing properly.

### HOW
Piece together consistent fully qualified test names from different fields based on the test framework.

## Merge?

I'm not sure if this PR is worth merging yet.
It does get parameterized tests completing and status showing across xUnit, nUnit, MSTest, and expecto.

However, MSTest and xUnit still can't individually run the theory cases (some kind of filter issue), and the theory cases aren't nested under their shared method.
This makes it a impossible to run the theory test without running a larger grouping of tests.