### PR TITLE
Add exclusion config for parens analyzer

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -867,6 +867,20 @@
           "description": "Enables detection of unnecessary parentheses",
           "type": "boolean"
         },
+        "FSharp.unnecessaryParenthesesAnalyzerExclusions": {
+          "default": [
+            ".*\\.g\\.fs",
+            ".*\\.cg\\.fs"
+          ],
+          "description": "A set of regex patterns to exclude from the unnecessary parentheses analyzer",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "required": [
+            "FSharp.unnecessaryParenthesesAnalyzer"
+          ]
+        },
         "FSharp.smartIndent": {
           "default": false,
           "description": "Enables smart indent feature",


### PR DESCRIPTION
Resolves https://github.com/ionide/FsAutoComplete/discussions/1360 by applying the config technique used for the other FCS analyzers in https://github.com/ionide/FsAutoComplete/pull/1120 and https://github.com/ionide/ionide-vscode-fsharp/pull/1887. Depends on https://github.com/ionide/FsAutoComplete/pull/1363.