### PR TITLE
When generating FSI refs files, don't use an explicit view column.

### DIFF
--- a/src/Components/Fsi.fs
+++ b/src/Components/Fsi.fs
@@ -647,7 +647,7 @@ module Fsi =
 
             let! td = vscode.Uri.parse ("untitled:" + path) |> workspace.openTextDocument
 
-            let! te = window.showTextDocument (td, ViewColumn.Three)
+            let! te = window.showTextDocument (td, ViewColumn.Beside)
 
             let! _ =
                 te.edit (fun e ->


### PR DESCRIPTION
Instead, open the file in the 'beside' column - which is relative and will never open more than one column.

Thanks to gim on the F# discord for reporting.