### PR TITLE
fix and improve

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -525,6 +525,11 @@
           "description": "Includes external (from unopened modules and namespaces) symbols in autocomplete",
           "type": "boolean"
         },
+        "FSharp.fullNameExternalAutocomplete": {
+          "default": false,
+          "description": "When selecting an external symbols in autocomplete, insert the full name to the editor rather than open its module/namespace. Also allow filtering suggestions by typing its full name. \n\n Requires `FSharp.externalAutocomplete` enabled.",
+          "type": "boolean"
+        },
         "FSharp.fsac.attachDebugger": {
           "default": false,
           "description": "Appends the \u0027--attachdebugger\u0027 argument to fsac, this will allow you to attach a debugger.",

--- a/src/Components/LineLens/PipelineHints.fs
+++ b/src/Components/LineLens/PipelineHints.fs
@@ -44,10 +44,13 @@ module PipelineDecorationUpdate =
 
             textLine.range, n.Types, previousTextLine)
 
+    /// match something like " 'T1 is int list "
+    let typeParamRegex = JS.Constructors.RegExp.Create @"'.+?\s.+?\s([\s\S]+)"
+
     let private getSignature (index: int) (range: Vscode.Range, tts: string[]) =
         let tt = tts.[index]
-        let id = tt.IndexOf("is")
-        let res = tt.Substring(id + 3)
+        let groups = typeParamRegex.Match(tt).Groups
+        let res = groups[1].Value
         range, "  " + res
 
     let private getSignatures (range: Vscode.Range, tts: string[], previousNonPipeLine: Vscode.Range option) =


### PR DESCRIPTION

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53f4abb</samp>

This pull request adds a new option for customizing external autocomplete, a feature for sending the current line to F# interactive, and a bug fix for the pipeline hints type signatures. It affects the files `release/package.json`, `src/Components/Fsi.fs`, and `src/Components/LineLens/PipelineHints.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 53f4abb</samp>

> _If you want to use F# in VS Code_
> _You might like this pull request's load_
> _It fixes `getSignature`_
> _Adds `fullNameExternalAutocomplete`_
> _And lets you send lines to `Fsi` mode_

<!--
copilot:emoji
-->

🐛🛠️🚀

<!--
1.  🐛 for the bug fix in the `getSignature` function.
2.  🛠️ for the new option and formatting change in the `package.json` file.
3.  🚀 for the new feature of sending the current line to the F# interactive terminal.
-->

### WHY
1. add: new FSAC config fullNameExternalAutocomplete (fsharp/FsAutoComplete#1178) to package.json
2. fix: PipelineHint display wrong with localized type param output (wrong display examples like #1653), now it will correctly display hints without cutting too much to the type name, adding extra "1" or word "is" (like "是" in Chinese, "は" in Japanese).
3. improve: use correct line number when sending lines to fsi. This change makes the line numbers consistent in FSI and the editor, may making scripts easier to debug.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 53f4abb</samp>

*  Add a new configuration option for external autocomplete ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1952/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15R528-R532))
* Support sending the current line to F# interactive terminal ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1952/files?diff=unified&w=0#diff-9bc76a29d86d81de8050e1137bb71027121b22b7df2f87cf5e05a8e43dd6b39bL322-R334), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1952/files?diff=unified&w=0#diff-9bc76a29d86d81de8050e1137bb71027121b22b7df2f87cf5e05a8e43dd6b39bL344-R355), [link](https://github.com/ionide/ionide-vscode-fsharp/pull/1952/files?diff=unified&w=0#diff-9bc76a29d86d81de8050e1137bb71027121b22b7df2f87cf5e05a8e43dd6b39bL492-R505))
* Fix type signature extraction for pipeline hints ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1952/files?diff=unified&w=0#diff-dbab5b128338ebe31e4a7f519fa49fb3c35e53a8ef76615c0f78afe15ada4da6L47-R53))
* Add a newline at the end of `release/package.json` ([link](https://github.com/ionide/ionide-vscode-fsharp/pull/1952/files?diff=unified&w=0#diff-7902ed52e6f39559068a38e3c223d7f7d7d0b0977aee33d659db648092a62b15L1774-R1779))
