### PR TITLE
Migrate the Test Explorer to use FSAutoComplete / VSTest

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -901,6 +901,11 @@
           "description": "Decides if the test explorer will automatically try discover tests when the workspace loads. You can still manually refresh the explorer to discover tests at any time",
           "type": "boolean"
         },
+        "FSharp.TestExplorer.UseLegacyDotnetCliIntegration": {
+          "default": false,
+          "description": "Use the dotnet cli to discover and run tests instead of the language server. Will lose features like streamed test results and Microsoft Testing Platform support.",
+          "type": "boolean"
+        },
         "FSharp.trace.server": {
           "default": "off",
           "description": "Trace server messages at the LSP protocol level for diagnostics.",

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1802,7 +1802,19 @@ module Interactions =
                             showStarted runUpdate.ActiveTests
                             mergeResults TrimMissing.NoTrim runUpdate.TestResults
 
-                        let! runResult = LanguageService.runTests incrementalUpdateHandler ()
+                        let filterExpression =
+                            match req.``include`` with
+                            | None -> None
+                            | Some selectedCases when Seq.isEmpty selectedCases -> None
+                            | Some selectedCases ->
+                                projectRunRequests
+                                |> Array.collect (fun rr -> rr.Tests)
+                                |> buildFilterExpression
+                                |> Some
+
+                        logger.Debug($"Test Filter Expression: {filterExpression}")
+
+                        let! runResult = LanguageService.runTests incrementalUpdateHandler filterExpression
 
                         mergeResults TrimMissing.Trim runResult.Data
 

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1919,17 +1919,22 @@ module Interactions =
                     let mutable discoveredTestsAccumulator: TestItem array =
                         rootTestCollection.TestItems()
 
+                    let mutable discoveredTestCount: int = 0
+
                     let incrementalUpdateHandler (discoveryUpdate: TestDiscoveryUpdate) : unit =
                         try
                             let newItems =
                                 discoveryUpdate.Tests |> TestItem.ofTestDTOs testItemFactory tryGetLocation
 
                             discoveredTestsAccumulator <- mergeTestItemCollections discoveredTestsAccumulator newItems
+                            discoveredTestCount <- discoveredTestCount + (discoveryUpdate.Tests |> Array.length)
 
+                            report $"Discovering tests: {discoveredTestCount} discovered"
                             rootTestCollection.replace (ResizeArray discoveredTestsAccumulator)
                         with e ->
                             logger.Debug("Incremental test discovery update threw an exception", e)
 
+                    report "Discovering tests"
                     let! discoveryResponse = LanguageService.discoverTests incrementalUpdateHandler ()
 
                     let testItems =

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -2031,6 +2031,12 @@ module Interactions =
                         |> ResizeArray
 
                     rootTestCollection.replace (testItems)
+
+                    if testItems |> Seq.length = 0 then
+                        window.showWarningMessage (
+                            $"No tests discovered. Make sure your projects are restored, built, and can be run with dotnet test."
+                        )
+                        |> ignore
             }
 
     let tryMatchTestBySuffix (locationCache: CodeLocationCache) (testId: TestId) =

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1846,8 +1846,7 @@ module Interactions =
                             let appendToTestRun testRun (log: TestLogMessage) =
                                 match log.Level with
                                 | TestLogLevel.Informational -> TestRun.Output.appendLine testRun log.Message
-                                | TestLogLevel.Warning ->
-                                    TestRun.Output.appendWarningLine testRun log.Message
+                                | TestLogLevel.Warning -> TestRun.Output.appendWarningLine testRun log.Message
                                 | TestLogLevel.Error -> TestRun.Output.appendErrorLine testRun log.Message
 
                             progress.TestLogs |> Array.iter (appendToTestRun testRun)
@@ -1882,6 +1881,13 @@ module Interactions =
                                 shouldDebug
 
                         mergeResults TrimMissing.Trim runResult.Data
