### PR TITLE
Add bracket indentation semantics to (* *)

### DIFF
--- a/src/Components/LanguageConfiguration.fs
+++ b/src/Components/LanguageConfiguration.fs
@@ -12,10 +12,10 @@ module LanguageConfiguration =
         jsOptions<IndentationRule> (fun o ->
             o.increaseIndentPattern <-
                 Regex(
-                    """^(\s*(module|type|let|static member|member)\b.*=\s*)$|^(\s*(with get|and set)\b.*=.*)$|^(\s*(if|elif|then|else|static member|member)).*$"""
+                    """^(\s*(module|type|let|static member|member)\b.*=\s*)$|^(\s*(with get|and set)\b.*=.*)$|^(\s*(if|elif|then|else|static member|member|\(\*)).*$"""
                 )
 
-            o.decreaseIndentPattern <- Regex("""^(\s*(else|elif|and)).*$"""))
+            o.decreaseIndentPattern <- Regex("""^(\s*(else|elif|and|\*\))).*$"""))
 
     let setLanguageConfiguration (triggerNotification: bool) =
         // Config always setted


### PR DESCRIPTION
Background: ionide/ionide-fsgrammar#209 and ionide/ionide-fsgrammar#210

This comes from a comment regarding a pull request that I made on the ionide-fsgrammar repository, which removes the `(* *)` bracket pair from the "brackets" field of language-configuration.json. One issue with doing this is that we lose the bracket-like indentation that VSCode provides by default for all bracket pairs. This pull request re-adds the same semantics to the indentation rules.

In other words, when I hit Enter in the following configuration, cursor location represented by the white block:

    (*█*)

It should indent the cursor and then put the `*)` on the next line with the same indentation level as the `(*` as follows:

    (*
        █
    *)

---

When I hit Enter with an unaccompanied `(*`:

    (*█

It should simply indent as follows:

    (*
        █

---

Lastly, an unaccompanied `*)` should outdent. That is,

        *)█

should become

    *)█