### PR TITLE
fixed error introduced in 5fcad29 that breaks the evaluation of values

### DIFF
--- a/release/watcher/watcher.fsx
+++ b/release/watcher/watcher.fsx
@@ -137,7 +137,7 @@ fsi.AddPrinter (fun (_: obj) ->
                 let shadowed = (fst state).Contains name
                 let parms =
                     parms
-                    |> Seq.map (fun (n, t) -> $"{n}: {t}")
+                    |> Seq.map (fun (n, t) -> n + ": " + t)
                     |> String.concat "; "
                 formatVarsAndFuncs name parms typ step shadowed, name)
         let names =


### PR DESCRIPTION
When evaluating expressions in FSI `watcher.fsx` loaded, evaluation of expressions yielded only the name of the variable but not the value anymore. This behaviour seems to have been introduced by a string formatting change in 5fcad29.
The change on the respective line was rolled back and tested - evaluation now works as before the update to version 7.23.