+
+                        if Array.isEmpty runResult.Data then
+                            let message =
+                                $"WARNING: No tests ran. The test explorer might be out of sync. Try running a higher test group or refreshing the test explorer"
+
+                            window.showWarningMessage (message) |> ignore
+                            TestRun.Output.appendWarningLine testRun message
 
                     with ex ->
                         logger.Debug("Test run failed with exception", ex)

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -286,8 +286,13 @@ module TestItemDTO =
             else
                 dto.FullName + "." + dto.DisplayName
         | Some TestFrameworkId.XUnit ->
-            // NOTE: XUnit includes the FullyQualifiedName in the DisplayName
-            dto.DisplayName
+            // NOTE: XUnit includes the FullyQualifiedName in the DisplayName.
+            //       But it doesn't nest theory cases, just appends the case parameters
+            if dto.DisplayName <> dto.FullName then
+                let theoryCaseFragment = dto.DisplayName.Split('.') |> Array.last
+                dto.FullName + "." + theoryCaseFragment
+            else
+                dto.FullName
         | _ -> dto.FullName
 
 type TestResult =

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1737,7 +1737,7 @@ module Interactions =
               HasIncludeFilter = hasIncludeFilter
               Tests = replaceProjectRootIfPresent tests })
 
-    let private discoverTests_WithLangaugeServer
+    let private discoverTests_WithLanguageServer
         testItemFactory
         (rootTestCollection: TestItemCollection)
         tryGetLocation
@@ -2005,7 +2005,7 @@ module Interactions =
                 else
                     do! runTests_WithLanguageServer mergeTestResultsToExplorer testController.items req testRun
                     testRun.``end`` ()
-                    do! discoverTests_WithLangaugeServer testItemFactory testController.items tryGetLocation
+                    do! discoverTests_WithLanguageServer testItemFactory testController.items tryGetLocation
 
             }
             |> (Promise.toThenable >> (!^))
@@ -2160,7 +2160,7 @@ module Interactions =
                             cancellationToken
                             builtTestProjects
                 else
-                    do! discoverTests_WithLangaugeServer testItemFactory rootTestCollection tryGetLocation
+                    do! discoverTests_WithLanguageServer testItemFactory rootTestCollection tryGetLocation
             }
 
     let tryMatchTestBySuffix (locationCache: CodeLocationCache) (testId: TestId) =

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1550,8 +1550,10 @@ module Interactions =
                 testResult.TargetFramework
                 testResult.FullTestName
 
-        let treeItemComparable (t: TestItem) = TestItem.getFullName t.id
-        let resultComparable (r: TestResult) = r.FullTestName
+        let treeItemComparable (t: TestItem) = TestItem.getId t
+
+        let resultComparable (r: TestResult) =
+            TestItem.constructId r.ProjectFilePath r.FullTestName
 
         let missing, expected, added =
             ArrayExt.venn treeItemComparable resultComparable expectedToRun testResults

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -237,6 +237,7 @@ module TestResultOutcome =
         | TestOutcomeDTO.Skipped -> TestResultOutcome.Skipped
         | TestOutcomeDTO.None -> TestResultOutcome.NotExecuted
         | TestOutcomeDTO.NotFound -> TestResultOutcome.NotExecuted
+        | _ -> failwith $"Unknown value for TestOutcomeDTO: {outcomeDto}. The language server may have changed its possible values."
 
 
 type TestFrameworkId = string

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1993,11 +1993,12 @@ module Interactions =
                         successfullyBuiltRequests
                         |> (Promise.executeWithMaxParallel maxParallelTestProjects runTestProject)
 
-                    ()
+                    testRun.``end`` ()
                 else
                     do! runTests_WithLanguageServer mergeTestResultsToExplorer testController.items req testRun
+                    testRun.``end`` ()
+                    do! discoverTests_WithLangaugeServer testItemFactory testController.items tryGetLocation
 
