### PR TITLE
Adds arbitrary additional arguments to be passed to fsac

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -569,6 +569,14 @@
           },
           "type": "array"
         },
+        "FSharp.fsac.fsacArgs": {
+          "default": [],
+          "description": "additional CLI arguments to be provided to FSAC itself. Useful for flags that aren't exposed in the settings or CLI arguments that only exist in custom built versions of FSAC. Requires restart.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "FSharp.fsac.gc.conserveMemory": {
           "markdownDescription": "Configures the garbage collector to [conserve memory](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#conserve-memory) at the expense of more frequent garbage collections and possibly longer pause times. Acceptable values are 0-9. Any non-zero value will allow the [Large Object Heap](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap) to be compacted automatically if it has too much fragmentation. Requires restart.",
           "type": "integer",

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -900,6 +900,8 @@ Consider:
 
                     exeOpts.env <- exeEnv
 
+                    let additionalFSACArgs = "FSharp.fsac.fsacArgs" |> Configuration.get [||]
+
                     let args =
                         [ yield! fsacDotnetArgs
                           yield fsacPath
@@ -920,7 +922,8 @@ Consider:
                               let storageDir = uri.fsPath
                               yield "--state-directory"
                               yield storageDir
-                          | None -> () ]
+                          | None -> ()
+                          yield! additionalFSACArgs ]
                         |> ResizeArray
 
                     let executable = createEmpty<Executable>


### PR DESCRIPTION
This lets any args be passed to FSAC. This is useful for flags that don't exist in main and only on nightly. (like https://github.com/ionide/ionide-vscode-fsharp/pull/2003)