### PR TITLE
[WIP] Allow selecting fsproj files into workspace

### DIFF
--- a/src/Components/MSBuild.fs
+++ b/src/Components/MSBuild.fs
@@ -399,6 +399,7 @@ module MSBuild =
     let buildTaskListForSolution (s: WorkspacePeekFound) : JS.Promise<MSBuildTask seq> =
         promise {
             match s with
+            | WorkspacePeekFound.Fsproj _ -> return Seq.empty
             | WorkspacePeekFound.Directory _ -> return Seq.empty
             | WorkspacePeekFound.Solution({ Path = p }) ->
                 let! dotnet = dotnetBinary ()

--- a/src/Components/SolutionExplorer.fs
+++ b/src/Components/SolutionExplorer.fs
@@ -262,6 +262,11 @@ module SolutionExplorer =
             let result = Workspace items
             setParentRefs items result
             result
+        | WorkspacePeekFound.Fsproj proj ->
+            let result = getProjItem proj.Fsproj
+            let root = Workspace [ result ]
+            setParentRef result root
+            root
 
     let private getSolution () =
         Project.getLoadedSolution () |> Option.map getSolutionModel

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -272,8 +272,11 @@ module DTO =
     type WorkspacePeek = { Found: WorkspacePeekFound[] }
 
     and WorkspacePeekFound =
+        | Fsproj of WorkspacePeekFoundFsproj
         | Directory of WorkspacePeekFoundDirectory
         | Solution of WorkspacePeekFoundSolution
+    and WorkspacePeekFoundFsproj =
+        { Fsproj: string }
 
     and WorkspacePeekFoundDirectory =
         { Directory: string; Fsprojs: string[] }


### PR DESCRIPTION
### WHAT
copilot:summary

copilot:poem

copilot:emoji

### WHY
When working in a monorepo with multiple independent projects it is not feasible to load all the projects in the repository. This change allows the user to select the projects that they are working on and only load them.

### HOW
copilot:walkthrough