-                testRun.``end`` ()
             }
             |> (Promise.toThenable >> (!^))
 

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -766,8 +766,10 @@ module TestItem =
     let constructProjectRootId (projectPath: ProjectPath) : TestId = constructId projectPath ""
 
     let private componentizeId (testId: TestId) : (ProjectPath * FullTestName) =
+        // IMPORTANT: the fullname should be last and we should limit the number of substrings
+        //            to prevent incorrently splitting tests names with -- in them
         let split =
-            testId.Split(separator = [| idSeparator |], options = StringSplitOptions.None)
+            testId.Split(separator = [| idSeparator |], count = 2, options = StringSplitOptions.None)
 
         (split.[0], split.[1])
 

--- a/src/Components/TestExplorer.fs
+++ b/src/Components/TestExplorer.fs
@@ -1930,6 +1930,12 @@ module Interactions =
                     TestRun.Output.appendWarningLine testRun message
             with ex ->
                 logger.Debug("Test run failed with exception", ex)
+                TestRun.Output.appendErrorLine testRun $"The test run errored {Environment.NewLine}{string ex}"
+
+                window.showErrorMessage (
+                    "Test run errored. See TestResults or Output > F# - Test Adapter for more info"
+                )
+                |> ignore
         }
 
     let runHandler

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -402,10 +402,13 @@ module DTO =
 
     type TestDiscoveryUpdate = { Tests: TestItemDTO array }
 
-    type TestRunUpdate =
+    type TestRunProgress =
         { TestResults: TestResultDTO array
           ActiveTests: TestItemDTO array }
 
+    type TestRunUpdateNotification =
+        | Progress of TestRunProgress
+        | ProcessWaitingForDebugger of processId: string
 
     type Result<'T> = { Kind: string; Data: 'T }
 

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -406,9 +406,7 @@ module DTO =
         { TestResults: TestResultDTO array
           ActiveTests: TestItemDTO array }
 
-    type TestRunUpdateNotification =
-        | Progress of TestRunProgress
-        | ProcessWaitingForDebugger of processId: string
+    type TestRunUpdateNotification = Progress of TestRunProgress
 
     type Result<'T> = { Kind: string; Data: 'T }
 

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -400,10 +400,22 @@ module DTO =
           AdditionalOutput: string option
           Duration: System.TimeSpan }
 
-    type TestDiscoveryUpdate = { Tests: TestItemDTO array }
+    [<Fable.Core.StringEnum(Fable.Core.CaseRules.None)>]
+    [<RequireQualifiedAccess>]
+    type TestLogLevel =
+        | Informational
+        | Warning
+        | Error
+
+    type TestLogMessage =
+        { Level: TestLogLevel; Message: string }
+
+    type TestDiscoveryUpdate =
+        { Tests: TestItemDTO array
+          TestLogs: TestLogMessage array }
 
     type TestRunProgress =
-        { TestLogs: string array
+        { TestLogs: TestLogMessage array
           TestResults: TestResultDTO array
           ActiveTests: TestItemDTO array }
 

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -384,6 +384,22 @@ module DTO =
             CodeLocationRange: TestFileRange option
         }
 
+    [<RequireQualifiedAccess>]
+    type TestOutcomeDTO =
+        | Failed = 0
+        | Passed = 1
+        | Skipped = 2
+        | None = 3
+        | NotFound = 4
+
+    type TestResultDTO =
+        { TestItem: TestItemDTO
+          Outcome: TestOutcomeDTO
+          ErrorMessage: string option
+          ErrorStackTrace: string option
+          AdditionalOutput: string option
+          Duration: System.TimeSpan }
+
     type TestDiscoveryUpdate = { Tests: TestItemDTO array }
 
 
@@ -416,6 +432,7 @@ module DTO =
     type PipelineHintsResult = Result<PipelineHint array>
     type TestResult = Result<TestForFile>
     type DiscoverTestsResult = Result<TestItemDTO array>
