### PR TITLE
Escape quotes in test filter expressions

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -48,4 +48,4 @@ group build
   // Enforce updated binlog parser until Fake gets an update, so we're not stuck
   // on an old sdk version.
   // ref: https://github.com/fsprojects/FAKE/issues/2744
-  nuget MSBuild.StructuredLogger >= 2.1.784
+  nuget MSBuild.StructuredLogger >= 2.2

--- a/paket.lock
+++ b/paket.lock
@@ -194,7 +194,7 @@ NUGET
       System.Security.Principal.Windows (>= 5.0)
     Microsoft.Win32.SystemEvents (7.0)
     Mono.Posix.NETStandard (1.0)
-    MSBuild.StructuredLogger (2.1.846)
+    MSBuild.StructuredLogger (2.2.206)
       Microsoft.Build.Framework (>= 17.5)
       Microsoft.Build.Utilities.Core (>= 17.5)
     Newtonsoft.Json (13.0.2)

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1174,7 +1174,10 @@ module Interactions =
         |> Promise.ofThenable
 
     let private filterEscapeCharacter = '\\'
-    let private filterSpecialCharacters = [| '\\'; '('; ')'; '&'; '|'; '='; '!'; '~' |]
+
+    let private filterSpecialCharacters =
+        [| '\\'; '('; ')'; '&'; '|'; '='; '!'; '~'; '"' |]
+
     let private filterSpecialCharactersSet = Set.ofArray filterSpecialCharacters
 
     let private buildFilterExpression (tests: TestItem array) =


### PR DESCRIPTION
Test names with quotes currently prevent the test explorer from running that test individually.
This PR escapes quotes in the test name when creating the filter expression to fix that issue.