### PR TITLE
Don't offer to reference the target project when adding a project reference

### DIFF
--- a/src/Core/FsProjEdit.fs
+++ b/src/Core/FsProjEdit.fs
@@ -64,18 +64,21 @@ module FsProjEdit =
 
     let addProjectReferencePath path =
         promise {
-            let projects = Project.getAll () |> ResizeArray
+            match path with
+            | Some path ->
+                let projects = Project.getAll () |> List.filter (fun p -> p <> path) |> ResizeArray
 
-            if projects.Count <> 0 then
-                let opts = createEmpty<QuickPickOptions>
-                opts.placeHolder <- Some "Reference"
+                if projects.Count <> 0 then
+                    let opts = createEmpty<QuickPickOptions>
+                    opts.placeHolder <- Some "Reference"
 
-                let! n = window.showQuickPick (projects |> U2.Case1, opts)
+                    let! n = window.showQuickPick (projects |> U2.Case1, opts)
 
-                return!
-                    match n, path with
-                    | Some n, Some path -> LanguageService.dotnetAddProject path n
-                    | _ -> Promise.empty
+                    return!
+                        match n with
+                        | Some n -> LanguageService.dotnetAddProject path n
+                        | _ -> Promise.empty
+            | _ -> return! Promise.empty
         }
 
     let removeProjectReferencePath ref proj =


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at becb165</samp>

Fixed a bug and improved the user experience for adding project references in `FsProjEdit.fs`. Filtered out the current project and handled None paths in `addProjectReferencePath`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at becb165</samp>

> _`addProjectReferencePath`_
> _Filters out self, handles None_
> _Autumn bug fixing_

<!--
copilot:emoji
-->

🐛🚸🔧

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It indicates that the function was not working as expected before and that the issue was resolved.
2.  🚸 - This emoji represents an improvement in the user experience, which is a secondary benefit of the change. It indicates that the function now provides more helpful feedback and prevents invalid inputs.
3.  🔧 - This emoji represents a configuration change, which is a minor aspect of the change. It indicates that the function now handles a different case when the path argument is None, which may affect how the function is called or configured.
-->

### WHY
Don't offer people a rope.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at becb165</samp>

* Fix a bug that allowed adding a circular reference to the same project and improve the user experience by showing only relevant options ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1945/files?diff=unified&w=0#diff-bfb75cc398e99c2d45911a776235bf42ea43185d2272387ce0b76f1f33a85881L67-R81))