+    type RunTestsResult = Result<TestResultDTO array>
 
 
     module DotnetNew =

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -384,6 +384,9 @@ module DTO =
             CodeLocationRange: TestFileRange option
         }
 
+    type TestDiscoveryUpdate = { Tests: TestItemDTO array }
+
+
     type Result<'T> = { Kind: string; Data: 'T }
 
     type HelptextResult = Result<Helptext>

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -402,6 +402,10 @@ module DTO =
 
     type TestDiscoveryUpdate = { Tests: TestItemDTO array }
 
+    type TestRunUpdate =
+        { TestResults: TestResultDTO array
+          ActiveTests: TestItemDTO array }
+
 
     type Result<'T> = { Kind: string; Data: 'T }
 

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -368,6 +368,22 @@ module DTO =
         { file: string
           tests: TestAdapterEntry[] }
 
+    type TestFileRange = { StartLine: int; EndLine: int }
+
+    type TestItemDTO =
+        {
+            FullName: string
+            DisplayName: string
+            /// Identifies the test adapter that ran the tests
+            /// Example: executor://xunit/VsTestRunner2/netcoreapp
+            /// Used for determining the test library, which effects how tests names are broken down
+            ExecutorUri: string
+            ProjectFilePath: string
+            TargetFramework: string
+            CodeFilePath: string option
+            CodeLocationRange: TestFileRange option
+        }
+
     type Result<'T> = { Kind: string; Data: 'T }
 
     type HelptextResult = Result<Helptext>
@@ -396,6 +412,7 @@ module DTO =
     type FSharpLiterateResult = Result<string>
     type PipelineHintsResult = Result<PipelineHint array>
     type TestResult = Result<TestForFile>
+    type DiscoverTestsResult = Result<TestItemDTO array>
 
 
     module DotnetNew =

--- a/src/Core/DTO.fs
+++ b/src/Core/DTO.fs
@@ -403,10 +403,9 @@ module DTO =
     type TestDiscoveryUpdate = { Tests: TestItemDTO array }
 
     type TestRunProgress =
-        { TestResults: TestResultDTO array
+        { TestLogs: string array
+          TestResults: TestResultDTO array
           ActiveTests: TestItemDTO array }
-
-    type TestRunUpdateNotification = Progress of TestRunProgress
 
     type Result<'T> = { Kind: string; Data: 'T }
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -609,10 +609,17 @@ Consider:
             cl.sendRequest ("test/discoverTests", ())
             |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<DiscoverTestsResult>)
 
-    let runTests () =
+    let runTests incrementalUpdateHandler () =
         match client with
         | None -> Promise.empty
         | Some cl ->
+            cl.onNotification (
+                "test/testRunUpdate",
+                (fun (notification: Types.PlainNotification) ->
+                    let parsed = ofJson<TestRunUpdate> notification.content
+                    incrementalUpdateHandler parsed)
+            )
+
             cl.sendRequest ("test/runTests", ())
             |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<RunTestsResult>)
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -595,6 +595,15 @@ Consider:
     let fsiSdk () =
         promise { return Environment.configFsiSdkFilePath () }
 
+    let testDiscovery s =
+        match client with
+        | None ->
+            Promise.empty
+        | Some cl ->
+            cl.sendRequest ("test/discoverTests", ())
+            |> Promise.map (fun (res: Types.PlainNotification) ->
+                res.content |> ofJson<DiscoverTestsResult>)
+
     let private createClient (opts: Executable) =
 
         let options: ServerOptions = U5.Case2 {| run = opts; debug = opts |}

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -599,7 +599,7 @@ Consider:
     let fsiSdk () =
         promise { return Environment.configFsiSdkFilePath () }
 
-    let discoverTests incrementalUpdateHandler () =
+    let discoverTests onDiscoveryProgress () =
         match client with
         | None -> Promise.empty
         | Some cl ->
