### PR TITLE
Enable unnecessary parentheses analyzer by default

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -859,7 +859,7 @@
           ]
         },
         "FSharp.unnecessaryParenthesesAnalyzer": {
-          "default": false,
+          "default": true,
           "description": "Enables detection of unnecessary parentheses",
           "type": "boolean"
         },


### PR DESCRIPTION
- Enable the unnecessary parentheses analyzer added in #1994 (https://github.com/ionide/FsAutoComplete/pull/1235) by default.