### PR TITLE
Add more Debug logs when activating features

### DIFF
--- a/src/fsharp.fs
+++ b/src/fsharp.fs
@@ -50,6 +50,7 @@ let private doActivate (context: ExtensionContext) : JS.Promise<Api> =
     let tryActivate label activationFn =
         fun ctx ->
             try
+                logger.Debug $"Activating feature '{label}'"
                 activationFn ctx
             with ex ->
                 logger.Error $"Error while activating feature '{label}': {ex}"
@@ -60,7 +61,7 @@ let private doActivate (context: ExtensionContext) : JS.Promise<Api> =
     |> Promise.onSuccess (fun _ ->
         let progressOpts = createEmpty<ProgressOptions>
         progressOpts.location <- U2.Case1 ProgressLocation.Window
-        logger.Debug "Activating features"
+        logger.Debug "Activating features..."
 
         window.withProgress (
             progressOpts,


### PR DESCRIPTION
## Description

With this small PR, I'm adding more `Debug` logs when activating specific features. Perhaps this could be useful to identify whether some activation is hanging.

This is how the logs look like:

<img width="1686" height="1411" alt="image" src="https://github.com/user-attachments/assets/5d67ccf6-fcf5-4bd9-b834-f85957036faf" />
