### PR TITLE
Update .NET download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You find a version of this plugin pre-packaged with the FOSS debugger from Samsu
 
 # Requirements
 
-* .NET 8.0/9.0 SDK - https://dotnet.microsoft.com/download/dotnet/7.0
+* .NET 8.0/9.0 SDK - https://dotnet.microsoft.com/download
 
 * VS Code C# plugin - Ionide's debugging capabilities rely on either the [Omnisharp](https://github.com/OmniSharp/omnisharp-vscode) debugger or [netcoredbg](https://github.com/muhammadsammy/free-omnisharp-vscode).
 


### PR DESCRIPTION
I removed the version from the link as in general Ionide supports the 2 latest versions and if needed the user can do click on `All .NET version` from the main download page

Fix #2071 