### PR TITLE
"Send references for FSI" also loads the project files

### DIFF
--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -611,12 +611,17 @@ module Fsi =
             |> Seq.filter (fun n -> n.EndsWith "FSharp.Core.dll" |> not && n.EndsWith "mscorlib.dll" |> not)
             |> Seq.toList
 
+        let files = project.Files |> Seq.toList
+
         let sendReference terminal (path: ResolvedReferencePath) = send terminal $"#r @\"%s{path}\""
+
+        let sendLoad terminal path = send terminal $"#load @\"%s{path}\""
 
         promise {
             let! terminal = getTerminal ()
 
             do! Promise.executeForAll (sendReference terminal) references
+            do! Promise.executeForAll (sendLoad terminal) files
         }
         |> Promise.suppress
         |> ignore


### PR DESCRIPTION
"Send references for FSI" also loads the project files like "Generate references for FSI". Of course, this is debatable but I was surprised that the two functions had different behaviour. I think, also `#load`ing the project files such that exploration in FSI can take place in the context of the project is more useful.