### PR TITLE
Update to F#9, FSAC 0.75.0, and .NET 9

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### 7.22.0 - 24.11.2024
+
+* Update to FSAC 0.75.0. This release adds support for F# 9 language features and .NET 9 SDKs and tooling.
+* Removes support for .NET 6 and .NET 7 SDKs and tooling.
+* Added new configuration for using the DATAS Server GC Mode via the "FSharp.fsac.gc.useDatas" setting. This mode is enabled by default in .NET 9, disabled by default in .NET 8, and mutually exclusive with the pre-existing "Fsharp.fsac.gc.noAffinitize" and "Fsharp.fsac.gc.heapCount" settings.
+
 ### 7.21.2 - 21.09.2024
 
 * FIXED: [Fix Find References in CodeLens](https://github.com/ionide/ionide-vscode-fsharp/pull/2042) from @PaigeM80

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -309,7 +309,7 @@ let initTargets () =
 
 
     Target.create "CopyFSACNetcore" (fun _ ->
-        let tfms = [ "net6.0"; "net7.0"; "net8.0" ]
+        let tfms = [ "net8.0"; "net9.0" ]
 
         for tfm in tfms do
             let fsacBinNetcore = $"packages/fsac/fsautocomplete/tools/{tfm}/any"

--- a/paket.lock
+++ b/paket.lock
@@ -241,4 +241,4 @@ STORAGE: PACKAGES
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    fsautocomplete (0.74.1)
+    fsautocomplete (0.75)

--- a/release/package.json
+++ b/release/package.json
@@ -585,17 +585,15 @@
           "maximum": 9
         },
         "FSharp.fsac.gc.heapCount": {
-          "default": 2,
-          "markdownDescription": "Limits the number of [heaps](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals#the-managed-heap) created by the garbage collector. Applies to server garbage collection only. See [Middle Ground between Server and Workstation GC](https://devblogs.microsoft.com/dotnet/middle-ground-between-server-and-workstation-gc/) for more details. This can allow FSAC to still benefit from Server garbage collection while still limiting the number of heaps. [Only available on .NET 7 or higher](https://github.com/ionide/ionide-vscode-fsharp/issues/1899#issuecomment-1649009462). Requires restart.",
+          "markdownDescription": "Limits the number of [heaps](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals#the-managed-heap) created by the garbage collector. Applies to server garbage collection only. See [Middle Ground between Server and Workstation GC](https://devblogs.microsoft.com/dotnet/middle-ground-between-server-and-workstation-gc/) for more details. This can allow FSAC to still benefit from Server garbage collection while still limiting the number of heaps. [Only available on .NET 7 or higher](https://github.com/ionide/ionide-vscode-fsharp/issues/1899#issuecomment-1649009462). Requires restart. If FSAC is run on .NET 8 runtimes, this will be set to 2 by default to prevent inflated memory use. On .NET 9 with DATAS enabled, this will not be set. ",
           "type": "integer",
           "required": [
             "FSharp.fsac.gc.server"
           ]
         },
         "Fsharp.fsac.gc.noAffinitize": {
-          "default": true,
           "type": "boolean",
-          "markdownDescription": "Specifies whether to [affinitize](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#affinitize) garbage collection threads with processors. To affinitize a GC thread means that it can only run on its specific CPU.. Applies to server garbage collection only. See [GCNoAffinitize](https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/gcnoaffinitize-element#remarks) for more details. [Only available on .NET 7 or higher](https://github.com/ionide/ionide-vscode-fsharp/issues/1899#issuecomment-1649009462). Requires restart.",
+          "markdownDescription": "Specifies whether to [affinitize](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#affinitize) garbage collection threads with processors. To affinitize a GC thread means that it can only run on its specific CPU.. Applies to server garbage collection only. See [GCNoAffinitize](https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/gcnoaffinitize-element#remarks) for more details. [Only available on .NET 7 or higher](https://github.com/ionide/ionide-vscode-fsharp/issues/1899#issuecomment-1649009462). Requires restart. If FSAC is run on .NET 8 runtimes, this will be set by default. On .NET 9 with DATAS enabled, this will not be set.",
           "required": [
             "FSharp.fsac.gc.server"
           ]
@@ -604,6 +602,13 @@
           "default": true,
           "markdownDescription": "Configures whether the application uses workstation garbage collection or server garbage collection. See [Workstation vs Server Garbage Collection](https://devblogs.microsoft.com/premier-developer/understanding-different-gc-modes-with-concurrency-visualizer/#workstation-gc-vs-server-gc) for more details. Workstation will use less memory but Server will have more throughput. Requires restart.",
           "type": "boolean"
+        },
+        "FSharp.fsac.gc.useDatas": {
+          "markdownDescription": "Configures whether the application uses the DATAS(dynamic adaptation to application sizes) server garbage collection mode. See [DATAS](https://learn.microsoft.com/dotnet/core/runtime-config/garbage-collector#dynamic-adaptation-to-application-sizes-datas) for more details. Requires restart. When FSAC is run on .NET 8 runtimes, this will be set to false by default. On .NET 9 runtimes, this will be set to true by default.",
+          "type": "boolean",
+          "required": [
+            "FSharp.fsac.gc.server"
+          ]
         },
         "FSharp.fsac.netCoreDllPath": {
           "default": "",


### PR DESCRIPTION
This also adds configuration for the .NET 8/9 DATAS server GC mode. This is mutually-exclusive with the existing settings for GC affinitization/heap counts, so we've changed the way we calculate the defaults for these values a bit to handle which runtime version is being used.