### PR TITLE
Fix #2060: Restore variable evaluation in FSI

### DIFF
--- a/release/watcher/watcher.fsx
+++ b/release/watcher/watcher.fsx
@@ -213,4 +213,4 @@ fsi.AddPrinter (fun (_: obj) ->
     }
     |> Async.Start
 
-    "")
+    null)


### PR DESCRIPTION
This reverts a change made in [5fcad29](https://github.com/ionide/ionide-vscode-fsharp/commit/5fcad2926ccf09d7c987ab6a409c481dda2c4610). This fixes the issue (#2060 )of no values being shown after evaluating expressions in FSI. I am however a bit uneasy about introducing `null` back into the codebase so: suggestions are very welcome!