### PR TITLE
Check for C# extension dependencies at runtime

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1831,8 +1831,12 @@
   "engines": {
     "vscode": "^0.10.0"
   },
+  "extensionPack": [
+    "ms-dotnettools.csharp",
+    "anyshere.csharp",
+    "muhammad-sammy.csharp"
+  ],
   "extensionDependencies": [
-    "ms-dotnettools.csharp"
   ],
   "homepage": "http://ionide.io",
   "icon": "images/logo.png",

--- a/release/package.json
+++ b/release/package.json
@@ -1833,7 +1833,7 @@
   },
   "extensionPack": [
     "ms-dotnettools.csharp",
-    "anyshere.csharp",
+    "anysphere.csharp",
     "muhammad-sammy.csharp"
   ],
   "extensionDependencies": [


### PR DESCRIPTION
## Why

We should not have a hard dependency on `ms-dotnettools.csharp` since that makes it impossible to use Ionide with forks os VScode e.g Cursor. This PR does the check at runtime instead adding recommended extensions to the Extension Pack tab instead.

Fixes #2087 

## How

- Check for valid C# extensions at runtime instead of in the manifest
- Suggest valid dependencies ast Extension Pack instead to allow for easy navigation to required C# extension
- Give error message if no valid C# extension can be found