### PR TITLE
Associate `.fantomasignore` with `ignore` files

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -45,6 +45,9 @@
         "*.fs": "${basename}.fsi, ${basename}.fs.js, ${basename}.fs.js.map",
         "*.fsl": "${basename}.fsi, ${basename}.fs",
         "*.fsy": "${basename}.fsi, ${basename}.fs"
+      },
+      "files.associations": {
+        ".fantomasignore": "ignore"
       }
     },
     "colors": [


### PR DESCRIPTION
Doing so allows us to have nice icon for `.fantomasignore` file and also syntax highlighting, etc.

![CleanShot 2024-03-05 at 19 04 28](https://github.com/ionide/ionide-vscode-fsharp/assets/4760796/9819ebd7-7a4a-414e-8061-841efafc02fd)
