### PR TITLE
Make inlayhint config changes at the user-level if no workspace is available

### DIFF
--- a/src/Core/Utils.fs
+++ b/src/Core/Utils.fs
@@ -163,6 +163,11 @@ module Configuration =
             .getConfiguration()
             .update (key, value, configurationTarget = U2.Case1 ConfigurationTarget.Global)
 
+    let setForFsharpLanguageOnly key value target =
+        workspace
+            .getConfiguration(scope = ConfigurationScope.Case4 {| languageId = "fsharp"; uri = None |})
+            .update (key, value, configurationTarget = U2.Case1 target, overrideInLanguage = true)
+
 [<AutoOpen>]
 module Utils =
     open Fable.Core


### PR DESCRIPTION
In a 'loose fsx' scenario where no workspace has been opened, saving 'workspace level' configs has no impact.

In that scenario, save any requested config changes to the user-level configuration, and if making a change that impacts settings that are used by multiple languages (like `editor.inlayHints.enable`) make that change specifically for the `fsharp` language identifier.