### PR TITLE
Log standard out on passing tests

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
     "sdk": {
-        "version": "8.0.100"
+        "version": "8.0.100",
+        "rollForward": "feature",
+        "allowPrerelease": false
     }
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
   },
   "engines": {
     "node": ">=16.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/release/README.md
+++ b/release/README.md
@@ -59,7 +59,7 @@ You find a version of this plugin pre-packaged with the FOSS debugger from Samsu
 
 ## How to Contribute
 
-Ths project is hosted on [GitHub](https://github.com/ionide/ionide-vscode-fsharp) where you can [report issues](https://github.com/ionide/ionide-vscode-fsharp/issues), participate in [discussions](https://github.com/ionide/ionide-vscode-fsharp/discussions), fork
+This project is hosted on [GitHub](https://github.com/ionide/ionide-vscode-fsharp) where you can [report issues](https://github.com/ionide/ionide-vscode-fsharp/issues), participate in [discussions](https://github.com/ionide/ionide-vscode-fsharp/discussions), fork
 the project and submit pull requests.
 
 ### Building and Running

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -313,12 +313,15 @@ module TrxParser =
         { Message: string option
           StackTrace: string option }
 
+    type Output =
+        { StdOut: string option
+          ErrorInfo: ErrorInfo }
+
     type UnitTestResult =
         { ExecutionId: string
           Outcome: string
           Duration: TimeSpan
-          Output: string option
-          ErrorInfo: ErrorInfo }
+          Output: Output }
 
     type TestWithResult =
         { UnitTest: UnitTest
@@ -392,10 +395,11 @@ module TrxParser =
             { ExecutionId = executionId
               Outcome = outcome
               Duration = durationSpan
-              Output = outputMessage
-              ErrorInfo =
-                { StackTrace = errorStackTrace
-                  Message = errorInfoMessage } }
+              Output =
+                { StdOut = outputMessage
+                  ErrorInfo =
+                    { StackTrace = errorStackTrace
+                      Message = errorInfoMessage } } }
 
         xpathSelector.SelectNodes "/t:TestRun/t:Results/t:UnitTestResult"
         |> Array.map extractRow
@@ -1310,7 +1314,7 @@ module Interactions =
 
     let private trxResultToTestResult (trxResult: TrxParser.TestWithResult) =
         let expected, actual =
-            match trxResult.UnitTestResult.ErrorInfo.Message with
+            match trxResult.UnitTestResult.Output.ErrorInfo.Message with
             | None -> None, None
             | Some message ->
                 let lines =
@@ -1325,9 +1329,9 @@ module Interactions =
 
         { FullTestName = trxResult.UnitTest.FullName
           Outcome = !!trxResult.UnitTestResult.Outcome
-          Output = trxResult.UnitTestResult.Output
-          ErrorMessage = trxResult.UnitTestResult.ErrorInfo.Message
-          ErrorStackTrace = trxResult.UnitTestResult.ErrorInfo.StackTrace
+          Output = trxResult.UnitTestResult.Output.StdOut
+          ErrorMessage = trxResult.UnitTestResult.Output.ErrorInfo.Message
+          ErrorStackTrace = trxResult.UnitTestResult.Output.ErrorInfo.StackTrace
           Expected = expected
           Actual = actual
           Timing = trxResult.UnitTestResult.Duration.Milliseconds


### PR DESCRIPTION
This PR slightly modifies the code in `TestExplorer.fs`, such that if a TRX file contains output, it is emitted for passing tests. This is similar to the behavior of JetBrains Rider. Further, it facilitates having meaningful output when, eg, using FsCheck. 

For example, the following test:
```fsharp
[<Property>]
let ``test some stuff`` (PositiveInt value) =
    (0 < value) |> Prop.collect value
```
will print output like the following:
![image](https://github.com/user-attachments/assets/454e1a4c-8dcf-414e-bd64-5191069f5b1f)

Happy to hear feedback on this (esp. from @farlee2121 and @TheAngryByrd). Thanks!