@@ -607,7 +607,7 @@ Consider:
                 "test/testDiscoveryUpdate",
                 (fun (notification: Types.PlainNotification) ->
                     let parsed = ofJson<TestDiscoveryUpdate> notification.content
-                    incrementalUpdateHandler parsed)
+                    onDiscoveryProgress parsed)
             )
 
             cl.sendRequest ("test/discoverTests", ())
@@ -617,7 +617,7 @@ Consider:
     type DidDebuggerAttach = bool
 
     let runTests
-        (incrementalUpdateHandler: TestRunUpdateNotification -> unit)
+        (onTestRunProgress: TestRunProgress -> unit)
         (onAttachDebugger: ProcessId -> JS.Promise<bool>)
         (testCaseFilter: string option)
         (attachDebugger: bool)
@@ -629,7 +629,7 @@ Consider:
                 "test/testRunProgressUpdate",
                 (fun (notification: Types.PlainNotification) ->
                     let parsed = ofJson<TestRunProgress> notification.content
-                    incrementalUpdateHandler (Progress parsed))
+                    onTestRunProgress parsed)
             )
 
             cl.onRequest (

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -595,10 +595,17 @@ Consider:
     let fsiSdk () =
         promise { return Environment.configFsiSdkFilePath () }
 
-    let testDiscovery s =
+    let testDiscovery incrementalUpdateHandler () =
         match client with
         | None -> Promise.empty
         | Some cl ->
+            cl.onNotification (
+                "test/testDiscoveryUpdate",
+                (fun (notification: Types.PlainNotification) ->
+                    let parsed = ofJson<TestDiscoveryUpdate> notification.content
+                    incrementalUpdateHandler parsed)
+            )
+
             cl.sendRequest ("test/discoverTests", ())
             |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<DiscoverTestsResult>)
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -95,7 +95,8 @@ module LanguageService =
               ``end``: Fable.Import.VSCode.Vscode.Position }
 
         type TestRunRequest =
-            { TestCaseFilter: string option
+            { LimitToProjects: string array option
+              TestCaseFilter: string option
               AttachDebugger: bool }
 
     type Uri with
@@ -619,6 +620,7 @@ Consider:
     let runTests
         (onTestRunProgress: TestRunProgress -> unit)
         (onAttachDebugger: ProcessId -> JS.Promise<bool>)
+        (projectSubset: string array option)
         (testCaseFilter: string option)
         (attachDebugger: bool)
         =
@@ -642,7 +644,8 @@ Consider:
             )
 
             let request: Types.TestRunRequest =
-                { TestCaseFilter = testCaseFilter
+                { LimitToProjects = projectSubset
+                  TestCaseFilter = testCaseFilter
                   AttachDebugger = attachDebugger }
 
             cl.sendRequest ("test/runTests", request)

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -595,7 +595,7 @@ Consider:
     let fsiSdk () =
         promise { return Environment.configFsiSdkFilePath () }
 
-    let testDiscovery incrementalUpdateHandler () =
+    let discoverTests incrementalUpdateHandler () =
         match client with
         | None -> Promise.empty
         | Some cl ->
@@ -608,6 +608,13 @@ Consider:
 
             cl.sendRequest ("test/discoverTests", ())
             |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<DiscoverTestsResult>)
+
+    let runTests () =
+        match client with
+        | None -> Promise.empty
+        | Some cl ->
+            cl.sendRequest ("test/runTests", ())
+            |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<RunTestsResult>)
 
     let private createClient (opts: Executable) =
 

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -94,6 +94,8 @@ module LanguageService =
             { start: Fable.Import.VSCode.Vscode.Position
               ``end``: Fable.Import.VSCode.Vscode.Position }
 
+        type TestRunRequest = { TestCaseFilter: string option }
+
     type Uri with
 
         member uri.ToDocumentUri = uri.ToString()
