### PR TITLE
use project names instead of full paths to make the picker easier to …

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-dotnet@v2
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
         cache: 'yarn'
     - name: Restore tools
       run: dotnet tool restore

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,6 @@ jobs:
         cache: 'yarn'
     - name: Restore tools
       run: dotnet tool restore
-    - run: yarn global add vsce
+    - run: yarn global add @vscode/vsce
     - name: Run Test
       run: dotnet run --project build -- -t Build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
     - uses: actions/setup-node@v3
       with:
         node-version: '18'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-dotnet@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'yarn'
     - name: Restore tools
       run: dotnet tool restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-dotnet@v2
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
         cache: 'yarn'
     - name: Restore tools
       run: dotnet tool restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-dotnet@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'yarn'
     - name: Restore tools
       run: dotnet tool restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
     - uses: actions/setup-node@v3
       with:
         node-version: '18'

--- a/src/Components/Debugger.fs
+++ b/src/Components/Debugger.fs
@@ -53,6 +53,7 @@ module LaunchJsonVersion2 =
         }
 
 module Debugger =
+    open Node.Api
     let outputChannel = window.createOutputChannel "Ionide: Debugger"
 
     let private logger =
@@ -149,7 +150,10 @@ module Debugger =
             | projects ->
                 let picks =
                     projects
-                    |> List.map (fun p -> createObj [ "data" ==> p; "label" ==> p.Project ])
+                    |> List.map (fun p -> path.basename p.Project, p)
+                    |> List.sortBy fst
+                    |> List.map (fun (projectName, project) ->
+                        createObj [ "data" ==> project; "label" ==> projectName ])
                     |> ResizeArray
 
                 let! proj = window.showQuickPick (unbox<U2<ResizeArray<QuickPickItem>, _>> picks)


### PR DESCRIPTION
@mathias-brandewinder mentioned today that the default project picker is hard to use today if your project paths are quite long. So let's use project name instead!

![image](https://github.com/user-attachments/assets/3690fcc7-1797-4768-9b57-ff687208c6bd)