### PR TITLE
Xunit theory filter

### DIFF
--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1202,6 +1202,17 @@ module Interactions =
                 // NOTE: using DisplayName allows single theory cases to be run for xUnit
                 let operator = if test.children.size = 0 then "=" else "~"
                 $"(DisplayName{operator}{escapedTestName})"
+            else if test.TestFramework = TestFrameworkId.MsTest && String.endWith ")" fullTestName then
+                // NOTE: MSTest can't filter to parameterized test cases
+                //  Truncating before the case parameters will run all the theory cases
+                //  example parameterized test name -> `MsTestTests.TestClass.theoryTest (2,3,5)`
+                let truncateOnLast (separator: string) (toSplit: string) =
+                    match toSplit.LastIndexOf(separator) with
+                    | -1 -> toSplit
+                    | index -> toSplit.Substring(0, index)
+
+                let truncatedTestName = truncateOnLast @" \(" escapedTestName
+                $"(FullyQualifiedName~{truncatedTestName})"
             else if test.children.size = 0 then
                 $"(FullyQualifiedName={escapedTestName})"
             else


### PR DESCRIPTION
### WHAT

#1935

#1936 got parameterized tests running as part of larger groups. 
This PR continues that work and allows individual cases to be run individually from
the test explorer (i.e. clicking the run button on a theory case in the test explorer)

Note that for MSTest, it will actually run all of the theory cases because there doesn't appear to be a way to filter to a single parameterized test case in MSTest. It'll still look right, but multiple cases will be run if they try to debug. 
All other frameworks (xUnit, nUnit, Expecto) can run individual parameterized cases and will debug as expected.

### HOW

Mostly through modifying how we build the `dotnet test` filter expressions based on which test framework the project uses.

### Nesting Deferred

I decided not to tackle nesting parameterized cases under a dedicated parent item in the test explorer (like Visual Studio does).
I'm still contemplating the options. Breaking the assumption that the explorer hierarchy matches the test name hierarchy could cause a lot of problems and complexity.