### PR TITLE
Add command to restart language service

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -408,6 +408,11 @@
           "light": "./images/lock-open-solid-light.svg"
         },
         "title": "Unlock Info Panel"
+      },
+      {
+        "category": "F#",
+        "command": "fsharp.restartLanguageService",
+        "title": "Restart Language Service"
       }
     ],
     "configuration": {
@@ -1231,6 +1236,10 @@
         {
           "command": "fsharp.showDocumentation",
           "when": "false"
+        },
+        {
+          "command": "fsharp.restartLanguageService",
+          "when": "editorLangId == \u0027fsharp\u0027"
         }
       ],
       "editor/context": [

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -1004,3 +1004,14 @@ Consider:
             | Some cl -> return! cl.stop ()
             | None -> return ()
         }
+
+    let activate (context: ExtensionContext) =
+        let restart () =
+            promise {
+                logger.Debug("Restarting F# langugae service")
+                do! stop ()
+                do! start context
+            }
+
+        commands.registerCommand ("fsharp.restartLanguageService", restart |> objfy2)
+        |> context.Subscribe

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -1004,14 +1004,3 @@ Consider:
             | Some cl -> return! cl.stop ()
             | None -> return ()
         }
-
-    let activate (context: ExtensionContext) =
-        let restart () =
-            promise {
-                logger.Debug("Restarting F# langugae service")
-                do! stop ()
-                do! start context
-            }
-
-        commands.registerCommand ("fsharp.restartLanguageService", restart |> objfy2)
-        |> context.Subscribe

--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -93,6 +93,7 @@ let activate (context: ExtensionContext) : JS.Promise<Api> =
         tryActivate "pipelinehints" PipelineHints.Instance.activate context
         tryActivate "testExplorer" TestExplorer.activate context
         tryActivate "inlayhints" InlayHints.activate context
+        tryActivate "languageservice" LanguageService.activate context
 
         let buildProject project =
             promise {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a851bf</samp>

This pull request adds a new feature to the extension that allows users to restart the F# language service from the command palette or a keyboard shortcut. It defines a new command `fsharp.restartLanguageService` and registers it in the `release/package.json`, `src/Core/LanguageService.fs`, and `src/fsharp.fs` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a851bf</samp>

> _If your F# extension is slow_
> _And you want to give it a go_
> _Use `fsharp.restartLanguageService`_
> _With a key or a palette, your choice_
> _And it will reload the language flow_

<!--
copilot:emoji
-->

🔄🌐🔧

<!--
1.  🔄 This emoji represents the idea of restarting or reloading something, which is what the new command does for the language service. It also suggests a circular dependency or a feedback loop, which is relevant for the language service feature.
2.  🌐 This emoji represents the concept of a language or a communication system, which is what the language service provides for the extension. It also suggests a global or universal scope, which is relevant for the F# language and its cross-platform support.
3.  🔧 This emoji represents the idea of a tool or a utility, which is what the language service is for the extension. It also suggests a configuration or a customization option, which is relevant for the language service settings and preferences.
-->

This will close #1911 
![image](https://github.com/ionide/ionide-vscode-fsharp/assets/105478675/ced08464-d951-420b-a279-da958bb23697)


### WHY
> Ionide frequently has corner cases and needs refresh, I think it would improve to some extend developer experience just to have a way to completely restart ionide from vscode, when nothing else works, instead of closing and reopening vscode.

#1911 

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a851bf</samp>

*  Add a new command to restart the language service ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1942/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R411-R415), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1942/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R1239-R1242), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1942/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befR1007-R1017), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1942/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2R96))
  - Define the command "fsharp.restartLanguageService" in `package.json` with the title "Restart Language Service" and the category "F#" ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1942/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R411-R415))
  - Assign a keybinding to the command when the editor language is F# in `package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1942/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R1239-R1242))
  - Implement the command logic in `LanguageService.fs` by defining a "restart" function that stops and starts the language service using a promise ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1942/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befR1007-R1017))
  - Register the "restart" function as a command handler and subscribe it to the extension context's disposable resources in `LanguageService.fs` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1942/files?diff=unified&w=0#diff-7a4817cd38831edb5b73fc3a9302f3770b0b7b9c38a8bf1d0ddd19db0ca48befR1007-R1017))
  - Activate the language service feature when the extension is activated by calling "tryActivate" with the feature name "languageservice" and the activation function `LanguageService.activate` in `fsharp.fs` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1942/files?diff=unified&w=0#diff-93605fe63fbdae821d93b1581e0ba8e17939b52f643f7dfb0871423f6f5fd6b2R96))
