### PR TITLE
Update stale VSTEST_HOST_DEBUG env var on non debug test run

### DIFF
--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -578,7 +578,12 @@ module DotnetCli =
                 childEnv |> box |> Some
 
             Process.execWithCancel "dotnet" (ResizeArray(args)) env tryLaunchDebugger cancellationToken
-        | NoDebug -> Process.execWithCancel "dotnet" (ResizeArray(args)) None ignore cancellationToken
+        | NoDebug ->
+            let env =
+                let staleOverrides = {| VSTEST_HOST_DEBUG = 0 |}
+                staleOverrides |> box |> Some
+
+            Process.execWithCancel "dotnet" (ResizeArray(args)) env ignore cancellationToken
 
 
     type TrxPath = string


### PR DESCRIPTION
### Problem

Test runs triggered via the Ionide Test Adapter hang and never complete, when run after a test has been debugged via the Test Adapter.

Caused by stale `VSTEST_HOST_DEBUG=1` env variable values affecting the non-debug run, resulting the test hanging waiting for debugger attachment.

### Steps to reproduce

1. Create solution and open solution:
```
dotnet new sln -n HangingTestExecutionTestCase
dotnet new console -lang "F#" -o console
dotnet sln add console/console.fsproj
dotnet new xunit -lang "F#" -o tests
dotnet sln add tests/tests.fsproj
code .
```

2. Wait for Ionide F# Test Explorer to load
3. Click debug icon on the F# test - test is executed with debugger attached
4. Click run icon on the F# - test execution hangs 

### Machine infos

* Operating system: **Windows_NT**
* Arch: **x64**
* VSCode: **1.100.3**
* UI Kind: **Desktop**
* Ionide: **7.26.1**
* Runtime: **netcore**
* Dotnet version: **9.0.200**