@@ -609,7 +611,7 @@ Consider:
             cl.sendRequest ("test/discoverTests", ())
             |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<DiscoverTestsResult>)
 
-    let runTests incrementalUpdateHandler () =
+    let runTests incrementalUpdateHandler (testCaseFilter: string option) =
         match client with
         | None -> Promise.empty
         | Some cl ->
@@ -620,7 +622,9 @@ Consider:
                     incrementalUpdateHandler parsed)
             )
 
-            cl.sendRequest ("test/runTests", ())
+            let request: Types.TestRunRequest = { TestCaseFilter = testCaseFilter }
+
+            cl.sendRequest ("test/runTests", request)
             |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<RunTestsResult>)
 
     let private createClient (opts: Executable) =

--- a/src/Core/LanguageService.fs
+++ b/src/Core/LanguageService.fs
@@ -597,12 +597,10 @@ Consider:
 
     let testDiscovery s =
         match client with
-        | None ->
-            Promise.empty
+        | None -> Promise.empty
         | Some cl ->
             cl.sendRequest ("test/discoverTests", ())
-            |> Promise.map (fun (res: Types.PlainNotification) ->
-                res.content |> ofJson<DiscoverTestsResult>)
+            |> Promise.map (fun (res: Types.PlainNotification) -> res.content |> ofJson<DiscoverTestsResult>)
 
     let private createClient (opts: Executable) =
 


### PR DESCRIPTION
# Test Explorer VSTest Migration

Depends on [FSAutoComplete PR 1383](https://github.com/ionide/FsAutoComplete/pull/1383)

## Motivation

- [Microsoft is releasing a new test platform, and it doesn't support the `dotnet test` parameter we use](https://github.com/ionide/ionide-vscode-fsharp/issues/2069)
- [Access to standardized test code locations](https://github.com/ionide/ionide-vscode-fsharp/pull/2000) / The same code location support as VS
- Ability to write automated tests against test explorer code
- Ability to share test explorer features across FSAC clients
- [Improve test discovery speed](https://github.com/ionide/ionide-vscode-fsharp/issues/2038)

## Before this PR

The Ionide test explorer run on dotnet test and TRX files. 
Test discovery and test execution are implemented directly in Ionide.

## After this PR

Test discovery and execution are moved to the language server, allowing them to be used across clients.
Users can revert to the dotnet test-based approach with the setting `FSharp.TestExplorer.UseLegacyDotnetCliIntegration`

When using the LSP discovery
- we now support Microsoft.Testing.Platform VSTestBridge projects
- We have access to test code locations provided by the test libraries themselves
- We don't have to run tests to discover them, which makes test discovery much faster
- We don't need to create temporary artifacts (i.e. TRX files)
- VSTest manages test execution across assemblies, reducing our responsibility for managing resource utilization

We will not yet support Microsoft Testing Platform projects that don't use VSTestBridge.

## Outstanding issues

- I tried to support .runsettings ([ionide 2093](https://github.com/ionide/ionide-vscode-fsharp/discussions/2093) and [2040](https://github.com/ionide/ionide-vscode-fsharp/discussions/2040)), but there are [outstanding questions](https://github.com/ionide/FsAutoComplete/pull/1383#issuecomment-3258623066) on how to support it via VSTestConsoleWrapper.

- Microsoft Testing Platform VSTestBridge projects report their test locations as the end of a test's code block.
There's not really a way for us to fix this.

- Additional work is needed to support pure Microsoft Testing Platform projects.

- We'll probably want to remove the dotnet test-based code once we're confident the LSP-based holds up to user expectations

- There is some duplication of logic between Ionide and FSAutoComplete, specifically around deciding what projects are test projects


I also considered moving more logic to the language server for better testing, but I decided to hold off.
The current progress is useful, and supporting Microsoft.Testing.Platform is likely to add new constraints to the design.
