### PR TITLE
Experimental setting to leverage FSAC path as an extra --compilertool flag

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -614,6 +614,11 @@
           "markdownDescription": "An array of additional command line parameters to pass to FSI when it is started. See [the Microsoft documentation](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/fsharp-interactive-options) for an exhaustive list.",
           "type": "array"
         },
+        "FSharp.fsiUsesFSACDirectoryForCompilerTool": {
+          "default": false,
+          "markdownDescription": "EXPERIMENTAL: adds an --compiltertool:/path/to/FSAC argument to the FSI parameters so the extensions that FSAC ships are conviniently loaded in the FSI session",
+          "type": "bool"
+        },
         "FSharp.fsiSdkFilePath": {
           "default": "",
           "description": "The path to the F# Interactive tool used by Ionide-FSharp (When using .NET SDK scripts)",

--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -386,8 +386,60 @@ module Fsi =
             match dotnet with
             | Ok dotnet ->
                 let! fsiSetting = LanguageService.fsiSdk ()
+                let! (_, fsacPath) = LanguageService.SdkResolution.resolvedFsacPathForAmbientSdkTargetFramework ()
+
+                let fsacPath =
+                    if fsacPath.EndsWith ".dll" then
+                        let lastIndex =
+                            [ fsacPath.LastIndexOf "/"; fsacPath.LastIndexOf @"\\" ]
+                            |> Seq.sortDescending
+                            |> Seq.tryHead
+
+                        match lastIndex with
+                        | Some lastIndex when lastIndex > 0 -> fsacPath.Substring(0, lastIndex)
+                        | None
+                        | Some _ -> fsacPath
+                    else
+                        fsacPath
+
                 let fsiArg = defaultArg fsiSetting "fsi"
-                return dotnet, [| yield fsiArg; yield! parms |]
+
+                let parms =
+                    let useFsacDirectoryAsCompilerTool =
+                        "FSharp.fsiUsesFSACDirectoryForCompilerTool" |> Configuration.get false
+
+                    let p =
+                        node.path.join (VSCodeExtension.ionidePluginPath (), "watcher", "watcher.fsx")
+
+                    let fsiParams =
+                        let userParams =
+                            "FSharp.fsiExtraParameters"
+                            |> Configuration.get Array.empty<string>
+                            |> List.ofArray
+
+                        if useFsacDirectoryAsCompilerTool then
+                            userParams @ [ $"--compilertool:{fsacPath}" ]
+                        else
+                            userParams
+
+                    let fsiParams =
+                        let addWatcher = "FSharp.addFsiWatcher" |> Configuration.get false
+
+                        if addWatcher then
+                            [ "--load:" + p ] @ fsiParams
+                        else
+                            fsiParams
+
+                    if Environment.isWin then
+                        // these flags are added to work around issues with the vscode terminal shell on windows
+                        [ "--fsi-server-input-codepage:28591"; "--fsi-server-output-codepage:65001" ]
+                        @ fsiParams
+                    else
+                        fsiParams
+
+                let args = [| fsiArg; yield! parms |]
+
+                return dotnet, args
             | Error msg -> return failwith msg
         }
 


### PR DESCRIPTION
add experimental option to conveniently add --compilertool:/path/to/fsac to the FSI session.

related:
* https://github.com/fsharp/FsAutoComplete/pull/1198
* https://github.com/dotnet/fsharp/issues/8880

### WHAT
copilot:summary

copilot:poem

copilot:emoji

### WHY

[FSAC is bound to ship great FSI extensions](https://github.com/fsharp/FsAutoComplete/pull/1198), let's make it convenient for users to add those to the FSI session.


### HOW
copilot:walkthrough
