### PR TITLE
Fix test explorer zsh

### DIFF
--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -557,12 +557,12 @@ module DotnetCli =
             let filter =
                 match filterExpression with
                 | None -> Array.empty
-                | Some filterExpression -> [| "--filter"; filterExpression |]
+                | Some filterExpression -> [| "--filter"; $"\"{filterExpression}\"" |]
 
             if filter.Length > 0 then
                 logger.Debug("Filter", filter)
 
-            let! _, stdOutput, stdError =
+            let! errored, stdOutput, stdError =
                 dotnetTest
                     cancellationToken
                     projectPath
@@ -571,7 +571,9 @@ module DotnetCli =
                     shouldDebug
                     [| "--no-build"; yield! filter |]
 
-            logger.Debug("Test run exitCode", stdError)
+            match errored with
+            | Some error -> logger.Error("Test run failed - %s - %s - %s", error, stdOutput, stdError)
+            | None -> logger.Debug("Test run exitCode - %s - %s", stdOutput, stdError)
 
             return (stdOutput + stdError)
         }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4556279</samp>

This pull request improves the test explorer functionality by fixing a test filter bug, adding error handling and logging, and changing the `dotnet test` usage in `TestExplorer.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4556279</samp>

> _Oh we're the crew of the dotnet test_
> _We filter and log with the best_
> _We fix the bugs and we handle the errors_
> _We heave away on the dotnetTest_

<!--
copilot:emoji
-->

🐛🚧🛠️

<!--
1.  🐛 - This emoji represents a bug fix, and is appropriate for the fix to the test filter expression.
2.  🚧 - This emoji represents work in progress or improvement, and is appropriate for the better error handling and logging for the test run.
3.  🛠️ - This emoji represents a tool or configuration change, and is appropriate for the change to how the `dotnet test` command and the `dotnetTest` function are used.
-->

### WHY

I couldn't get the single tests to run on zsh. I wasn't getting anything useful out of the message `Test run exitCode`.

I took what what it was running and got this output:

```
 dotnet test "/workspaces/IcedTasks/tests/IcedTasks.Tests/IcedTasks.Tests.fsproj" --framework:"net7.0" --logger:"trx;LogFileName=/home/vscode/.vscode-server/data/User/workspaceStorage/cb18f208f0b841c60c9d3407677860ba/Ionide.Ionide-fsharp/TestResults/tests/IcedTasks.Tests/IcedTasks.Tests.trx" --noLogo --no-build --filter (FullyQualifiedName=IcedTasks.CancellableTask.CancellableTaskBuilder.Return.Simple Return)
zsh: unknown username ''
```

Turns out we need to quote the filter expression.


Future things:
* I still couldn't get any useful logs out of the stdout/stderr to `dotnet test` `Process.execWithCancel`. Not sure what we need to do here to make this better.
* It seems we always [assume the process doesn't fail](https://github.com/ionide/ionide-vscode-fsharp/blob/0295f8566d63c0ef537c264b565068c8467c9e35/src/Components/TestExplorer.fs#L576). It used the last run which passed and showing incorrect.
  * we should probably delete the old trx before each test run
  * Maybe we should do the promise.reject here instead

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4556279</samp>

*  Fix test filter expression bug and improve error reporting ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1940/files?diff=unified&w=0#diff-51e985f1db823123c423ec349d4ae157638ef09eed6c1881558239dca6b592baL560-R565), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1940/files?diff=unified&w=0#diff-51e985f1db823123c423ec349d4ae157638ef09eed6c1881558239dca6b592baL574-R576))
