### PR TITLE
register the msbuild language as xml as a backstop

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -1814,7 +1814,12 @@
           "when": "fsharp.showProjectExplorerInFsharpActivity"
         }
       ]
-    }
+    },
+    "xmlLanguageParticipants": [
+      {
+        "languageId": "msbuild"
+      }
+    ]
   },
   "contributors": [
     {


### PR DESCRIPTION
This means that even if folks don't install the TinToy extension (or any extension that supports the `msbuild` language identifier), they get XML support as a backstop.