### PR TITLE
Forward env variables in test debugging

### DIFF
--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -566,7 +566,12 @@ module DotnetCli =
                         launchDebugger processId
                         isDebuggerStarted <- true
 
-            let env = {| VSTEST_HOST_DEBUG = 1 |} |> box |> Some
+            let env =
+                let parentEnv = Node.Api.``process``.env
+                let childEnv = parentEnv
+                childEnv?VSTEST_HOST_DEBUG <- 1
+                childEnv |> box |> Some
+
             Process.execWithCancel "dotnet" (ResizeArray(args)) env tryLaunchDebugger cancellationToken
         | NoDebug -> Process.execWithCancel "dotnet" (ResizeArray(args)) None ignore cancellationToken
 


### PR DESCRIPTION
### WHAT
Ensure environment variables are forwarded when debugging tests.

### WHY
Issue #1946 revealed that the environment variables were not the same between debug and non-debug executions of a test.
This causes inconsistent behavior for tests that access environment variables. 

The cause of this bug was accidental override of the whole environment variable collection in order to set the debug flag for vstest.



